### PR TITLE
refactor(api): standardize script bootstrap

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -24,6 +24,30 @@ To learn more about NestJs, take a look at the following resources:
 - [Official NestJS Courses](https://courses.nestjs.com) - Learn everything you need to master NestJS and tackle modern backend applications at any scale.
 - [GitHub Repo](https://github.com/nestjs/nest)
 
+## Scripts
+
+Admin scripts live in `src/scripts/` and are exposed as npm commands. They all bootstrap a full NestJS application context, so database and external service configuration must be available via environment variables.
+
+### Environment loading
+
+All scripts support `DOTENV_CONFIG_PATH` to load a specific `.env` file before the NestJS app bootstraps. This is useful for targeting a specific environment (e.g. platform):
+
+```bash
+DOTENV_CONFIG_PATH=.env.dontsave.platform npm run invite:manage
+```
+
+When `DOTENV_CONFIG_PATH` is set, the specified file is loaded with `override: true`, meaning its values take precedence over any previously set environment variables.
+
+### Available scripts
+
+| Command | Description |
+|---|---|
+| `npm run invite:manage` | List and resend pending invitations interactively |
+| `npm run invite:organization-owners` | Batch-invite organization owners from a CSV file (`--file <path>` required, supports `--dry-run` and `--inviter-name`) |
+| `npm run seed:mcp-preset` | Create an MCP server preset interactively |
+| `npm run mcp:link-to-project` | Link an MCP server preset to project agents interactively |
+| `npm run requeue:document-embeddings` | Re-enqueue documents for embedding generation (supports `--dry-run`, `--limit`, `--batch-size`, `--organization-id`, `--project-id`, `--all-project-documents`) |
+
 ## Force API Deployment (No TS Changes)
 
 Production CI only deploys when `make check-api-changes` finds meaningful API changes.

--- a/apps/api/src/scripts/invite-organization-owners.ts
+++ b/apps/api/src/scripts/invite-organization-owners.ts
@@ -1,22 +1,15 @@
 import { readFileSync } from "node:fs"
-import { createInterface } from "node:readline"
 import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
-import { config as dotenvConfig } from "dotenv"
 import { DataSource } from "typeorm"
 import { AppModule } from "@/app.module"
-
-const envPath = process.env.DOTENV_CONFIG_PATH
-if (envPath) {
-  dotenvConfig({ path: envPath, override: true })
-}
-
 import { INVITATION_SENDER } from "@/domains/auth/invitation-sender.interface"
 import {
   type InviteWorkspaceOwnerResult,
   type PreviewWorkspaceInvitationResult,
   WorkspaceInvitationService,
 } from "@/domains/organizations/provisioning/workspace-invitation.service"
+import { confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
 type CliOptions = {
   csvFilePath: string
@@ -144,29 +137,6 @@ export async function runInvitationBatch(params: {
 
 const logger = new Logger("InviteOrganizationOwners")
 
-function ask(question: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer.trim())
-    })
-  })
-}
-
-async function confirmDatabaseTarget(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL
-  const target =
-    databaseUrl ??
-    `${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`
-  logger.warn(`Target database: ${target}`)
-  const answer = await ask("Do you want to proceed? (yes/no): ")
-  if (answer.toLowerCase() !== "yes") {
-    logger.log("Aborted by user.")
-    process.exit(0)
-  }
-}
-
 function printSummary(results: CliRowResult[]): void {
   const invitedCount = results.filter((result) => result.status === "invited").length
   const skippedCount = results.filter((result) =>
@@ -216,7 +186,7 @@ async function bootstrapCli(): Promise<void> {
   const options = parseCliOptions(process.argv.slice(2))
   const csvContent = readFileSync(options.csvFilePath, "utf-8")
   const rows = parseInvitationCsv(csvContent)
-  await confirmDatabaseTarget()
+  await confirmDatabaseTarget(logger)
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ["error", "warn", "log"],
   })

--- a/apps/api/src/scripts/link-mcp-to-project.ts
+++ b/apps/api/src/scripts/link-mcp-to-project.ts
@@ -1,4 +1,4 @@
-import { createInterface } from "node:readline"
+import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { getRepositoryToken } from "@nestjs/typeorm"
 import type { Repository } from "typeorm"
@@ -7,20 +7,15 @@ import { Agent } from "@/domains/agents/agent.entity"
 import { McpServer } from "@/domains/mcp-servers/mcp-server.entity"
 import { McpServersService } from "@/domains/mcp-servers/mcp-servers.service"
 import { Project } from "@/domains/projects/project.entity"
+import { ask, confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
-function ask(question: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer.trim())
-    })
-  })
-}
+const logger = new Logger("LinkMcpToProject")
 
 async function main(): Promise<void> {
+  await confirmDatabaseTarget(logger)
+
   const app = await NestFactory.createApplicationContext(AppModule, {
-    logger: ["error", "warn"],
+    logger: ["error", "warn", "log"],
   })
 
   try {
@@ -33,26 +28,26 @@ async function main(): Promise<void> {
     const presetServers = allServers.filter((server) => server.presetSlug !== null)
 
     if (presetServers.length === 0) {
-      console.log("No MCP server presets found. Run `npm run seed:mcp-preset` first.")
+      logger.log("No MCP server presets found. Run `npm run seed:mcp-preset` first.")
       return
     }
 
-    console.log("\nAvailable MCP server presets:")
+    logger.log("\nAvailable MCP server presets:")
     for (const server of presetServers) {
-      console.log(`  [${server.presetSlug}] ${server.name} (${server.id})`)
+      logger.log(`  [${server.presetSlug}] ${server.name} (${server.id})`)
     }
 
     const slug = await ask("\nPreset slug to link: ")
     const selected = presetServers.find((server) => server.presetSlug === slug)
     if (!selected) {
-      console.error(`No preset found with slug "${slug}"`)
+      logger.error(`No preset found with slug "${slug}"`)
       process.exit(1)
     }
 
     const projectId = await ask("Project ID: ")
     const project = await projectRepository.findOne({ where: { id: projectId } })
     if (!project) {
-      console.error(`No project found with ID "${projectId}"`)
+      logger.error(`No project found with ID "${projectId}"`)
       process.exit(1)
     }
 
@@ -63,13 +58,13 @@ async function main(): Promise<void> {
     })
 
     if (agents.length === 0) {
-      console.log(`\nNo agents found in project "${project.name}".`)
+      logger.log(`\nNo agents found in project "${project.name}".`)
       return
     }
 
-    console.log(`\nAgents in project "${project.name}":`)
+    logger.log(`\nAgents in project "${project.name}":`)
     for (const agent of agents) {
-      console.log(`  [${agent.id}] ${agent.name} (${agent.type})`)
+      logger.log(`  [${agent.id}] ${agent.name} (${agent.type})`)
     }
 
     const agentInput = await ask("\nAgent ID to link (or 'all' for all agents): ")
@@ -78,16 +73,16 @@ async function main(): Promise<void> {
       agentInput === "all" ? agents : agents.filter((agent) => agent.id === agentInput)
 
     if (agentsToLink.length === 0) {
-      console.error(`No agent found with ID "${agentInput}"`)
+      logger.error(`No agent found with ID "${agentInput}"`)
       process.exit(1)
     }
 
     for (const agent of agentsToLink) {
       await mcpServersService.enableForAgent(agent.id, selected.id)
-      console.log(`  Linked "${selected.name}" → agent "${agent.name}" (${agent.id})`)
+      logger.log(`  Linked "${selected.name}" → agent "${agent.name}" (${agent.id})`)
     }
 
-    console.log("\nDone.")
+    logger.log("\nDone.")
   } finally {
     await app.close()
   }

--- a/apps/api/src/scripts/manage-invitations.ts
+++ b/apps/api/src/scripts/manage-invitations.ts
@@ -1,45 +1,15 @@
 import { writeFileSync } from "node:fs"
-import { createInterface } from "node:readline"
 import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
-import { config as dotenvConfig } from "dotenv"
 import { DataSource } from "typeorm"
 import { AppModule } from "@/app.module"
-
-const envPath = process.env.DOTENV_CONFIG_PATH
-if (envPath) {
-  dotenvConfig({ path: envPath, override: true })
-}
-
 import type { InvitationSender } from "@/domains/auth/invitation-sender.interface"
 import { INVITATION_SENDER } from "@/domains/auth/invitation-sender.interface"
+import { ask, confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
 const PLACEHOLDER_AUTH0_ID_PREFIX = "00000000-0000-0000-0000-"
 
 const logger = new Logger("ManageInvitations")
-
-function ask(question: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer.trim())
-    })
-  })
-}
-
-async function confirmDatabaseTarget(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL
-  const target =
-    databaseUrl ??
-    `${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`
-  logger.warn(`Target database: ${target}`)
-  const answer = await ask("Do you want to proceed? (yes/no): ")
-  if (answer.toLowerCase() !== "yes") {
-    logger.log("Aborted by user.")
-    process.exit(0)
-  }
-}
 
 type PendingInvitation = {
   index: number
@@ -130,7 +100,7 @@ async function resendInvitation(
 }
 
 async function bootstrapCli(): Promise<void> {
-  await confirmDatabaseTarget()
+  await confirmDatabaseTarget(logger)
 
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ["error", "warn", "log"],

--- a/apps/api/src/scripts/requeue-document-embeddings.ts
+++ b/apps/api/src/scripts/requeue-document-embeddings.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { getRepositoryToken } from "@nestjs/typeorm"
 import type { Repository } from "typeorm"
@@ -8,6 +9,7 @@ import {
   DOCUMENT_EMBEDDINGS_BATCH_SERVICE,
   type DocumentEmbeddingsBatchService,
 } from "@/domains/documents/embeddings/document-embeddings-batch.interface"
+import { confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
 type CliOptions = {
   dryRun: boolean
@@ -41,6 +43,8 @@ function getOptionalArgValue(argv: string[], argName: string): string | undefine
   return argv[argIndex + 1]
 }
 
+const logger = new Logger("RequeueDocumentEmbeddings")
+
 function validateCliOptions(options: CliOptions): void {
   if (options.limit !== undefined && (Number.isNaN(options.limit) || options.limit <= 0)) {
     throw new Error("Invalid --limit value. It must be a positive integer.")
@@ -54,6 +58,7 @@ function validateCliOptions(options: CliOptions): void {
 async function bootstrapCli(): Promise<void> {
   const options = parseCliOptions(process.argv.slice(2))
   validateCliOptions(options)
+  await confirmDatabaseTarget(logger)
 
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ["error", "warn", "log"],
@@ -71,24 +76,22 @@ async function bootstrapCli(): Promise<void> {
     })
 
     if (documentsToRequeue.length === 0) {
-      console.log("No documents matched the requeue filters.")
+      logger.log("No documents matched the requeue filters.")
       return
     }
 
-    console.log(
+    logger.log(
       `Found ${documentsToRequeue.length} documents to ${options.dryRun ? "preview" : "requeue"}.`,
     )
 
     if (options.dryRun) {
       for (const document of documentsToRequeue.slice(0, 20)) {
-        console.log(
+        logger.log(
           `[dry-run] ${document.id} org=${document.organizationId} project=${document.projectId} extractionEngine=${document.extractionEngine ?? "null"} embeddingStatus=${document.embeddingStatus}`,
         )
       }
       if (documentsToRequeue.length > 20) {
-        console.log(
-          `[dry-run] ... ${documentsToRequeue.length - 20} additional document(s) omitted`,
-        )
+        logger.log(`[dry-run] ... ${documentsToRequeue.length - 20} additional document(s) omitted`)
       }
       return
     }
@@ -106,7 +109,7 @@ async function bootstrapCli(): Promise<void> {
         })
         enqueuedCount += 1
       }
-      console.log(`Enqueued ${enqueuedCount}/${documentsToRequeue.length} documents`)
+      logger.log(`Enqueued ${enqueuedCount}/${documentsToRequeue.length} documents`)
     }
   } finally {
     await app.close()

--- a/apps/api/src/scripts/script-bootstrap.ts
+++ b/apps/api/src/scripts/script-bootstrap.ts
@@ -1,0 +1,31 @@
+import { createInterface } from "node:readline"
+import type { Logger } from "@nestjs/common"
+import { config as dotenvConfig } from "dotenv"
+
+const envPath = process.env.DOTENV_CONFIG_PATH
+if (envPath) {
+  dotenvConfig({ path: envPath, override: true })
+}
+
+export function ask(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+export async function confirmDatabaseTarget(logger: Logger): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  const target =
+    databaseUrl ??
+    `${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`
+  logger.warn(`Target database: ${target}`)
+  const answer = await ask("Do you want to proceed? (yes/no): ")
+  if (answer.toLowerCase() !== "yes") {
+    logger.log("Aborted by user.")
+    process.exit(0)
+  }
+}

--- a/apps/api/src/scripts/seed-mcp-preset.ts
+++ b/apps/api/src/scripts/seed-mcp-preset.ts
@@ -1,31 +1,47 @@
-import { createInterface } from "node:readline"
+import { Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { AppModule } from "@/app.module"
 import { McpServersService } from "@/domains/mcp-servers/mcp-servers.service"
+import { ask, confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
-function ask(question: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer.trim())
-    })
-  })
+const logger = new Logger("SeedMcpPreset")
+
+async function confirmEncryptionKey(): Promise<void> {
+  const currentKey = process.env.MCP_ENCRYPTION_KEY
+  if (currentKey) {
+    const masked = `*****${currentKey.slice(-6)}`
+    logger.warn(`MCP_ENCRYPTION_KEY: ${masked}`)
+    const answer = await ask("Use this key? (yes/no): ")
+    if (answer.toLowerCase() === "yes") {
+      return
+    }
+  } else {
+    logger.warn("MCP_ENCRYPTION_KEY is not set")
+  }
+  const newKey = await ask("Enter MCP_ENCRYPTION_KEY: ")
+  if (!newKey) {
+    logger.error("MCP_ENCRYPTION_KEY is required")
+    process.exit(1)
+  }
+  process.env.MCP_ENCRYPTION_KEY = newKey
 }
 
 async function main(): Promise<void> {
+  await confirmDatabaseTarget(logger)
+  await confirmEncryptionKey()
+
   const slug = await ask("Preset slug (e.g. social): ")
   const name = await ask("Display name (e.g. Bayes Social): ")
   const url = await ask("MCP server URL: ")
   const apiKey = await ask("API key (leave empty if none): ")
 
   if (!slug || !name || !url) {
-    console.error("slug, name and url are required")
+    logger.error("slug, name and url are required")
     process.exit(1)
   }
 
   const app = await NestFactory.createApplicationContext(AppModule, {
-    logger: ["error", "warn"],
+    logger: ["error", "warn", "log"],
   })
 
   try {
@@ -35,15 +51,15 @@ async function main(): Promise<void> {
       ...(apiKey ? { apiKey } : {}),
     })
 
-    console.log(`\nMCP server created:`)
-    console.log(`  ID:   ${server.id}`)
-    console.log(`  Slug: ${server.presetSlug}`)
-    console.log(`  Name: ${server.name}`)
-    console.log(`\nTo enable for an agent:`)
-    console.log(
+    logger.log(`MCP server created:`)
+    logger.log(`  ID:   ${server.id}`)
+    logger.log(`  Slug: ${server.presetSlug}`)
+    logger.log(`  Name: ${server.name}`)
+    logger.log(`To enable for an agent:`)
+    logger.log(
       `  INSERT INTO agent_mcp_server (id, agent_id, mcp_server_id, enabled, created_at, updated_at)`,
     )
-    console.log(`  VALUES (gen_random_uuid(), '<agent_id>', '${server.id}', true, now(), now());`)
+    logger.log(`  VALUES (gen_random_uuid(), '<agent_id>', '${server.id}', true, now(), now());`)
   } finally {
     await app.close()
   }


### PR DESCRIPTION
Standardize script bootstrap with shared env loading and db confirmation

- Extract dotenv loading, ask, and confirmDatabaseTarget into shared script-bootstrap.ts
- Add DOTENV_CONFIG_PATH support and db confirmation to all scripts
- Replace console.log/error with NestJS Logger in mcp and requeue scripts
- Add MCP_ENCRYPTION_KEY confirmation to seed:mcp-preset
- Document all scripts and env loading in API README