### PR TITLE
feat(api): add structured logger, source maps, and LOG_LEVEL env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Changed
 - New user interface to list organizations, workspaces, agents, sessions
+- Better support of cloud native loggers
 
 ### Fixed
 

--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -1,4 +1,7 @@
 TZ='UTC'
+
+LOG_LEVEL=debug # fatal | error | warn | log | debug | verbose (default: log)
+
 GOOGLE_APPLICATION_CREDENTIALS=../../dontsave/caseai-connect-XXX.json
 
 LANGFUSE_SK=XXX

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /app/node_modules node_modules
 #
 FROM runtime-base AS api-runtime
 
-CMD ["node", "/app/apps/api/dist/main.js"]
+CMD ["node", "--enable-source-maps", "/app/apps/api/dist/main.js"]
 
 #
 # 🚀 Workers Runtime (Docling enabled)
@@ -80,4 +80,4 @@ RUN python3 -m venv /opt/docling-venv \
     --max-nodes 1 \
   && ln -s /opt/docling-venv/bin/docling /usr/local/bin/docling
 
-CMD ["node", "/app/apps/api/dist/workers-main.js"]
+CMD ["node", "--enable-source-maps", "/app/apps/api/dist/workers-main.js"]

--- a/apps/api/src/common/logger/structured-logger.ts
+++ b/apps/api/src/common/logger/structured-logger.ts
@@ -1,0 +1,122 @@
+import type { LoggerService, LogLevel } from "@nestjs/common"
+import { context, trace } from "@opentelemetry/api"
+
+type GcpSeverity = "DEBUG" | "INFO" | "WARNING" | "ERROR"
+
+interface StructuredLogEntry {
+  severity: GcpSeverity
+  message: string
+  context?: string
+  timestamp: string
+  stack_trace?: string
+  "logging.googleapis.com/trace"?: string
+  "logging.googleapis.com/spanId"?: string
+}
+
+const LOG_LEVEL_TO_SEVERITY: Record<LogLevel, GcpSeverity> = {
+  log: "INFO",
+  error: "ERROR",
+  warn: "WARNING",
+  debug: "DEBUG",
+  verbose: "DEBUG",
+  fatal: "ERROR",
+}
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  fatal: 0,
+  error: 1,
+  warn: 2,
+  log: 3,
+  debug: 4,
+  verbose: 5,
+}
+
+/**
+ * Returns NestJS log levels enabled by the LOG_LEVEL env var.
+ * Defaults to "log" (error, warn, log). Set to "debug" or "verbose" for more output.
+ */
+export function getLogLevels(): LogLevel[] {
+  const envLevel = (process.env.LOG_LEVEL ?? "log") as LogLevel
+  const threshold = LOG_LEVEL_PRIORITY[envLevel] ?? LOG_LEVEL_PRIORITY.log
+  return Object.entries(LOG_LEVEL_PRIORITY)
+    .filter(([, priority]) => priority <= threshold)
+    .map(([level]) => level as LogLevel)
+}
+
+function isStackTrace(value: unknown): value is string {
+  return typeof value === "string" && value.includes("\n") && value.includes("    at ")
+}
+
+export class StructuredLogger implements LoggerService {
+  private readonly isTest = process.env.NODE_ENV === "test"
+  private readonly gcpProject = process.env.GOOGLE_CLOUD_PROJECT ?? ""
+  private readonly enabledLevels: Set<LogLevel>
+
+  constructor(logLevels?: LogLevel[]) {
+    this.enabledLevels = new Set(logLevels ?? getLogLevels())
+  }
+
+  log(message: unknown, context?: string): void {
+    this.writeLog("log", String(message), undefined, context)
+  }
+
+  error(message: unknown, stackOrContext?: string, context?: string): void {
+    let stack: string | undefined
+    let ctx: string | undefined
+
+    if (context) {
+      stack = stackOrContext
+      ctx = context
+    } else if (isStackTrace(stackOrContext)) {
+      stack = stackOrContext
+    } else {
+      ctx = stackOrContext
+    }
+
+    this.writeLog("error", String(message), stack, ctx)
+  }
+
+  warn(message: unknown, context?: string): void {
+    this.writeLog("warn", String(message), undefined, context)
+  }
+
+  debug(message: unknown, context?: string): void {
+    this.writeLog("debug", String(message), undefined, context)
+  }
+
+  verbose(message: unknown, context?: string): void {
+    this.writeLog("verbose", String(message), undefined, context)
+  }
+
+  fatal(message: unknown, context?: string): void {
+    this.writeLog("fatal", String(message), undefined, context)
+  }
+
+  private writeLog(level: LogLevel, message: string, stack?: string, logContext?: string): void {
+    if (this.isTest) return
+    if (!this.enabledLevels.has(level)) return
+
+    const entry: StructuredLogEntry = {
+      severity: LOG_LEVEL_TO_SEVERITY[level],
+      message,
+      timestamp: new Date().toISOString(),
+    }
+
+    if (logContext) {
+      entry.context = logContext
+    }
+
+    if (stack) {
+      entry.stack_trace = stack
+    }
+
+    const spanContext = trace.getSpan(context.active())?.spanContext()
+    if (spanContext) {
+      entry["logging.googleapis.com/trace"] =
+        `projects/${this.gcpProject}/traces/${spanContext.traceId}`
+      entry["logging.googleapis.com/spanId"] = spanContext.spanId
+    }
+
+    process.stdout.write(`${JSON.stringify(entry)}\n`)
+  }
+}

--- a/apps/api/src/common/middleware/request-logger.middleware.ts
+++ b/apps/api/src/common/middleware/request-logger.middleware.ts
@@ -1,4 +1,4 @@
-import { Injectable, type NestMiddleware } from "@nestjs/common"
+import { Injectable, Logger, type NestMiddleware } from "@nestjs/common"
 import type { NextFunction, Request, Response } from "express"
 
 /**
@@ -8,33 +8,32 @@ import type { NextFunction, Request, Response } from "express"
  * Must be registered via AppModule.configure() so it runs AFTER body parsing.
  *
  * Example output:
- *   --> POST /invitations/accept
- *       body: {"payload":{"ticketId":"ticket_abc"}}
+ *   --> POST /invitations/accept body: {"payload":{"ticketId":"ticket_abc"}}
  *   <-- POST /invitations/accept 201 45ms
  */
 @Injectable()
 export class RequestLoggerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger("HTTP")
+
   use(request: Request, response: Response, next: NextFunction) {
     const { method, originalUrl, body, query } = request
     const startTime = Date.now()
 
-    // Build the log parts
-    const parts = [`--> ${method} ${originalUrl} 📥`]
+    const parts = [`--> ${method} ${originalUrl}`]
 
     if (Object.keys(query).length > 0) {
-      parts.push(`    query: ${JSON.stringify(query)}`)
+      parts.push(`query: ${JSON.stringify(query)}`)
     }
 
     if (body && Object.keys(body).length > 0) {
-      parts.push(`    body: ${JSON.stringify(body)}`)
+      parts.push(`body: ${JSON.stringify(body)}`)
     }
 
-    console.log(parts.join("\n"))
+    this.logger.debug(parts.join(" "))
 
-    // Log response when finished
     response.on("finish", () => {
       const duration = Date.now() - startTime
-      console.log(`<-- ${method} ${originalUrl} ${response.statusCode} ${duration}ms 📤`)
+      this.logger.debug(`<-- ${method} ${originalUrl} ${response.statusCode} ${duration}ms`)
     })
 
     next()

--- a/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.ts
+++ b/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from "@nestjs/bullmq"
-import { Injectable } from "@nestjs/common"
+import { Injectable, Logger } from "@nestjs/common"
 import type { Queue } from "bullmq"
 import {
   DOCUMENT_EMBEDDINGS_JOB_NAME,
@@ -9,6 +9,8 @@ import type { CreateDocumentEmbeddingsJobPayload } from "./document-embeddings.t
 
 @Injectable()
 export class BullMqDocumentEmbeddingsBatchService {
+  private readonly logger = new Logger(BullMqDocumentEmbeddingsBatchService.name)
+
   constructor(
     @InjectQueue(DOCUMENT_EMBEDDINGS_QUEUE_NAME)
     private readonly documentEmbeddingsQueue: Queue<CreateDocumentEmbeddingsJobPayload>,
@@ -17,7 +19,7 @@ export class BullMqDocumentEmbeddingsBatchService {
   async enqueueCreateEmbeddingsForDocument(
     payload: CreateDocumentEmbeddingsJobPayload,
   ): Promise<void> {
-    console.log("Enqueuing document embeddings job", payload)
+    this.logger.log(`Enqueuing document embeddings job ${JSON.stringify(payload)}`)
     await this.documentEmbeddingsQueue.add(DOCUMENT_EMBEDDINGS_JOB_NAME, payload)
   }
 }

--- a/apps/api/src/domains/documents/embeddings/document-embedding-status-stream.service.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embedding-status-stream.service.ts
@@ -45,7 +45,7 @@ export class DocumentEmbeddingStatusStreamService implements OnModuleInit, OnMod
     })
 
     listenerClient.on("notification", (notification) => {
-      console.log("NOTIFICATION", notification)
+      this.logger.debug(`Received notification: ${JSON.stringify(notification)}`)
       if (!notification.payload) return
       try {
         const parsedPayload = JSON.parse(

--- a/apps/api/src/domains/documents/storage/storage.module.ts
+++ b/apps/api/src/domains/documents/storage/storage.module.ts
@@ -1,4 +1,4 @@
-import { Module, type Provider } from "@nestjs/common"
+import { Logger, Module, type Provider } from "@nestjs/common"
 import { ConfigModule, ConfigService } from "@nestjs/config"
 import { isEmpty } from "lodash"
 import { FILE_STORAGE_SERVICE } from "./file-storage.interface"
@@ -11,10 +11,10 @@ const storageProvider: Provider = {
     const storageBucketName = configService.get<string>("GCS_STORAGE_BUCKET_NAME")
 
     if (isEmpty(storageBucketName)) {
-      console.log("Use LocalStorageService for file storage.")
+      Logger.log("Use LocalStorageService for file storage.", "StorageModule")
       return new LocalStorageService(configService)
     } else {
-      console.log("Use GcsStorageService for file storage.")
+      Logger.log("Use GcsStorageService for file storage.", "StorageModule")
       return new GcsStorageService(configService)
     }
   },

--- a/apps/api/src/domains/organizations/organization.policy.ts
+++ b/apps/api/src/domains/organizations/organization.policy.ts
@@ -7,10 +7,6 @@ export class OrganizationPolicy {
 
   canCreate(): boolean {
     const normalizedEmail = this.user.email.trim().toLowerCase()
-    console.log(
-      `❤️‍🩹 ❤️‍🩹 ❤️‍🩹 normalizedEmail: ${normalizedEmail}`,
-      `ALLOWED_ORGANIZATION_CREATOR_EMAIL_DOMAIN: ${ALLOWED_ORGANIZATION_CREATOR_EMAIL_DOMAIN}`,
-    )
     return normalizedEmail.endsWith(ALLOWED_ORGANIZATION_CREATOR_EMAIL_DOMAIN)
   }
 }

--- a/apps/api/src/external/llm/providers/provider-specs.ts
+++ b/apps/api/src/external/llm/providers/provider-specs.ts
@@ -148,7 +148,6 @@ export class ProviderSpecs {
     let stream = provider.streamChatResponse({ messages: chatMessages, config, metadata })
     let results = await ProviderSpecs.streamToStringArray(stream)
     expect(results).toBeDefined()
-    console.log(JSON.stringify(results))
     expect(results.length).toBeGreaterThan(0)
     if (advancedExpectation) {
       expect(status).not.toEqual("completed")

--- a/apps/api/src/external/llm/providers/spec-gcp-tools.ts
+++ b/apps/api/src/external/llm/providers/spec-gcp-tools.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common"
 import { GoogleAuth } from "google-auth-library"
 
 export const gcpCredentialsCheck = async (): Promise<boolean> => {
@@ -10,7 +11,7 @@ export const gcpCredentialsCheck = async (): Promise<boolean> => {
     const token = await client.getAccessToken()
     check = !!token
   } catch (err) {
-    console.error("AUTH ERROR:", JSON.stringify(err))
+    Logger.error(`GCP auth check failed: ${JSON.stringify(err)}`, undefined, "GcpTools")
   }
   return check
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,16 +1,21 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { ValidationPipe } from "@nestjs/common"
+import { Logger, ValidationPipe } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS
 import { NestExpressApplication } from "@nestjs/platform-express"
 import { AppModule } from "./app.module"
 import { StackTraceLoggingExceptionFilter } from "./common/filters/stack-trace-logging-exception.filter"
+import { getLogLevels, StructuredLogger } from "./common/logger/structured-logger"
+
+const isProduction = process.env.NODE_ENV === "production"
 
 async function bootstrap() {
   const frontendUrl = normalizeFrontendUrl(process.env.FRONTEND_URL)
   const httpsOptions = loadHttpsCertificates()
+  const logLevels = getLogLevels()
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    logger: isProduction ? new StructuredLogger(logLevels) : logLevels,
     ...(httpsOptions && { httpsOptions }),
   })
   app.useBodyParser("json", { limit: "500kb" })
@@ -33,7 +38,7 @@ async function bootstrap() {
   })
   const protocol = httpsOptions ? "https" : "http"
   await app.listen(3000)
-  console.log(`API server running on ${protocol}://connect.localhost:3000`)
+  Logger.log(`API server running on ${protocol}://connect.localhost:3000`, "Bootstrap")
 }
 
 function normalizeFrontendUrl(frontendUrl: string | undefined): string | undefined {

--- a/apps/api/src/workers-main.ts
+++ b/apps/api/src/workers-main.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
+import { getLogLevels, StructuredLogger } from "@/common/logger/structured-logger"
 import {
   getDoclingNodesCommand,
   getDoclingTimeoutMs,
@@ -27,7 +28,11 @@ async function bootstrapWorkersMain() {
   const healthCheckTimeoutMs = getWorkerDoclingHealthCheckTimeoutMs()
   await ensureDoclingIsReadyForWorkers(healthCheckTimeoutMs)
   await runDoclingSelfTestIfEnabled(healthCheckTimeoutMs)
-  await NestFactory.createApplicationContext(WorkersAppModule)
+  const isProduction = process.env.NODE_ENV === "production"
+  const logLevels = getLogLevels()
+  await NestFactory.createApplicationContext(WorkersAppModule, {
+    logger: isProduction ? new StructuredLogger(logLevels) : logLevels,
+  })
   Logger.log("Workers app started", "WorkersMain")
 }
 


### PR DESCRIPTION
- add StructuredLogger with GCP Cloud Logging severity and OTEL trace correlation (production only)
- enable --enable-source-maps in Dockerfile for TypeScript stack traces
- replace all console.log/console.error with NestJS Logger
- add LOG_LEVEL env var to control log verbosity (default: log)
- switch request logger to debug level