### PR TITLE
ci: clean up workflow triggers

### DIFF
--- a/.github/workflows/branch-workers-smoke.yml
+++ b/.github/workflows/branch-workers-smoke.yml
@@ -8,7 +8,6 @@ on:
       - "apps/api/**"
       - "infra/**"
       - "Makefile"
-      - ".github/workflows/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
   tests:
     runs-on:
       labels: ubuntu-latest-m
-    environment: test
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -37,7 +37,6 @@ jobs:
     if: needs.check-changes.outputs.deploy == 'true'
     runs-on:
       labels: ubuntu-latest-m
-    environment: test
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -58,7 +57,7 @@ jobs:
 
   dispatch:
     needs: [check-changes, tests]
-    if: needs.check-changes.outputs.deploy == 'true'
+    if: ${{ always() && needs.check-changes.result == 'success' && needs.tests.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
@@ -74,7 +73,8 @@ jobs:
           gh api repos/${{ github.repository_owner }}/infra/dispatches \
             -f event_type=deploy \
             -f "client_payload[sha]=${{ github.sha }}" \
-            -f "client_payload[repo]=${{ github.repository }}"
+            -f "client_payload[repo]=${{ github.repository }}" \
+            -f "client_payload[deploy_api]=${{ needs.check-changes.outputs.deploy }}"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,9 @@
 name: Security
 
 on:
-  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   gitleaks:


### PR DESCRIPTION
- remove unused test environment from ci and prod workflows
- scope security workflow to PRs on main only (was all pushes)
- always dispatch to infra on main push, forward deploy_api flag
- remove .github/workflows/** from branch-workers-smoke paths