### PR TITLE
feat(api): add OTEL queue metrics, diagnostics endpoint, and fix init…

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,6 +44,7 @@ jobs:
           output: 'trivy-api-results.txt'
 
       - name: Run Trivy vulnerability scanner on Workers
+        if: always()
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'caseai-connect/workers:local'
@@ -56,24 +57,26 @@ jobs:
           output: 'trivy-workers-results.txt'
 
       - name: Trivy scan summary
+        if: always()
         run: |
           MAX_SIZE=400000
+          print_report() {
+            local label="$1" file="$2"
+            echo "### $label"
+            echo '```'
+            if [ ! -f "$file" ]; then
+              echo "(scan did not run)"
+            elif [ "$(wc -c < "$file")" -gt "$MAX_SIZE" ]; then
+              echo "... output truncated (showing last ${MAX_SIZE} bytes)"
+              echo ""
+              tail -c $MAX_SIZE "$file"
+            else
+              cat "$file"
+            fi
+            echo '```'
+          }
           {
             echo "## Trivy Vulnerability Scan Results"
-            echo "### API Image"
-            echo '```'
-            if [ "$(wc -c < trivy-api-results.txt)" -gt "$MAX_SIZE" ]; then
-              echo "... output truncated (showing last ${MAX_SIZE} bytes)"
-              echo ""
-            fi
-            tail -c $MAX_SIZE trivy-api-results.txt
-            echo '```'
-            echo "### Workers Image"
-            echo '```'
-            if [ "$(wc -c < trivy-workers-results.txt)" -gt "$MAX_SIZE" ]; then
-              echo "... output truncated (showing last ${MAX_SIZE} bytes)"
-              echo ""
-            fi
-            tail -c $MAX_SIZE trivy-workers-results.txt
-            echo '```'
+            print_report "API Image" trivy-api-results.txt
+            print_report "Workers Image" trivy-workers-results.txt
           } >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Changed
 - New user interface to list organizations, workspaces, agents, sessions
-- Unified observability: structured logging, request tracing, and queue health monitoring via GCP
+- Unified observability: structured logging, request tracing, error alerting, and queue health monitoring via GCP
 
 ### Fixed
 - Breadcrumb misalignment in navigation UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Changed
 - New user interface to list organizations, workspaces, agents, sessions
-- Better support of cloud native loggers
+- Unified observability: structured logging, request tracing, and queue health monitoring via GCP
 
 ### Fixed
 - Breadcrumb misalignment in navigation UI

--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -2,6 +2,7 @@ TZ='UTC'
 
 LOG_LEVEL=debug # fatal | error | warn | log | debug | verbose (default: log)
 OTEL_CONSOLE_EXPORT=false # print OTEL spans to stdout (default: false)
+DIAGNOSTICS_SECRET=change-me # secret path for /diagnostics/<secret>/test-error
 
 GOOGLE_APPLICATION_CREDENTIALS=../../dontsave/caseai-connect-XXX.json
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "@ai-sdk/google-vertex": "^4.0.28",
     "@caseai-connect/api-contracts": "*",
     "@google-cloud/aiplatform": "^6.5.0",
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
     "@google-cloud/storage": "^7.18.0",
     "@google/genai": "^1.21.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common"
 import { ConfigModule, ConfigService } from "@nestjs/config"
 import { TypeOrmModule } from "@nestjs/typeorm"
+import { DiagnosticsModule } from "./common/diagnostics/diagnostics.module"
 import { RequestLoggerMiddleware } from "./common/middleware/request-logger.middleware"
 import typeorm from "./config/typeorm"
 import { AgentsModule } from "./domains/agents/agents.module"
@@ -32,6 +33,7 @@ import { UsersModule } from "./domains/users/users.module"
       inject: [ConfigService],
       useFactory: async (configService: ConfigService) => configService.get("typeorm")(),
     }),
+    DiagnosticsModule,
     AgentMessageFeedbackModule,
     AgentsModule,
     AuthModule,

--- a/apps/api/src/common/diagnostics/diagnostics.controller.spec.ts
+++ b/apps/api/src/common/diagnostics/diagnostics.controller.spec.ts
@@ -1,0 +1,44 @@
+import type { INestApplication } from "@nestjs/common"
+import { Test } from "@nestjs/testing"
+import request from "supertest"
+import type { App } from "supertest/types"
+import { DiagnosticsModule } from "./diagnostics.module"
+
+async function createApp(): Promise<INestApplication<App>> {
+  const module = await Test.createTestingModule({
+    imports: [DiagnosticsModule],
+  }).compile()
+  const app = module.createNestApplication()
+  await app.init()
+  return app
+}
+
+describe("DiagnosticsController", () => {
+  describe("GET /diagnostics/:secret/test-error", () => {
+    it("returns 404 when DIAGNOSTICS_SECRET is not set", async () => {
+      delete process.env.DIAGNOSTICS_SECRET
+      const app = await createApp()
+      const response = await request(app.getHttpServer()).get("/diagnostics/any-value/test-error")
+      expect(response.status).toBe(404)
+      await app.close()
+    })
+
+    it("returns 404 when secret does not match", async () => {
+      process.env.DIAGNOSTICS_SECRET = "correct-secret"
+      const app = await createApp()
+      const response = await request(app.getHttpServer()).get("/diagnostics/wrong-secret/test-error")
+      expect(response.status).toBe(404)
+      await app.close()
+    })
+
+    it("returns 500 when secret matches", async () => {
+      process.env.DIAGNOSTICS_SECRET = "correct-secret"
+      const app = await createApp()
+      const response = await request(app.getHttpServer()).get(
+        "/diagnostics/correct-secret/test-error",
+      )
+      expect(response.status).toBe(500)
+      await app.close()
+    })
+  })
+})

--- a/apps/api/src/common/diagnostics/diagnostics.controller.ts
+++ b/apps/api/src/common/diagnostics/diagnostics.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, NotFoundException, Param } from "@nestjs/common"
+
+@Controller("diagnostics")
+export class DiagnosticsController {
+  private readonly secret = process.env.DIAGNOSTICS_SECRET
+
+  @Get(":secret/test-error")
+  testError(@Param("secret") secret: string): never {
+    if (!this.secret || secret !== this.secret) throw new NotFoundException()
+    throw new Error("Diagnostics test error — verifying error reporting pipeline")
+  }
+}

--- a/apps/api/src/common/diagnostics/diagnostics.module.ts
+++ b/apps/api/src/common/diagnostics/diagnostics.module.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common"
+import { DiagnosticsController } from "./diagnostics.controller"
+
+@Module({
+  controllers: [DiagnosticsController],
+})
+export class DiagnosticsModule {}

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-workers.module.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-workers.module.ts
@@ -12,6 +12,7 @@ import { DocumentEmbeddingsWorker } from "./document-embeddings.worker"
 import { getDocumentEmbeddingsBullMqConnection } from "./document-embeddings-bullmq.config"
 import { DocumentEmbeddingsProcessorService } from "./document-embeddings-processor.service"
 import { DocumentTextExtractorService } from "./document-text-extractor.service"
+import { QueueMetricsService } from "./queue-metrics.service"
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { DocumentTextExtractorService } from "./document-text-extractor.service"
     DocumentTextExtractorService,
     DocumentsService,
     DocumentTagsService,
+    QueueMetricsService,
   ],
 })
 export class DocumentEmbeddingsWorkersModule {}

--- a/apps/api/src/domains/documents/embeddings/queue-metrics.service.ts
+++ b/apps/api/src/domains/documents/embeddings/queue-metrics.service.ts
@@ -1,0 +1,66 @@
+import { InjectQueue } from "@nestjs/bullmq"
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common"
+import { metrics } from "@opentelemetry/api"
+import type { Queue } from "bullmq"
+import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "./document-embeddings.constants"
+
+const QUEUE_METRICS_INTERVAL_MS = 30_000
+
+@Injectable()
+export class QueueMetricsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(QueueMetricsService.name)
+  private intervalHandle: NodeJS.Timeout | null = null
+
+  private readonly meter = metrics.getMeter("bullmq")
+  private readonly waitingGauge = this.meter.createObservableGauge("bullmq.queue.waiting", {
+    description: "Number of waiting jobs in the queue",
+  })
+  private readonly activeGauge = this.meter.createObservableGauge("bullmq.queue.active", {
+    description: "Number of active jobs in the queue",
+  })
+  private readonly completedGauge = this.meter.createObservableGauge("bullmq.queue.completed", {
+    description: "Number of completed jobs in the queue",
+  })
+  private readonly failedGauge = this.meter.createObservableGauge("bullmq.queue.failed", {
+    description: "Number of failed jobs in the queue",
+  })
+
+  private lastCounts: Record<string, number> = { waiting: 0, active: 0, completed: 0, failed: 0 }
+
+  constructor(
+    @InjectQueue(DOCUMENT_EMBEDDINGS_QUEUE_NAME)
+    private readonly documentEmbeddingsQueue: Queue,
+  ) {
+    const queueAttr = { queue: DOCUMENT_EMBEDDINGS_QUEUE_NAME }
+    this.waitingGauge.addCallback((result) => result.observe(this.lastCounts.waiting ?? 0, queueAttr))
+    this.activeGauge.addCallback((result) => result.observe(this.lastCounts.active ?? 0, queueAttr))
+    this.completedGauge.addCallback((result) => result.observe(this.lastCounts.completed ?? 0, queueAttr))
+    this.failedGauge.addCallback((result) => result.observe(this.lastCounts.failed ?? 0, queueAttr))
+  }
+
+  onModuleInit() {
+    this.intervalHandle = setInterval(() => {
+      void this.collectQueueMetrics()
+    }, QUEUE_METRICS_INTERVAL_MS)
+  }
+
+  onModuleDestroy() {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle)
+      this.intervalHandle = null
+    }
+  }
+
+  private async collectQueueMetrics(): Promise<void> {
+    try {
+      this.lastCounts = await this.documentEmbeddingsQueue.getJobCounts()
+      this.logger.debug(
+        `queue_metrics queue=${DOCUMENT_EMBEDDINGS_QUEUE_NAME} waiting=${this.lastCounts.waiting} active=${this.lastCounts.active} completed=${this.lastCounts.completed} failed=${this.lastCounts.failed}`,
+      )
+    } catch (error) {
+      this.logger.error(
+        `Failed to collect queue metrics: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+}

--- a/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
+++ b/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
@@ -1,4 +1,3 @@
-import "./open-telemetry-init" // !!!! first import !!!!
 import { AgentModelToAgentProvider, AgentProvider } from "@caseai-connect/api-contracts"
 import { NotImplementedException } from "@nestjs/common"
 import { generateText, jsonSchema, Output, ToolLoopAgent } from "ai"

--- a/apps/api/src/external/llm/open-telemetry-init.ts
+++ b/apps/api/src/external/llm/open-telemetry-init.ts
@@ -1,9 +1,11 @@
 import "dotenv/config"
+import { MetricExporter } from "@google-cloud/opentelemetry-cloud-monitoring-exporter"
 import { TraceExporter } from "@google-cloud/opentelemetry-cloud-trace-exporter"
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http"
 import { NestInstrumentation } from "@opentelemetry/instrumentation-nestjs-core"
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg"
 import { NodeSDK } from "@opentelemetry/sdk-node"
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics"
 import { BatchSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base"
 import { LangfuseIntegrationExporter } from "@/external/langfuse/langfuse-integration-exporter"
 
@@ -26,8 +28,13 @@ if (isProduction) {
   spanProcessors.push(new BatchSpanProcessor(new ConsoleSpanExporter()))
 }
 
+const metricReader = isProduction
+  ? new PeriodicExportingMetricReader({ exporter: new MetricExporter() })
+  : undefined
+
 export const sdk = new NodeSDK({
   spanProcessors,
+  ...(metricReader && { metricReader }),
   instrumentations: isTest
     ? []
     : [new HttpInstrumentation(), new NestInstrumentation(), new PgInstrumentation()],

--- a/apps/api/src/external/llm/providers/ai-sdk-med-gemma.provider.ts
+++ b/apps/api/src/external/llm/providers/ai-sdk-med-gemma.provider.ts
@@ -1,4 +1,3 @@
-import "../open-telemetry-init" // !!!! first import !!!!
 import { createOpenResponses } from "@ai-sdk/open-responses"
 import { createOpenAI } from "@ai-sdk/openai"
 import type { LanguageModelV3 } from "@ai-sdk/provider"

--- a/apps/api/src/external/llm/providers/ai-sdk-vertex.provider.ts
+++ b/apps/api/src/external/llm/providers/ai-sdk-vertex.provider.ts
@@ -1,4 +1,3 @@
-import "../open-telemetry-init" // !!!! first import !!!!
 import { createVertex } from "@ai-sdk/google-vertex"
 import { AgentProvider } from "@caseai-connect/api-contracts"
 import { Injectable } from "@nestjs/common"

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,3 +1,4 @@
+import "./external/llm/open-telemetry-init" // must be first — patches http/pg before they are imported
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { Logger, ValidationPipe } from "@nestjs/common"

--- a/apps/api/src/workers-main.ts
+++ b/apps/api/src/workers-main.ts
@@ -1,3 +1,4 @@
+import "./external/llm/open-telemetry-init" // must be first — patches http/pg before they are imported
 import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { getLogLevels, StructuredLogger } from "@/common/logger/structured-logger"

--- a/docs/adr/0005-gcp-native-observability.md
+++ b/docs/adr/0005-gcp-native-observability.md
@@ -1,4 +1,4 @@
-# ADR-001: GCP-Native Observability Stack
+# ADR-0005: GCP-Native Observability Stack
 
 **Status:** Accepted
 **Date:** 2026-03-19
@@ -101,27 +101,15 @@ Redis/BullMQ instrumentation is deferred (nice-to-have, workers are async so tra
 
 ### 5. BullMQ Queue Metrics
 
-**Goal:** Monitor queue health (backlog, failures) via Cloud Monitoring.
+**Goal:** Monitor queue health (backlog, failures) via Cloud Monitoring with alerting.
 
-**Approach:** Log-based metrics (no custom metrics API needed).
+**Approach:** OTEL metrics exported to Cloud Monitoring via `@google-cloud/opentelemetry-cloud-monitoring-exporter`.
 
 - Add a periodic task (every 30s) in the Workers service
 - Calls `queue.getJobCounts()` → `{ waiting, active, completed, failed }`
-- Logs as structured JSON:
-
-```json
-{
-  "severity": "INFO",
-  "message": "queue_metrics",
-  "queue": "document-embeddings-queue",
-  "waiting": 5,
-  "active": 2,
-  "failed": 3
-}
-```
-
-- In GCP Console: create log-based metrics from `waiting` and `failed` fields
-- Set alerts on those metrics in Cloud Monitoring
+- Records values as OTEL gauge metrics (e.g. `bullmq.queue.waiting`, `bullmq.queue.failed`)
+- In production, metrics are exported directly to Cloud Monitoring — no log-based metrics needed
+- Alerts configured directly on OTEL metrics in Cloud Monitoring
 
 ### 6. Alerting (GCP Console config, not code)
 
@@ -144,8 +132,8 @@ Notification channel: Slack (configured once in Cloud Monitoring → Notificatio
 | Distributed tracing | Cloud Trace | New OTEL exporter + auto-instrumentations |
 | Logs | Cloud Logging | Structured JSON to stdout (no SDK) |
 | Error reporting | Cloud Error Reporting | Auto from structured logs with severity ERROR |
-| Metrics & dashboards | Cloud Monitoring | Built-in Cloud Run metrics + log-based custom metrics |
-| Alerting | Cloud Monitoring | Log-based + metric-based alerts → Slack |
+| Metrics & dashboards | Cloud Monitoring | Built-in Cloud Run metrics + OTEL custom metrics |
+| Alerting | Cloud Monitoring | OTEL metric-based alerts → Slack |
 
 ## Authentication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@ai-sdk/google-vertex": "^4.0.28",
         "@caseai-connect/api-contracts": "*",
         "@google-cloud/aiplatform": "^6.5.0",
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
         "@google-cloud/storage": "^7.18.0",
         "@google/genai": "^1.21.0",
@@ -1809,6 +1810,67 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.21.0.tgz",
+      "integrity": "sha512-+lAew44pWt6rA4l8dQ1gGhH7Uo95wZKfq/GBf9aEyuNDDLQ2XppGEEReu6ujesSqTtZ8ueQFt73+7SReSHbwqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/opentelemetry-resource-util": "^3.0.0",
+        "@google-cloud/precise-date": "^4.0.0",
+        "google-auth-library": "^9.0.0",
+        "googleapis": "^137.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0"
+      }
+    },
+    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@google-cloud/opentelemetry-cloud-trace-exporter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-3.0.0.tgz",
@@ -1919,6 +1981,15 @@
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
+      "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5399,6 +5470,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6040,6 +6112,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -13903,6 +13976,129 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "137.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
+      "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/googleapis/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -23678,6 +23874,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",


### PR DESCRIPTION
- add BullMQ queue metrics as OTEL gauges exported to Cloud Monitoring
- add /diagnostics/<secret>/test-error endpoint for error reporting validation
- move OTEL init to first import in entrypoints to fix instrumentation patching
- remove redundant OTEL imports from LLM provider files
- update ADR-0005 to reflect OTEL metrics approach