### PR TITLE
Add sub-agent orchestration for conversation agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ All commands should be run from the root directory using Turbo (via npm scripts)
 - Private packages with internal dependencies using `*` version specifier
 - Engines requirement: Node.js >= 18
 
+## Git
+
+- Use semantic commit messages consistent with the repo history: `feat: ...`, `fix: ...`, `chore: ...`.
+- Use scoped variants only when they match existing history and add clarity.
+
 ## Code Style
 
 ### Descriptive Variable Names in Loops

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Structure
+
+This is a Turborepo monorepo with the following structure:
+
+- `apps/api` - NestJS backend application (runs on port 3000)
+- `apps/web` - Vite + React frontend application (runs on port 5173)
+- `packages/@caseai-connect/api-contracts` - Shared API contracts and DTOs
+- `packages/@repo/jest-config` - Shared Jest configurations
+- `packages/@repo/typescript-config` - Shared TypeScript configurations
+- `packages/@caseai-connect/ui` - Shared React component library
+
+## Development Commands
+
+All commands should be run from the root directory using Turbo (via npm scripts):
+
+### Development
+- `npx turbo dev` - Start all applications in development mode
+- `npx turbo dev --filter=api` - Start only the API application
+- `npx turbo dev --filter=web` - Start only the web application
+
+### Building
+- `npx turbo build` - Build all applications and packages
+- `npx turbo build --filter=api` - Build only the API application
+- `npx turbo build --filter=web` - Build only the web application
+
+### Testing
+- `npx turbo test` - Run all tests
+- `npx turbo test --filter=api` - Run API tests only
+- `npx turbo test --filter=web` - Run web tests only
+
+### Code Quality
+- `npx turbo lint` - Lint all packages and applications
+
+### TypeScript Compilation Check
+- `cd apps/api && npx tsc --noEmit` - Check API TypeScript without emitting files
+- `cd apps/web && npx tsc --noEmit` - Check web TypeScript without emitting files
+
+## Architecture Notes
+
+### API Application
+- Built with NestJS framework
+- Entry point: `apps/api/src/main.ts`
+- Main module: `apps/api/src/app.module.ts`
+- Modular structure with feature-based modules under `apps/api/src/domains/`
+- Uses dependency injection and decorators pattern
+- See `apps/api/AGENTS.md` for detailed API rules
+
+### Web Application
+- Vite + React (SPA) with React Compiler enabled via `babel-plugin-react-compiler`
+- Redux for state management with feature-based slices/thunks/selectors
+- Integrates with shared UI component library from `@caseai-connect/ui`
+- Entry point: `apps/web/src/main.tsx`
+- See `apps/web/AGENTS.md` for detailed web rules
+
+### Shared Packages
+- `api-contracts`: DTOs and route definitions shared between API and web
+  - All DTOs consolidated per domain: `packages/api-contracts/src/{domain}/{domain}.dto.ts`
+  - All routes defined with `defineRoute` in `*.routes.ts` files
+  - Everything exported from `packages/api-contracts/src/index.ts`
+- All packages use TypeScript with strict configuration
+- Jest configuration centralized in `@repo/jest-config`
+
+## Package Management
+
+- Uses npm workspaces for monorepo management
+- Private packages with internal dependencies using `*` version specifier
+- Engines requirement: Node.js >= 18
+
+## Code Style
+
+### Descriptive Variable Names in Loops
+
+**Rule**: NEVER use single-letter variables in loops (for, map, forEach, etc.). Always use descriptive, human-readable variable names based on the type of object being iterated.
+
+```typescript
+// ❌ Wrong
+projects.map((p) => p.name)
+
+// ✅ Correct
+projects.map((project) => project.name)
+```
+
+### Neutral Sample Data in Mocks, Stories, and Fixtures
+
+**Rule**: When generating sample/mock data (Storybook stories, test fixtures, seed scripts, factory overrides), use domain-neutral examples — generic agent names like "Helpful Assistant", tags like "Product/Pricing/Support", schemas with `{ title, summary }`. Do NOT infer a vertical from weak signals (the `MedGemma` model enum, a `gemma` feature flag, the repo name). Only use domain-specific samples if the user explicitly asks for them; if unsure, ask rather than guess.
+
+## Completion Criteria
+
+Before marking any work as completed, run and verify:
+
+1. `npm run biome:check` — formatting and linting must pass
+2. `npm run typecheck` — no TypeScript errors
+3. `npm run test` — all tests must pass (API work)
+
+Work is NOT complete until all applicable commands pass with exit code 0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- (beta) Agent orchestration: configure conversation agents with sub-agents and delegate runtime tasks to them as tools
 
 ### Changed
 
 ### Fixed
+- Allow entering commas in comma-separated form fields
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,11 @@ All commands should be run from the root directory using Turbo (via npm scripts)
 - Private packages with internal dependencies using `*` version specifier
 - Engines requirement: Node.js >= 18
 
+## Git
+
+- Use semantic commit messages consistent with the repo history: `feat: ...`, `fix: ...`, `chore: ...`.
+- Use scoped variants only when they match existing history and add clarity.
+
 ## Code Style
 
 ### Descriptive Variable Names in Loops

--- a/apps/api/src/common/all-entities.ts
+++ b/apps/api/src/common/all-entities.ts
@@ -14,6 +14,7 @@ import { AgentMembership } from "@/domains/agents/memberships/agent-membership.e
 import { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 import { AgentMessageAttachmentDocument } from "@/domains/agents/shared/agent-session-messages/agent-message-attachment-document.entity"
 import { AgentMessageFeedback } from "@/domains/agents/shared/agent-session-messages/feedback/agent-message-feedback.entity"
+import { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
 import { Document } from "@/domains/documents/document.entity"
 import { DocumentChunk } from "@/domains/documents/embeddings/document-chunk.entity"
 import { DocumentChunkEmbedding } from "@/domains/documents/embeddings/document-chunk-embedding.entity"
@@ -55,6 +56,7 @@ export const ALL_ENTITIES = [
   AgentMessage,
   AgentMessageAttachmentDocument,
   AgentMessageFeedback,
+  AgentSubAgent,
   ConversationAgentSession,
   ConversationAgentSessionCategory,
   Document,

--- a/apps/api/src/common/test/test-all-repositories.ts
+++ b/apps/api/src/common/test/test-all-repositories.ts
@@ -11,6 +11,7 @@ import { AgentMembership } from "@/domains/agents/memberships/agent-membership.e
 import { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 import { AgentMessageAttachmentDocument } from "@/domains/agents/shared/agent-session-messages/agent-message-attachment-document.entity"
 import { AgentMessageFeedback } from "@/domains/agents/shared/agent-session-messages/feedback/agent-message-feedback.entity"
+import { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
 import { Document } from "@/domains/documents/document.entity"
 import { Evaluation } from "@/domains/evaluations/evaluation.entity"
 import { EvaluationExtractionDataset } from "@/domains/evaluations/extraction/datasets/evaluation-extraction-dataset.entity"
@@ -48,6 +49,7 @@ export type AllRepositories = {
   agentMessageFeedbackRepository: Repository<AgentMessageFeedback>
   agentMessageRepository: Repository<AgentMessage>
   agentRepository: Repository<Agent>
+  agentSubAgentRepository: Repository<AgentSubAgent>
   conversationAgentSessionRepository: Repository<ConversationAgentSession>
   conversationAgentSessionCategoryRepository: Repository<ConversationAgentSessionCategory>
   documentRepository: Repository<Document>
@@ -92,6 +94,7 @@ export function buildAllRepositories(
     agentMessageFeedbackRepository: getRepository(AgentMessageFeedback),
     agentMessageRepository: getRepository(AgentMessage),
     agentRepository: getRepository(Agent),
+    agentSubAgentRepository: getRepository(AgentSubAgent),
     conversationAgentSessionRepository: getRepository(ConversationAgentSession),
     conversationAgentSessionCategoryRepository: getRepository(ConversationAgentSessionCategory),
     documentRepository: getRepository(Document),

--- a/apps/api/src/common/test/test-database.ts
+++ b/apps/api/src/common/test/test-database.ts
@@ -172,6 +172,7 @@ export async function clearTestDatabase(dataSource: DataSource): Promise<void> {
       await queryRunner.query(`DELETE FROM "project_membership"`)
       await queryRunner.query(`DELETE FROM "document"`)
       await queryRunner.query(`DELETE FROM "agent_mcp_server"`)
+      await queryRunner.query(`DELETE FROM "agent_sub_agent"`)
       await queryRunner.query(`DELETE FROM "agent_membership"`)
       await queryRunner.query(`DELETE FROM "agent"`)
       await queryRunner.query(`DELETE FROM "mcp_server"`)

--- a/apps/api/src/domains/agents/agent.entity.ts
+++ b/apps/api/src/domains/agents/agent.entity.ts
@@ -16,6 +16,7 @@ import { EvaluationReport } from "../evaluations/reports/evaluation-report.entit
 import { AgentMcpServer } from "../mcp-servers/agent-mcp-server.entity"
 import { ExtractionAgentSession } from "./extraction-agent-sessions/extraction-agent-session.entity"
 import { AgentMembership } from "./memberships/agent-membership.entity"
+import { AgentSubAgent } from "./sub-agents/agent-sub-agent.entity"
 
 @ConnectEntity("agent")
 export class Agent extends ConnectEntityBase {
@@ -105,4 +106,16 @@ export class Agent extends ConnectEntityBase {
     (agentCategory) => agentCategory.agent,
   )
   categories!: AgentCategory[]
+
+  @OneToMany(
+    () => AgentSubAgent,
+    (agentSubAgent) => agentSubAgent.parentAgent,
+  )
+  childSubAgents!: AgentSubAgent[]
+
+  @OneToMany(
+    () => AgentSubAgent,
+    (agentSubAgent) => agentSubAgent.childAgent,
+  )
+  parentSubAgents!: AgentSubAgent[]
 }

--- a/apps/api/src/domains/agents/agent.entity.ts
+++ b/apps/api/src/domains/agents/agent.entity.ts
@@ -16,7 +16,11 @@ import { EvaluationReport } from "../evaluations/reports/evaluation-report.entit
 import { AgentMcpServer } from "../mcp-servers/agent-mcp-server.entity"
 import { ExtractionAgentSession } from "./extraction-agent-sessions/extraction-agent-session.entity"
 import { AgentMembership } from "./memberships/agent-membership.entity"
-import { AgentSubAgent } from "./sub-agents/agent-sub-agent.entity"
+
+type AgentSubAgentRelation = {
+  parentAgent: Agent
+  childAgent: Agent
+}
 
 @ConnectEntity("agent")
 export class Agent extends ConnectEntityBase {
@@ -107,15 +111,9 @@ export class Agent extends ConnectEntityBase {
   )
   categories!: AgentCategory[]
 
-  @OneToMany(
-    () => AgentSubAgent,
-    (agentSubAgent) => agentSubAgent.parentAgent,
-  )
-  childSubAgents!: AgentSubAgent[]
+  @OneToMany("AgentSubAgent", (agentSubAgent: AgentSubAgentRelation) => agentSubAgent.parentAgent)
+  childSubAgents!: AgentSubAgentRelation[]
 
-  @OneToMany(
-    () => AgentSubAgent,
-    (agentSubAgent) => agentSubAgent.childAgent,
-  )
-  parentSubAgents!: AgentSubAgent[]
+  @OneToMany("AgentSubAgent", (agentSubAgent: AgentSubAgentRelation) => agentSubAgent.childAgent)
+  parentSubAgents!: AgentSubAgentRelation[]
 }

--- a/apps/api/src/domains/agents/agent.factory.ts
+++ b/apps/api/src/domains/agents/agent.factory.ts
@@ -43,5 +43,7 @@ export const agentFactory = AgentFactory.define(({ sequence, params, transientPa
     agentMcpServers: params.agentMcpServers || [],
     reviewCampaigns: params.reviewCampaigns || [],
     categories: params.categories || [],
+    childSubAgents: params.childSubAgents || [],
+    parentSubAgents: params.parentSubAgents || [],
   } satisfies Agent
 })

--- a/apps/api/src/domains/agents/agents.controller.ts
+++ b/apps/api/src/domains/agents/agents.controller.ts
@@ -1,7 +1,7 @@
 import {
   type AgentDto,
-  AgentSubAgentsRoutes,
   type AgentSubAgentDto,
+  AgentSubAgentsRoutes,
   AgentsRoutes,
   createAgentSchema,
   replaceAgentSubAgentsSchema,

--- a/apps/api/src/domains/agents/agents.controller.ts
+++ b/apps/api/src/domains/agents/agents.controller.ts
@@ -1,4 +1,11 @@
-import { type AgentDto, AgentsRoutes, createAgentSchema } from "@caseai-connect/api-contracts"
+import {
+  type AgentDto,
+  AgentSubAgentsRoutes,
+  type AgentSubAgentDto,
+  AgentsRoutes,
+  createAgentSchema,
+  replaceAgentSubAgentsSchema,
+} from "@caseai-connect/api-contracts"
 import {
   Body,
   Controller,
@@ -6,6 +13,7 @@ import {
   Get,
   Patch,
   Post,
+  Put,
   Req,
   UseGuards,
   UsePipes,
@@ -26,12 +34,18 @@ import type { Agent } from "./agent.entity"
 import { AgentGuard } from "./agent.guard"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { AgentsService } from "./agents.service"
+import type { AgentSubAgent } from "./sub-agents/agent-sub-agent.entity"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { AgentSubAgentsService } from "./sub-agents/agent-sub-agents.service"
 
 @UseGuards(JwtAuthGuard, UserGuard, ResourceContextGuard, AgentGuard)
 @RequireContext("organization", "project")
 @Controller()
 export class AgentsController {
-  constructor(private readonly agentsService: AgentsService) {}
+  constructor(
+    private readonly agentsService: AgentsService,
+    private readonly agentSubAgentsService: AgentSubAgentsService,
+  ) {}
 
   @Post(AgentsRoutes.createOne.path)
   @CheckPolicy((policy) => policy.canCreate())
@@ -85,6 +99,38 @@ export class AgentsController {
     return { data: { success: true } }
   }
 
+  @Get(AgentSubAgentsRoutes.getAll.path)
+  @CheckPolicy((policy) => policy.canUpdate())
+  @AddContext("agent")
+  async getAllSubAgents(
+    @Req() request: EndpointRequestWithAgent,
+  ): Promise<typeof AgentSubAgentsRoutes.getAll.response> {
+    const subAgents = await this.agentSubAgentsService.listSubAgents({
+      connectScope: getRequiredConnectScope(request),
+      parentAgent: request.agent,
+    })
+
+    return { data: subAgents.map(toAgentSubAgentDto) }
+  }
+
+  @Put(AgentSubAgentsRoutes.updateAll.path)
+  @CheckPolicy((policy) => policy.canUpdate())
+  @AddContext("agent")
+  @TrackActivity({ action: "agent.sub_agents.update", entityFrom: "agent" })
+  @UsePipes(new ZodValidationPipe(replaceAgentSubAgentsSchema))
+  async updateAllSubAgents(
+    @Req() request: EndpointRequestWithAgent,
+    @Body() { payload }: typeof AgentSubAgentsRoutes.updateAll.request,
+  ): Promise<typeof AgentSubAgentsRoutes.updateAll.response> {
+    const subAgents = await this.agentSubAgentsService.replaceSubAgents({
+      connectScope: getRequiredConnectScope(request),
+      parentAgent: request.agent,
+      subAgents: payload.subAgents,
+    })
+
+    return { data: subAgents.map(toAgentSubAgentDto) }
+  }
+
   @Delete(AgentsRoutes.deleteOne.path)
   @CheckPolicy((policy) => policy.canDelete())
   @AddContext("agent")
@@ -94,6 +140,26 @@ export class AgentsController {
   ): Promise<typeof AgentsRoutes.deleteOne.response> {
     await this.agentsService.deleteAgent(request.agent)
     return { data: { success: true } }
+  }
+}
+
+function toAgentSubAgentDto(entity: AgentSubAgent): AgentSubAgentDto {
+  return {
+    id: entity.id,
+    parentAgentId: entity.parentAgentId,
+    childAgentId: entity.childAgentId,
+    toolName: entity.toolName,
+    description: entity.description,
+    enabled: entity.enabled,
+    childAgent: entity.childAgent
+      ? {
+          id: entity.childAgent.id,
+          name: entity.childAgent.name,
+          type: entity.childAgent.type,
+        }
+      : undefined,
+    createdAt: entity.createdAt.getTime(),
+    updatedAt: entity.updatedAt.getTime(),
   }
 }
 

--- a/apps/api/src/domains/agents/agents.module.ts
+++ b/apps/api/src/domains/agents/agents.module.ts
@@ -32,12 +32,15 @@ import { AgentMembership } from "./memberships/agent-membership.entity"
 import { AgentMembershipsController } from "./memberships/agent-memberships.controller"
 import { AgentMembershipsGuard } from "./memberships/agent-memberships.guard"
 import { AgentMembershipsService } from "./memberships/agent-memberships.service"
+import { AgentSubAgent } from "./sub-agents/agent-sub-agent.entity"
+import { AgentSubAgentsService } from "./sub-agents/agent-sub-agents.service"
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       Agent,
       AgentCategory,
+      AgentSubAgent,
       ProjectAgentCategory,
       AgentMembership,
       Project,
@@ -60,6 +63,7 @@ import { AgentMembershipsService } from "./memberships/agent-memberships.service
   providers: [
     AgentsService,
     AgentCategoriesService,
+    AgentSubAgentsService,
     BaseAgentSessionsService,
     AgentMembershipsService,
     AgentGuard,
@@ -71,6 +75,6 @@ import { AgentMembershipsService } from "./memberships/agent-memberships.service
     AgentMembershipContextResolver,
   ],
   controllers: [AgentsController, AgentMembershipsController],
-  exports: [AgentsService, AgentCategoriesService, AgentMembershipsService],
+  exports: [AgentsService, AgentCategoriesService, AgentMembershipsService, AgentSubAgentsService],
 })
 export class AgentsModule {}

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/build-tools.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/build-tools.spec.ts
@@ -13,7 +13,10 @@ type BuildToolsArgs = {
 }
 
 type BuildToolsAccessor = {
-  buildTools: (args: BuildToolsArgs) => Promise<{ tools: Record<string, unknown> | undefined }>
+  buildTools: (args: BuildToolsArgs) => Promise<{
+    toolDescriptions: Record<string, string>
+    tools: Record<string, unknown> | undefined
+  }>
 }
 
 describe("buildTools", () => {
@@ -111,5 +114,111 @@ describe("buildTools", () => {
     })
 
     expect(tools?.[ToolName.RecalculateConversationSessionMetadata]).toBeDefined()
+  })
+
+  it("should omit configured sub-agent tools when orchestration feature is disabled", async () => {
+    const {
+      agentRepository,
+      agentSubAgentRepository,
+      streamingService,
+      testAgent,
+      testOrganization,
+      testProject,
+    } = getTestContext()
+    const connectScope: RequiredConnectScope = {
+      organizationId: testOrganization.id,
+      projectId: testProject.id,
+    }
+    const childAgent = await agentRepository.save(
+      agentRepository.create({
+        organizationId: testOrganization.id,
+        projectId: testProject.id,
+        name: "Benefits Specialist",
+        defaultPrompt: "Answer benefits questions",
+        model: testAgent.model,
+        temperature: testAgent.temperature,
+        locale: testAgent.locale,
+        type: "conversation",
+        documentsRagMode: DocumentsRagMode.None,
+      }),
+    )
+    await agentSubAgentRepository.save(
+      agentSubAgentRepository.create({
+        parentAgentId: testAgent.id,
+        childAgentId: childAgent.id,
+        toolName: "benefits_specialist",
+        description: "Answer benefit eligibility questions.",
+        enabled: true,
+      }),
+    )
+
+    const { tools, toolDescriptions } = await (
+      streamingService as unknown as BuildToolsAccessor
+    ).buildTools({
+      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
+      sessionId: "session-id",
+      connectScope,
+      onExecute: () => undefined,
+    })
+
+    expect(tools?.benefits_specialist).toBeUndefined()
+    expect(toolDescriptions.benefits_specialist).toBeUndefined()
+  })
+
+  it("should expose enabled sub-agent tools when orchestration feature is enabled", async () => {
+    const {
+      agentRepository,
+      agentSubAgentRepository,
+      featureFlagRepository,
+      streamingService,
+      testAgent,
+      testOrganization,
+      testProject,
+    } = getTestContext()
+    const connectScope: RequiredConnectScope = {
+      organizationId: testOrganization.id,
+      projectId: testProject.id,
+    }
+    await featureFlagRepository.save(
+      featureFlagRepository.create({
+        projectId: testProject.id,
+        featureFlagKey: "agent-orchestration",
+        enabled: true,
+      }),
+    )
+    const childAgent = await agentRepository.save(
+      agentRepository.create({
+        organizationId: testOrganization.id,
+        projectId: testProject.id,
+        name: "Benefits Specialist",
+        defaultPrompt: "Answer benefits questions",
+        model: testAgent.model,
+        temperature: testAgent.temperature,
+        locale: testAgent.locale,
+        type: "conversation",
+        documentsRagMode: DocumentsRagMode.None,
+      }),
+    )
+    await agentSubAgentRepository.save(
+      agentSubAgentRepository.create({
+        parentAgentId: testAgent.id,
+        childAgentId: childAgent.id,
+        toolName: "benefits_specialist",
+        description: "Answer benefit eligibility questions.",
+        enabled: true,
+      }),
+    )
+
+    const { tools, toolDescriptions } = await (
+      streamingService as unknown as BuildToolsAccessor
+    ).buildTools({
+      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
+      sessionId: "session-id",
+      connectScope,
+      onExecute: () => undefined,
+    })
+
+    expect(tools?.benefits_specialist).toBeDefined()
+    expect(toolDescriptions.benefits_specialist).toBe("Answer benefit eligibility questions.")
   })
 })

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
@@ -8,6 +8,8 @@ import {
 import { Agent } from "@/domains/agents/agent.entity"
 import { agentFactory } from "@/domains/agents/agent.factory"
 import { AgentCategory } from "@/domains/agents/categories/agent-category.entity"
+import { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
+import { FeatureFlag } from "@/domains/feature-flags/feature-flag.entity"
 import { OrganizationMembership } from "@/domains/organizations/memberships/organization-membership.entity"
 import { Organization } from "@/domains/organizations/organization.entity"
 import { organizationFactory } from "@/domains/organizations/organization.factory"
@@ -30,7 +32,9 @@ export function agentSessionControllerTestSetup() {
   let conversationAgentSessionCategoryRepository: Repository<ConversationAgentSessionCategory>
   let agentRepository: Repository<Agent>
   let agentCategoryRepository: Repository<AgentCategory>
+  let agentSubAgentRepository: Repository<AgentSubAgent>
   let agentMessageRepository: Repository<AgentMessage>
+  let featureFlagRepository: Repository<FeatureFlag>
   let userRepository: Repository<User>
   let organizationRepository: Repository<Organization>
   let projectRepository: Repository<Project>
@@ -65,7 +69,9 @@ export function agentSessionControllerTestSetup() {
     agentMessageRepository = setup.getRepository(AgentMessage)
     agentRepository = setup.getRepository(Agent)
     agentCategoryRepository = setup.getRepository(AgentCategory)
+    agentSubAgentRepository = setup.getRepository(AgentSubAgent)
     userRepository = setup.getRepository(User)
+    featureFlagRepository = setup.getRepository(FeatureFlag)
     organizationRepository = setup.getRepository(Organization)
     projectRepository = setup.getRepository(Project)
     organizationMembershipRepository = setup.getRepository(OrganizationMembership)
@@ -108,8 +114,10 @@ export function agentSessionControllerTestSetup() {
     return {
       agentRepository,
       agentCategoryRepository,
+      agentSubAgentRepository,
       conversationAgentSessionRepository,
       conversationAgentSessionCategoryRepository,
+      featureFlagRepository,
       agentMessageRepository,
       organizationMembershipRepository,
       organizationRepository,

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
@@ -1,6 +1,7 @@
 import { afterAll } from "@jest/globals"
 import type { Repository } from "typeorm"
 import {
+  type AllRepositories,
   clearTestDatabase,
   setupE2eTestDatabase,
   teardownE2eTestDatabase,
@@ -9,7 +10,6 @@ import { Agent } from "@/domains/agents/agent.entity"
 import { agentFactory } from "@/domains/agents/agent.factory"
 import { AgentCategory } from "@/domains/agents/categories/agent-category.entity"
 import { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
-import { FeatureFlag } from "@/domains/feature-flags/feature-flag.entity"
 import { OrganizationMembership } from "@/domains/organizations/memberships/organization-membership.entity"
 import { Organization } from "@/domains/organizations/organization.entity"
 import { organizationFactory } from "@/domains/organizations/organization.factory"
@@ -34,7 +34,7 @@ export function agentSessionControllerTestSetup() {
   let agentCategoryRepository: Repository<AgentCategory>
   let agentSubAgentRepository: Repository<AgentSubAgent>
   let agentMessageRepository: Repository<AgentMessage>
-  let featureFlagRepository: Repository<FeatureFlag>
+  let featureFlagRepository: AllRepositories["featureFlagRepository"]
   let userRepository: Repository<User>
   let organizationRepository: Repository<Organization>
   let projectRepository: Repository<Project>
@@ -71,7 +71,7 @@ export function agentSessionControllerTestSetup() {
     agentCategoryRepository = setup.getRepository(AgentCategory)
     agentSubAgentRepository = setup.getRepository(AgentSubAgent)
     userRepository = setup.getRepository(User)
-    featureFlagRepository = setup.getRepository(FeatureFlag)
+    featureFlagRepository = setup.getAllRepositories().featureFlagRepository
     organizationRepository = setup.getRepository(Organization)
     projectRepository = setup.getRepository(Project)
     organizationMembershipRepository = setup.getRepository(OrganizationMembership)

--- a/apps/api/src/domains/agents/e2e-tests/sub-agents.spec.ts
+++ b/apps/api/src/domains/agents/e2e-tests/sub-agents.spec.ts
@@ -1,0 +1,145 @@
+import { AgentSubAgentsRoutes } from "@caseai-connect/api-contracts"
+import { afterAll } from "@jest/globals"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { setupUserGuardForTesting } from "../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../test/request"
+import { AgentsModule } from "../agents.module"
+
+describe("Agents - sub-agents", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let organizationId: string
+  let projectId: string
+  let agentId: string
+  let auth0Id = "auth0|123"
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [AgentsModule],
+      applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    auth0Id = "auth0|123"
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await sdk.shutdown()
+    await app.close()
+  })
+
+  const createContext = async () => {
+    const { user, organization, project, agent } = await createOrganizationWithAgent(repositories)
+    organizationId = organization.id
+    projectId = project.id
+    agentId = agent.id
+    auth0Id = user.auth0Id
+    return { organization, project, agent, user }
+  }
+
+  const getAllSubAgents = async () =>
+    request({
+      route: AgentSubAgentsRoutes.getAll,
+      pathParams: removeNullish({ organizationId, projectId, agentId }),
+      token: "token",
+    })
+
+  const updateAllSubAgents = async (payload: typeof AgentSubAgentsRoutes.updateAll.request) =>
+    request({
+      route: AgentSubAgentsRoutes.updateAll,
+      pathParams: removeNullish({ organizationId, projectId, agentId }),
+      token: "token",
+      request: payload,
+    })
+
+  it("replaces and returns sub-agents", async () => {
+    const { organization, project } = await createContext()
+    const childAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        name: "Policy Agent",
+        type: "conversation",
+      }),
+    )
+
+    const replaceResponse = await updateAllSubAgents({
+      payload: {
+        subAgents: [
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_policy",
+            description: "Use for policy questions.",
+            enabled: true,
+          },
+        ],
+      },
+    })
+
+    expectResponse(replaceResponse, 200)
+    expect(replaceResponse.body.data).toHaveLength(1)
+    expect(replaceResponse.body.data[0]).toMatchObject({
+      parentAgentId: agentId,
+      childAgentId: childAgent.id,
+      toolName: "ask_policy",
+      description: "Use for policy questions.",
+      enabled: true,
+      childAgent: {
+        id: childAgent.id,
+        name: "Policy Agent",
+        type: "conversation",
+      },
+    })
+
+    const getResponse = await getAllSubAgents()
+    expectResponse(getResponse, 200)
+    expect(getResponse.body.data.map((row) => row.childAgentId)).toEqual([childAgent.id])
+  })
+
+  it("rejects duplicate sub-agent ids", async () => {
+    const { organization, project } = await createContext()
+    const childAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build(),
+    )
+
+    const response = await updateAllSubAgents({
+      payload: {
+        subAgents: [
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_first",
+            description: "",
+            enabled: true,
+          },
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_second",
+            description: "",
+            enabled: true,
+          },
+        ],
+      },
+    })
+
+    expectResponse(response, 422)
+  })
+})

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
@@ -1,13 +1,14 @@
-import type { ToolName } from "@caseai-connect/api-contracts"
 import type { Agent } from "@/domains/agents/agent.entity"
 import { promptHelpers } from "./helpers"
 
 export function buildConversationAgentPrompt({
   agent,
+  toolDescriptions,
   toolNames,
 }: {
   agent: Agent
-  toolNames: ToolName[]
+  toolDescriptions?: Record<string, string>
+  toolNames: string[]
 }): string {
   return `${promptHelpers.now()}
 
@@ -16,7 +17,7 @@ You are **${agent.name}**, a conversational AI assistant.
 
 ${agent.defaultPrompt}
 
-${promptHelpers.tools(toolNames)}
+${promptHelpers.tools(toolNames, toolDescriptions)}
 
 ${promptHelpers.language(agent.locale)}`
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
@@ -1,13 +1,14 @@
-import type { ToolName } from "@caseai-connect/api-contracts"
 import type { Agent } from "@/domains/agents/agent.entity"
 import { promptHelpers } from "./helpers"
 
 export function buildFormAgentPrompt({
   agent,
+  toolDescriptions,
   toolNames,
 }: {
   agent: Agent
-  toolNames: ToolName[]
+  toolDescriptions?: Record<string, string>
+  toolNames: string[]
 }): string {
   return `${promptHelpers.now()}
 
@@ -21,7 +22,7 @@ ${Object.entries(agent.outputJsonSchema?.properties ?? {})
   )
   .join("\n")}
 
-${promptHelpers.tools(toolNames)}
+${promptHelpers.tools(toolNames, toolDescriptions)}
 
 ${promptHelpers.language(agent.locale)}`
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/helpers.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/helpers.ts
@@ -8,7 +8,7 @@ export const promptHelpers = {
 Always answer in ${locale === "en" ? "English" : locale === "fr" ? "French" : "user's language"}.
       `.trim(),
 
-  tools: (names: ToolName[]) =>
+  tools: (names: string[], descriptions: Record<string, string> = {}) =>
     names.length === 0
       ? ""
       : `## Tools:
@@ -34,6 +34,7 @@ ${names
         return `[${name}]: AI-powered search across multiple workforce and social sources. Rewrites the query for better results and reranks by relevance. Use this when the user's question spans multiple resource types or when you want the best results across all sources.`
 
       default:
+        if (descriptions[name]) return `[${name}]: ${descriptions[name]}`
         return `[${name}]: No specific instructions for this tool.`
     }
   })

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
@@ -1,0 +1,19 @@
+import type { ConversationAgentSession } from "../../../conversation-agent-sessions/conversation-agent-session.entity"
+import type { FormAgentSession } from "../../../form-agent-sessions/form-agent-session.entity"
+import type { AgentMessage } from "../agent-message.entity"
+
+/**
+ * Minimal session context for public/anonymous sessions that have no
+ * corresponding ConversationAgentSession or FormAgentSession row.
+ */
+export type PublicStreamingSessionProxy = {
+  id: string
+  traceId: string
+  organizationId: string
+  messages: AgentMessage[]
+}
+
+export type StreamingSession =
+  | ConversationAgentSession
+  | FormAgentSession
+  | PublicStreamingSessionProxy

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
@@ -40,7 +40,8 @@ import { AgentMessage } from "../agent-message.entity"
 import { AgentMessageAttachmentDocumentsService } from "../agent-message-attachment-documents.service"
 import { buildConversationAgentPrompt } from "./master-promts/conversation-agent.prompt"
 import { buildFormAgentPrompt } from "./master-promts/form-agent.prompt"
-import { type BuiltTools, buildSubAgentTools, type StreamingSession } from "./sub-agent-tools"
+import type { PublicStreamingSessionProxy, StreamingSession } from "./streaming-session.types"
+import { type BuiltTools, buildSubAgentTools } from "./sub-agent-tools"
 import { fillFormTool } from "./tools/fill-form.tool"
 import { recalculateConversationSessionMetadataTool } from "./tools/recalculate-conversation-session-metadata.tool"
 import { retrieveProjectDocumentChunksTool } from "./tools/retrieve-project-document-chunks.tool"
@@ -234,7 +235,7 @@ export class StreamingService extends ServiceWithLLM {
       order: { createdAt: "ASC" },
     })
 
-    const sessionProxy: StreamingSession = {
+    const sessionProxy: PublicStreamingSessionProxy = {
       id: publicSessionId,
       traceId: publicSessionId,
       organizationId: connectScope.organizationId,

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
@@ -22,6 +22,7 @@ import { ConversationAgentSession } from "@/domains/agents/conversation-agent-se
 import { ConversationAgentSessionsService } from "@/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service"
 import { FormAgentSession } from "@/domains/agents/form-agent-sessions/form-agent-session.entity"
 import { FormAgentSessionsService } from "@/domains/agents/form-agent-sessions/form-agent-sessions.service"
+import { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentChunkRetrievalService } from "@/domains/documents/embeddings/document-chunk-retrieval.service"
 import {
@@ -39,6 +40,7 @@ import { AgentMessage } from "../agent-message.entity"
 import { AgentMessageAttachmentDocumentsService } from "../agent-message-attachment-documents.service"
 import { buildConversationAgentPrompt } from "./master-promts/conversation-agent.prompt"
 import { buildFormAgentPrompt } from "./master-promts/form-agent.prompt"
+import { type BuiltTools, buildSubAgentTools, type StreamingSession } from "./sub-agent-tools"
 import { fillFormTool } from "./tools/fill-form.tool"
 import { recalculateConversationSessionMetadataTool } from "./tools/recalculate-conversation-session-metadata.tool"
 import { retrieveProjectDocumentChunksTool } from "./tools/retrieve-project-document-chunks.tool"
@@ -46,17 +48,6 @@ import { sourcesTool } from "./tools/sources.tool"
 import type { ToolExecutionLog } from "./tools/tool-execution-log"
 
 type NotifyClient = (event: Extract<StreamEvent, { type: "notify_client" }>) => void
-
-/**
- * Minimal session context for public/anonymous sessions that have no
- * corresponding ConversationAgentSession or FormAgentSession row.
- */
-type PublicStreamingSessionProxy = {
-  id: string
-  traceId: string
-  organizationId: string
-  messages: AgentMessage[]
-}
 
 @Injectable()
 export class StreamingService extends ServiceWithLLM {
@@ -76,6 +67,8 @@ export class StreamingService extends ServiceWithLLM {
     private readonly formAgentSessionsService: FormAgentSessionsService,
     @Inject(ConversationAgentSessionsService)
     private readonly conversationAgentSessionsService: ConversationAgentSessionsService,
+    @Inject(AgentSubAgentsService)
+    private readonly agentSubAgentsService: AgentSubAgentsService,
     @Inject(ProjectsService)
     private readonly projectsService: ProjectsService,
 
@@ -241,7 +234,7 @@ export class StreamingService extends ServiceWithLLM {
       order: { createdAt: "ASC" },
     })
 
-    const sessionProxy: PublicStreamingSessionProxy = {
+    const sessionProxy: StreamingSession = {
       id: publicSessionId,
       traceId: publicSessionId,
       organizationId: connectScope.organizationId,
@@ -320,13 +313,14 @@ export class StreamingService extends ServiceWithLLM {
     agent: Agent
     sessionId: string
     notifyClient: NotifyClient
-    session: ConversationAgentSession | FormAgentSession | PublicStreamingSessionProxy
+    session: StreamingSession
     attachmentDocumentId?: string
     connectScope: RequiredConnectScope
   }) {
-    const { tools, mcpClose } = await this.buildTools({
+    const { tools, mcpClose, toolDescriptions } = await this.buildTools({
       agent,
       sessionId,
+      session,
       connectScope,
       onExecute: async (toolExecution) =>
         await this.persistToolExecutionAndNotifyClient({
@@ -338,9 +332,9 @@ export class StreamingService extends ServiceWithLLM {
         }),
     })
 
-    const toolNames = tools ? (Object.keys(tools) as ToolName[]) : []
+    const toolNames = tools ? Object.keys(tools) : []
     const config = this.buildLLMConfig({
-      systemPrompt: this.generateMasterPrompt({ agent, toolNames }),
+      systemPrompt: this.generateMasterPrompt({ agent, toolNames, toolDescriptions }),
       model: agent.model,
       temperature: agent.temperature,
       tools,
@@ -473,7 +467,11 @@ export class StreamingService extends ServiceWithLLM {
     return llmMessages
   }
 
-  private generateMasterPrompt(params: { agent: Agent; toolNames: ToolName[] }): string {
+  private generateMasterPrompt(params: {
+    agent: Agent
+    toolDescriptions?: Record<string, string>
+    toolNames: string[]
+  }): string {
     const agentType = params.agent.type
     switch (agentType) {
       case "form":
@@ -704,20 +702,38 @@ export class StreamingService extends ServiceWithLLM {
     connectScope,
     currentCategoryNames,
     hasSourcesTool,
+    includeSessionMetadataTools,
     mcpTools,
     onExecute,
+    subAgentTools,
   }: {
     agent: Agent
     sessionId: string
     connectScope: RequiredConnectScope
     currentCategoryNames: string[]
     hasSourcesTool: boolean
+    includeSessionMetadataTools: boolean
     mcpTools: ToolSet
     onExecute: (toolExecution: ToolExecutionLog) => void
+    subAgentTools: ToolSet
   }): ToolSet {
-    const hasRecalculateConversationSessionMetadataTool = (agent.categories?.length ?? 0) > 0
+    const hasRecalculateConversationSessionMetadataTool =
+      includeSessionMetadataTools && (agent.categories?.length ?? 0) > 0
 
     const tools: ToolSet = {
+      ...(agent.documentsRagMode === DocumentsRagMode.None
+        ? {}
+        : {
+            [ToolName.RetrieveProjectDocumentChunks]: retrieveProjectDocumentChunksTool({
+              connectScope,
+              documentTagIds:
+                agent.documentsRagMode === DocumentsRagMode.Tags
+                  ? (agent.documentTags?.map((documentTag) => documentTag.id) ?? [])
+                  : [],
+              retrievalService: this.documentChunkRetrievalService,
+              onExecute,
+            }),
+          }),
       ...(hasSourcesTool ? { [ToolName.Sources]: sourcesTool({ onExecute }) } : {}),
       ...(hasRecalculateConversationSessionMetadataTool
         ? {
@@ -736,44 +752,41 @@ export class StreamingService extends ServiceWithLLM {
               }),
           }
         : {}),
-      ...mcpTools,
     }
 
-    if (agent.documentsRagMode === DocumentsRagMode.None) {
-      return tools
-    }
-
-    return {
-      [ToolName.RetrieveProjectDocumentChunks]: retrieveProjectDocumentChunksTool({
-        connectScope,
-        documentTagIds:
-          agent.documentsRagMode === DocumentsRagMode.Tags
-            ? (agent.documentTags?.map((documentTag) => documentTag.id) ?? [])
-            : [],
-        retrievalService: this.documentChunkRetrievalService,
-        onExecute,
-      }),
-      ...tools,
-    }
+    this.addToolsWithoutCollisions({ target: tools, source: mcpTools, sourceLabel: "MCP" })
+    this.addToolsWithoutCollisions({
+      target: tools,
+      source: subAgentTools,
+      sourceLabel: "sub-agent",
+    })
+    return tools
   }
 
   private async buildTools({
     agent,
     sessionId,
+    session,
     connectScope,
+    includeSessionMetadataTools = true,
+    includeSubAgentTools = true,
     onExecute,
   }: {
     agent: Agent
     sessionId: string
+    session?: StreamingSession
     connectScope: RequiredConnectScope
+    includeSessionMetadataTools?: boolean
+    includeSubAgentTools?: boolean
     onExecute: (toolExecution: ToolExecutionLog) => void
-  }): Promise<{ tools: ToolSet | undefined; mcpClose?: () => Promise<void> }> {
+  }): Promise<BuiltTools> {
     const hasSourcesTool = await this.projectsService.hasFeature({
       connectScope,
       feature: "sources-tool",
     })
     const mcpCloseFns: (() => Promise<void>)[] = []
     const mcpTools: ToolSet = {}
+    const mcpToolDescriptions: Record<string, string> = {}
 
     const serverConfigs = await this.mcpServersService.getEnabledServersForAgent(agent.id)
     for (const serverConfig of serverConfigs) {
@@ -782,6 +795,8 @@ export class StreamingService extends ServiceWithLLM {
       for (const [toolName, toolDef] of Object.entries(mcpSession.tools)) {
         const originalExecute = toolDef.execute
         if (!originalExecute) continue
+        const description = this.getToolDescription(toolDef)
+        if (description) mcpToolDescriptions[toolName] = description
         mcpTools[toolName] = {
           ...toolDef,
           execute: (async (...executeArgs: Parameters<typeof originalExecute>) => {
@@ -789,7 +804,7 @@ export class StreamingService extends ServiceWithLLM {
               `[MCP] Calling tool "${toolName}" with args: ${JSON.stringify(executeArgs[0])}`,
             )
             onExecute({
-              toolName: toolName as ToolName,
+              toolName,
               arguments: (executeArgs[0] ?? {}) as Record<string, unknown>,
             })
             try {
@@ -815,23 +830,46 @@ export class StreamingService extends ServiceWithLLM {
     switch (agent.type) {
       case "conversation": {
         const currentCategoryNames =
-          (agent.categories?.length ?? 0) > 0
+          includeSessionMetadataTools && (agent.categories?.length ?? 0) > 0
             ? await this.conversationAgentSessionsService.getCurrentCategoryNamesForSession({
                 connectScope,
                 sessionId,
               })
             : []
+        const { tools: subAgentTools, toolDescriptions: subAgentToolDescriptions } =
+          includeSubAgentTools
+            ? await buildSubAgentTools({
+                agent,
+                agentSubAgentsService: this.agentSubAgentsService,
+                buildLLMConfig: (params) => this.buildLLMConfig(params),
+                buildTools: (params) => this.buildTools(params),
+                connectScope,
+                generateMasterPrompt: (params) => this.generateMasterPrompt(params),
+                getProviderForModel: (model) => this.getProviderForModel(model),
+                onExecute,
+                projectsService: this.projectsService,
+                session,
+                sessionId,
+              })
+            : { tools: {}, toolDescriptions: {} }
+        const tools = this.buildConversationTools({
+          agent,
+          sessionId,
+          connectScope,
+          currentCategoryNames,
+          hasSourcesTool,
+          includeSessionMetadataTools,
+          mcpTools,
+          onExecute,
+          subAgentTools,
+        })
 
         return {
           mcpClose,
-          tools: this.buildConversationTools({
-            agent,
-            sessionId,
-            connectScope,
-            currentCategoryNames,
-            hasSourcesTool,
-            mcpTools,
-            onExecute,
+          tools,
+          toolDescriptions: this.filterToolDescriptions({
+            descriptions: { ...mcpToolDescriptions, ...subAgentToolDescriptions },
+            tools,
           }),
         }
       }
@@ -839,6 +877,7 @@ export class StreamingService extends ServiceWithLLM {
       case "form":
         return {
           mcpClose,
+          toolDescriptions: {},
           tools: {
             [ToolName.FillForm]: fillFormTool({
               connectScope,
@@ -851,8 +890,55 @@ export class StreamingService extends ServiceWithLLM {
         }
 
       default:
-        return { mcpClose, tools: undefined }
+        return { mcpClose, toolDescriptions: {}, tools: undefined }
     }
+  }
+
+  private addToolsWithoutCollisions({
+    source,
+    sourceLabel,
+    target,
+  }: {
+    source: ToolSet
+    sourceLabel: string
+    target: ToolSet
+  }) {
+    for (const [toolName, toolDef] of Object.entries(source)) {
+      if (target[toolName]) {
+        this.logger.warn(
+          `Skipping ${sourceLabel} tool "${toolName}" because another tool with the same name is already registered.`,
+        )
+        continue
+      }
+      target[toolName] = toolDef
+    }
+  }
+
+  private filterToolDescriptions({
+    descriptions,
+    tools,
+  }: {
+    descriptions: Record<string, string>
+    tools: ToolSet | undefined
+  }): Record<string, string> {
+    if (!tools) return {}
+
+    return Object.fromEntries(
+      Object.keys(tools)
+        .map((toolName) => [toolName, descriptions[toolName]] as const)
+        .filter((entry): entry is readonly [string, string] => entry[1] !== undefined),
+    )
+  }
+
+  private getToolDescription(toolDef: unknown): string | undefined {
+    if (!toolDef || typeof toolDef !== "object" || !("description" in toolDef)) {
+      return undefined
+    }
+
+    const description = (toolDef as { description?: unknown }).description
+    return typeof description === "string" && description.trim().length > 0
+      ? description
+      : undefined
   }
 
   private async persistToolExecutionAndNotifyClient({

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
@@ -6,30 +6,12 @@ import type {
   LLMProvider,
 } from "@/common/interfaces/llm-provider.interface"
 import type { Agent } from "@/domains/agents/agent.entity"
-import type { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
-import type { FormAgentSession } from "@/domains/agents/form-agent-sessions/form-agent-session.entity"
 import type { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
 import type { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
 import type { ProjectsService } from "@/domains/projects/projects.service"
-import type { AgentMessage } from "../agent-message.entity"
+import type { StreamingSession } from "./streaming-session.types"
 import { type SubAgentToolInput, subAgentTool } from "./tools/sub-agent.tool"
 import type { ToolExecutionLog } from "./tools/tool-execution-log"
-
-/**
- * Minimal session context for public/anonymous sessions that have no
- * corresponding ConversationAgentSession or FormAgentSession row.
- */
-type PublicStreamingSessionProxy = {
-  id: string
-  traceId: string
-  organizationId: string
-  messages: AgentMessage[]
-}
-
-export type StreamingSession =
-  | ConversationAgentSession
-  | FormAgentSession
-  | PublicStreamingSessionProxy
 
 export type BuiltTools = {
   tools: ToolSet | undefined

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
@@ -1,0 +1,242 @@
+import type { ToolSet } from "ai"
+import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
+import type {
+  LLMConfig,
+  LLMMetadata,
+  LLMProvider,
+} from "@/common/interfaces/llm-provider.interface"
+import type { Agent } from "@/domains/agents/agent.entity"
+import type { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
+import type { FormAgentSession } from "@/domains/agents/form-agent-sessions/form-agent-session.entity"
+import type { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
+import type { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
+import type { ProjectsService } from "@/domains/projects/projects.service"
+import type { AgentMessage } from "../agent-message.entity"
+import { type SubAgentToolInput, subAgentTool } from "./tools/sub-agent.tool"
+import type { ToolExecutionLog } from "./tools/tool-execution-log"
+
+/**
+ * Minimal session context for public/anonymous sessions that have no
+ * corresponding ConversationAgentSession or FormAgentSession row.
+ */
+type PublicStreamingSessionProxy = {
+  id: string
+  traceId: string
+  organizationId: string
+  messages: AgentMessage[]
+}
+
+export type StreamingSession =
+  | ConversationAgentSession
+  | FormAgentSession
+  | PublicStreamingSessionProxy
+
+export type BuiltTools = {
+  tools: ToolSet | undefined
+  mcpClose?: () => Promise<void>
+  toolDescriptions: Record<string, string>
+}
+
+type BuildLLMConfig = (params: {
+  model: Agent["model"]
+  systemPrompt: string
+  temperature: Agent["temperature"]
+  tools?: ToolSet
+}) => LLMConfig
+
+type GenerateMasterPrompt = (params: {
+  agent: Agent
+  toolDescriptions?: Record<string, string>
+  toolNames: string[]
+}) => string
+
+type BuildTools = (params: {
+  agent: Agent
+  connectScope: RequiredConnectScope
+  includeSessionMetadataTools?: boolean
+  includeSubAgentTools?: boolean
+  onExecute: (toolExecution: ToolExecutionLog) => void
+  session?: StreamingSession
+  sessionId: string
+}) => Promise<BuiltTools>
+
+export async function buildSubAgentTools({
+  agent,
+  agentSubAgentsService,
+  buildLLMConfig,
+  buildTools,
+  connectScope,
+  generateMasterPrompt,
+  getProviderForModel,
+  onExecute,
+  projectsService,
+  session,
+  sessionId,
+}: {
+  agent: Agent
+  agentSubAgentsService: AgentSubAgentsService
+  buildLLMConfig: BuildLLMConfig
+  buildTools: BuildTools
+  connectScope: RequiredConnectScope
+  generateMasterPrompt: GenerateMasterPrompt
+  getProviderForModel: (model: string) => LLMProvider
+  onExecute: (toolExecution: ToolExecutionLog) => void
+  projectsService: ProjectsService
+  session?: StreamingSession
+  sessionId: string
+}): Promise<{ tools: ToolSet; toolDescriptions: Record<string, string> }> {
+  const hasAgentOrchestration = await projectsService.hasFeature({
+    connectScope,
+    feature: "agent-orchestration",
+  })
+  if (!hasAgentOrchestration) {
+    return { tools: {}, toolDescriptions: {} }
+  }
+
+  const subAgents = await agentSubAgentsService.listSubAgents({
+    connectScope,
+    parentAgent: agent,
+  })
+  const tools: ToolSet = {}
+  const toolDescriptions: Record<string, string> = {}
+
+  for (const subAgent of subAgents) {
+    if (!subAgent.enabled) continue
+
+    const description = buildSubAgentToolDescription(subAgent)
+    tools[subAgent.toolName] = subAgentTool({
+      description,
+      toolName: subAgent.toolName,
+      onExecute,
+      execute: (input) =>
+        runSubAgentTool({
+          buildLLMConfig,
+          buildTools,
+          connectScope,
+          generateMasterPrompt,
+          getProviderForModel,
+          input,
+          onExecute,
+          parentAgent: agent,
+          session,
+          sessionId,
+          subAgent,
+        }),
+    })
+    toolDescriptions[subAgent.toolName] = description
+  }
+
+  return { tools, toolDescriptions }
+}
+
+async function runSubAgentTool({
+  buildLLMConfig,
+  buildTools,
+  connectScope,
+  generateMasterPrompt,
+  getProviderForModel,
+  input,
+  onExecute,
+  parentAgent,
+  session,
+  sessionId,
+  subAgent,
+}: {
+  buildLLMConfig: BuildLLMConfig
+  buildTools: BuildTools
+  connectScope: RequiredConnectScope
+  generateMasterPrompt: GenerateMasterPrompt
+  getProviderForModel: (model: string) => LLMProvider
+  input: SubAgentToolInput
+  onExecute: (toolExecution: ToolExecutionLog) => void
+  parentAgent: Agent
+  session?: StreamingSession
+  sessionId: string
+  subAgent: AgentSubAgent
+}): Promise<string> {
+  const childAgent = subAgent.childAgent
+  const { tools, mcpClose, toolDescriptions } = await buildTools({
+    agent: childAgent,
+    sessionId,
+    session,
+    connectScope,
+    includeSessionMetadataTools: false,
+    includeSubAgentTools: false,
+    onExecute,
+  })
+
+  try {
+    const toolNames = tools ? Object.keys(tools) : []
+    const config = buildLLMConfig({
+      systemPrompt: generateMasterPrompt({
+        agent: childAgent,
+        toolNames,
+        toolDescriptions,
+      }),
+      model: childAgent.model,
+      temperature: childAgent.temperature,
+      tools,
+    })
+    const metadata = buildSubAgentMetadata({
+      childAgent,
+      connectScope,
+      parentAgent,
+      session,
+      sessionId,
+    })
+    const chunks = getProviderForModel(config.model).streamChatResponse({
+      messages: [{ role: "user", content: buildSubAgentPrompt(input) }],
+      config,
+      metadata,
+    })
+
+    let answer = ""
+    for await (const chunk of chunks) answer += chunk
+    return answer
+  } finally {
+    await mcpClose?.()
+  }
+}
+
+function buildSubAgentPrompt(input: SubAgentToolInput): string {
+  const context = input.context.trim()
+  return [
+    "You are being invoked as a sub-agent by another assistant.",
+    context ? `Conversation context:\n${context}` : undefined,
+    `Delegated task:\n${input.task}`,
+    "Return a direct answer that the parent assistant can use for the user.",
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join("\n\n")
+}
+
+function buildSubAgentMetadata({
+  childAgent,
+  connectScope,
+  parentAgent,
+  session,
+  sessionId,
+}: {
+  childAgent: Agent
+  connectScope: RequiredConnectScope
+  parentAgent: Agent
+  session?: StreamingSession
+  sessionId: string
+}): LLMMetadata {
+  return {
+    traceId: session?.traceId ?? sessionId,
+    agentSessionId: session?.id ?? sessionId,
+    agentId: childAgent.id,
+    projectId: childAgent.projectId,
+    organizationId: session?.organizationId ?? connectScope.organizationId,
+    currentTurn: session?.messages.filter((message) => message.role === "user").length ?? 0,
+    tags: [parentAgent.name, childAgent.name, "sub-agent"],
+  }
+}
+
+function buildSubAgentToolDescription(subAgent: AgentSubAgent): string {
+  const configuredDescription = subAgent.description.trim()
+  if (configuredDescription.length > 0) return configuredDescription
+
+  return `Delegate to ${subAgent.childAgent.name}, a conversation agent, when that agent is better suited to the user's request.`
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/sub-agent.tool.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/sub-agent.tool.ts
@@ -1,0 +1,38 @@
+import { tool } from "ai"
+import { z } from "zod"
+import type { ToolExecutionLog } from "./tool-execution-log"
+
+const subAgentInputSchema = z.object({
+  task: z.string().min(1).describe("The precise task or question to delegate to the sub-agent."),
+  context: z
+    .string()
+    .default("")
+    .describe("Relevant conversation context the sub-agent needs to answer accurately."),
+})
+
+export type SubAgentToolInput = z.infer<typeof subAgentInputSchema>
+
+export function subAgentTool({
+  description,
+  execute,
+  onExecute,
+  toolName,
+}: {
+  description: string
+  execute: (input: SubAgentToolInput) => Promise<string>
+  onExecute: (toolExecution: ToolExecutionLog) => void
+  toolName: string
+}) {
+  return tool({
+    description,
+    inputSchema: subAgentInputSchema,
+    outputSchema: z.object({
+      answer: z.string().describe("The sub-agent response."),
+    }),
+    execute: async (input) => {
+      onExecute({ toolName, arguments: input })
+      const answer = await execute(input)
+      return { answer }
+    },
+  })
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/tool-execution-log.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/tool-execution-log.ts
@@ -1,6 +1,4 @@
-import type { ToolName } from "@caseai-connect/api-contracts"
-
 export type ToolExecutionLog = {
-  toolName: ToolName
+  toolName: string
   arguments: Record<string, unknown>
 }

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agent.entity.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agent.entity.ts
@@ -1,0 +1,39 @@
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from "typeorm"
+import { Base4AllEntity } from "@/common/entities/base4all.entity"
+import { Agent } from "../agent.entity"
+
+@Entity("agent_sub_agent")
+@Unique(["parentAgentId", "childAgentId"])
+@Unique(["parentAgentId", "toolName"])
+export class AgentSubAgent extends Base4AllEntity {
+  @Column({ type: "uuid", name: "parent_agent_id" })
+  parentAgentId!: string
+
+  @Column({ type: "uuid", name: "child_agent_id" })
+  childAgentId!: string
+
+  @Column({ type: "varchar", name: "tool_name", length: 64 })
+  toolName!: string
+
+  @Column({ type: "text", default: "" })
+  description!: string
+
+  @Column({ type: "boolean", default: true })
+  enabled!: boolean
+
+  @ManyToOne(
+    () => Agent,
+    (agent) => agent.childSubAgents,
+    { onDelete: "CASCADE" },
+  )
+  @JoinColumn({ name: "parent_agent_id" })
+  parentAgent!: Agent
+
+  @ManyToOne(
+    () => Agent,
+    (agent) => agent.parentSubAgents,
+    { onDelete: "CASCADE" },
+  )
+  @JoinColumn({ name: "child_agent_id" })
+  childAgent!: Agent
+}

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
@@ -1,0 +1,260 @@
+import { afterAll } from "@jest/globals"
+import { UnprocessableEntityException } from "@nestjs/common"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { projectFactory } from "@/domains/projects/project.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { AgentsModule } from "../agents.module"
+import { AgentSubAgentsService } from "./agent-sub-agents.service"
+
+describe("AgentSubAgentsService", () => {
+  let service: AgentSubAgentsService
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [AgentsModule],
+    })
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await sdk.shutdown()
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    service = setup.module.get<AgentSubAgentsService>(AgentSubAgentsService)
+    repositories = setup.getAllRepositories()
+  })
+
+  it("replaces and lists sub-agents for a conversation agent", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+    const childAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        name: "Resource Lookup",
+        type: "conversation",
+      }),
+    )
+
+    const result = await service.replaceSubAgents({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      parentAgent: agent,
+      subAgents: [
+        {
+          childAgentId: childAgent.id,
+          toolName: "ask_resources",
+          description: "Use for resource questions.",
+          enabled: true,
+        },
+      ],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      parentAgentId: agent.id,
+      childAgentId: childAgent.id,
+      toolName: "ask_resources",
+      description: "Use for resource questions.",
+      enabled: true,
+    })
+    expect(result[0]?.childAgent.name).toBe("Resource Lookup")
+
+    const listed = await service.listSubAgents({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      parentAgent: agent,
+    })
+    expect(listed.map((row) => row.childAgentId)).toEqual([childAgent.id])
+  })
+
+  it("removes rows missing from the replacement set", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+    const firstChild = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({ name: "First Child" }),
+    )
+    const secondChild = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({ name: "Second Child" }),
+    )
+
+    const connectScope = { organizationId: organization.id, projectId: project.id }
+    await service.replaceSubAgents({
+      connectScope,
+      parentAgent: agent,
+      subAgents: [
+        {
+          childAgentId: firstChild.id,
+          toolName: "ask_first",
+          description: "",
+          enabled: true,
+        },
+      ],
+    })
+    await service.replaceSubAgents({
+      connectScope,
+      parentAgent: agent,
+      subAgents: [
+        {
+          childAgentId: secondChild.id,
+          toolName: "ask_second",
+          description: "",
+          enabled: false,
+        },
+      ],
+    })
+
+    const rows = await repositories.agentSubAgentRepository.find({
+      where: { parentAgentId: agent.id },
+    })
+    expect(rows.map((row) => row.childAgentId)).toEqual([secondChild.id])
+    expect(rows[0]?.enabled).toBe(false)
+  })
+
+  it("rejects self-reference, duplicate child agents, and duplicate tool names", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+    const childAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build(),
+    )
+    const connectScope = { organizationId: organization.id, projectId: project.id }
+
+    await expect(
+      service.replaceSubAgents({
+        connectScope,
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: agent.id,
+            toolName: "ask_self",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow(UnprocessableEntityException)
+
+    await expect(
+      service.replaceSubAgents({
+        connectScope,
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_child",
+            description: "",
+            enabled: true,
+          },
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_child_again",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Duplicate sub-agents are not allowed")
+
+    const otherChildAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build(),
+    )
+    await expect(
+      service.replaceSubAgents({
+        connectScope,
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_duplicate",
+            description: "",
+            enabled: true,
+          },
+          {
+            childAgentId: otherChildAgent.id,
+            toolName: "ask_duplicate",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Duplicate sub-agent tool names are not allowed")
+  })
+
+  it("rejects sub-agents outside the project or with a non-conversation type", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+    const otherProject = await repositories.projectRepository.save(
+      projectFactory.transient({ organization }).build(),
+    )
+    const otherProjectAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project: otherProject }).build(),
+    )
+    const extractionAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        type: "extraction",
+        outputJsonSchema: { type: "object", properties: {} },
+      }),
+    )
+    const connectScope = { organizationId: organization.id, projectId: project.id }
+
+    await expect(
+      service.replaceSubAgents({
+        connectScope,
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: otherProjectAgent.id,
+            toolName: "ask_other_project",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow("One or more sub-agents do not exist in this project")
+
+    await expect(
+      service.replaceSubAgents({
+        connectScope,
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: extractionAgent.id,
+            toolName: "ask_extraction",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Sub-agents must be conversation agents")
+  })
+
+  it("rejects non-conversation parent agents", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories, {
+      agent: {
+        type: "form",
+        outputJsonSchema: { type: "object", properties: {} },
+      },
+    })
+    const childAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({ type: "conversation" }),
+    )
+
+    await expect(
+      service.replaceSubAgents({
+        connectScope: { organizationId: organization.id, projectId: project.id },
+        parentAgent: agent,
+        subAgents: [
+          {
+            childAgentId: childAgent.id,
+            toolName: "ask_child",
+            description: "",
+            enabled: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Only conversation agents can have sub-agents")
+  })
+})

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
@@ -28,7 +28,12 @@ export class AgentSubAgentsService {
 
     return this.agentSubAgentRepository.find({
       where: { parentAgentId: parentAgent.id },
-      relations: { childAgent: true },
+      relations: {
+        childAgent: {
+          categories: true,
+          documentTags: true,
+        },
+      },
       order: { createdAt: "ASC" },
     })
   }

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
@@ -1,0 +1,151 @@
+import type { ReplaceAgentSubAgentDto } from "@caseai-connect/api-contracts"
+import { Injectable, UnprocessableEntityException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+// biome-ignore lint/style/useImportType: DataSource required at runtime for NestJS DI
+import { DataSource, In, type Repository } from "typeorm"
+import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
+import { Agent } from "../agent.entity"
+import { AgentSubAgent } from "./agent-sub-agent.entity"
+
+@Injectable()
+export class AgentSubAgentsService {
+  constructor(
+    @InjectRepository(AgentSubAgent)
+    private readonly agentSubAgentRepository: Repository<AgentSubAgent>,
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async listSubAgents({
+    connectScope,
+    parentAgent,
+  }: {
+    connectScope: RequiredConnectScope
+    parentAgent: Agent
+  }): Promise<AgentSubAgent[]> {
+    this.validateParentAgent({ connectScope, parentAgent })
+
+    return this.agentSubAgentRepository.find({
+      where: { parentAgentId: parentAgent.id },
+      relations: { childAgent: true },
+      order: { createdAt: "ASC" },
+    })
+  }
+
+  async replaceSubAgents({
+    connectScope,
+    parentAgent,
+    subAgents,
+  }: {
+    connectScope: RequiredConnectScope
+    parentAgent: Agent
+    subAgents: ReplaceAgentSubAgentDto[]
+  }): Promise<AgentSubAgent[]> {
+    this.validateParentAgent({ connectScope, parentAgent })
+    this.validateReplacementInput({ parentAgent, subAgents })
+
+    const childAgents = await this.resolveChildAgents({
+      connectScope,
+      childAgentIds: subAgents.map((subAgent) => subAgent.childAgentId),
+    })
+    const childAgentById = new Map(childAgents.map((agent) => [agent.id, agent]))
+
+    await this.dataSource.transaction(async (entityManager) => {
+      await entityManager.delete(AgentSubAgent, { parentAgentId: parentAgent.id })
+
+      if (subAgents.length === 0) {
+        return
+      }
+
+      const rows = subAgents.map((subAgent) =>
+        entityManager.create(AgentSubAgent, {
+          parentAgentId: parentAgent.id,
+          childAgentId: subAgent.childAgentId,
+          toolName: subAgent.toolName,
+          description: subAgent.description,
+          enabled: subAgent.enabled,
+        }),
+      )
+      await entityManager.save(AgentSubAgent, rows)
+    })
+
+    const savedRows = await this.listSubAgents({ connectScope, parentAgent })
+    for (const row of savedRows) {
+      row.childAgent = childAgentById.get(row.childAgentId) ?? row.childAgent
+    }
+    return savedRows
+  }
+
+  private validateParentAgent({
+    connectScope,
+    parentAgent,
+  }: {
+    connectScope: RequiredConnectScope
+    parentAgent: Agent
+  }) {
+    if (
+      parentAgent.organizationId !== connectScope.organizationId ||
+      parentAgent.projectId !== connectScope.projectId
+    ) {
+      throw new UnprocessableEntityException("Parent agent must belong to the current project")
+    }
+
+    if (parentAgent.type !== "conversation") {
+      throw new UnprocessableEntityException("Only conversation agents can have sub-agents")
+    }
+  }
+
+  private validateReplacementInput({
+    parentAgent,
+    subAgents,
+  }: {
+    parentAgent: Agent
+    subAgents: ReplaceAgentSubAgentDto[]
+  }) {
+    const childAgentIds = subAgents.map((subAgent) => subAgent.childAgentId)
+    if (childAgentIds.includes(parentAgent.id)) {
+      throw new UnprocessableEntityException("An agent cannot be its own sub-agent")
+    }
+
+    if (new Set(childAgentIds).size !== childAgentIds.length) {
+      throw new UnprocessableEntityException("Duplicate sub-agents are not allowed")
+    }
+
+    const toolNames = subAgents.map((subAgent) => subAgent.toolName)
+    if (new Set(toolNames).size !== toolNames.length) {
+      throw new UnprocessableEntityException("Duplicate sub-agent tool names are not allowed")
+    }
+  }
+
+  private async resolveChildAgents({
+    connectScope,
+    childAgentIds,
+  }: {
+    connectScope: RequiredConnectScope
+    childAgentIds: string[]
+  }): Promise<Agent[]> {
+    if (childAgentIds.length === 0) {
+      return []
+    }
+
+    const childAgents = await this.agentRepository.find({
+      where: {
+        id: In(childAgentIds),
+        organizationId: connectScope.organizationId,
+        projectId: connectScope.projectId,
+      },
+    })
+
+    if (childAgents.length !== childAgentIds.length) {
+      throw new UnprocessableEntityException("One or more sub-agents do not exist in this project")
+    }
+
+    const invalidChildAgent = childAgents.find((agent) => agent.type !== "conversation")
+    if (invalidChildAgent) {
+      throw new UnprocessableEntityException("Sub-agents must be conversation agents")
+    }
+
+    return childAgents
+  }
+}

--- a/apps/api/src/migrations/1779909374924-create-agent-sub-agent.ts
+++ b/apps/api/src/migrations/1779909374924-create-agent-sub-agent.ts
@@ -1,0 +1,27 @@
+import type { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateAgentSubAgent1779909374924 implements MigrationInterface {
+  name = "CreateAgentSubAgent1779909374924"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "agent_sub_agent" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "parent_agent_id" uuid NOT NULL, "child_agent_id" uuid NOT NULL, "tool_name" character varying(64) NOT NULL, "description" text NOT NULL DEFAULT '', "enabled" boolean NOT NULL DEFAULT true, CONSTRAINT "UQ_72d4978eb9b4341402f39e9c8c5" UNIQUE ("parent_agent_id", "tool_name"), CONSTRAINT "UQ_e1361459627fc9fc9e0fa41d9e3" UNIQUE ("parent_agent_id", "child_agent_id"), CONSTRAINT "PK_9dae75f33df4e5db0096fbd2802" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "agent_sub_agent" ADD CONSTRAINT "FK_0700deff477b3214a1b184589cf" FOREIGN KEY ("parent_agent_id") REFERENCES "agent"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "agent_sub_agent" ADD CONSTRAINT "FK_8faefc512553078c6ea68965cd2" FOREIGN KEY ("child_agent_id") REFERENCES "agent"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_sub_agent" DROP CONSTRAINT "FK_8faefc512553078c6ea68965cd2"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "agent_sub_agent" DROP CONSTRAINT "FK_0700deff477b3214a1b184589cf"`,
+    )
+    await queryRunner.query(`DROP TABLE "agent_sub_agent"`)
+  }
+}

--- a/apps/api/src/scripts/manage-invitations.ts
+++ b/apps/api/src/scripts/manage-invitations.ts
@@ -5,6 +5,7 @@ import { DataSource } from "typeorm"
 import { AppModule } from "@/app.module"
 import type { InvitationSender } from "@/domains/auth/invitation-sender.interface"
 import { INVITATION_SENDER } from "@/domains/auth/invitation-sender.interface"
+import { Invitation, type InvitationTargetType } from "@/domains/invitations/invitation.entity"
 import { ask, confirmDatabaseTarget } from "@/scripts/script-bootstrap"
 
 const PLACEHOLDER_AUTH0_ID_PREFIX = "00000000-0000-0000-0000-"
@@ -14,57 +15,92 @@ const logger = new Logger("ManageInvitations")
 type PendingInvitation = {
   index: number
   invitationId: string
-  membershipId: string
   email: string
   userName: string | null
-  auth0Id: string
+  auth0Id: string | null
   hasAccount: boolean
+  targetType: InvitationTargetType
+  targetName: string
   projectName: string
   organizationName: string
   role: string
   sentAt: Date
 }
 
+function resolveTargetName(row: Record<string, unknown>): string {
+  const targetType = row.targetType as InvitationTargetType
+  if (targetType === "project") return (row.projectName as string | null) ?? ""
+  if (targetType === "agent") return (row.agentName as string | null) ?? ""
+  if (targetType === "review_campaign") return (row.reviewCampaignName as string | null) ?? ""
+  return ""
+}
+
 async function listPendingInvitations(dataSource: DataSource): Promise<PendingInvitation[]> {
   const rows = await dataSource
     .createQueryBuilder()
     .select("inv.id", "invitationId")
-    .addSelect("pm.id", "membershipId")
-    .addSelect("u.email", "email")
+    .addSelect("COALESCE(inv.invited_email, u.email)", "email")
     .addSelect("u.name", "userName")
     .addSelect("u.auth0_id", "auth0Id")
+    .addSelect("inv.target_type", "targetType")
     .addSelect("p.name", "projectName")
     .addSelect("o.name", "organizationName")
+    .addSelect("a.name", "agentName")
+    .addSelect("rc.name", "reviewCampaignName")
     .addSelect("inv.role", "role")
     .addSelect("inv.invited_at", "sentAt")
     .from("invitation", "inv")
-    .innerJoin("user", "u", "inv.user_id = u.id")
-    .innerJoin("project", "p", "inv.target_id = p.id AND inv.target_type = 'project'")
-    .innerJoin("organization", "o", "p.organization_id = o.id")
-    .innerJoin(
+    .leftJoin("user", "u", "inv.user_id = u.id")
+    .innerJoin("project", "p", "inv.project_id = p.id")
+    .innerJoin("organization", "o", "inv.organization_id = o.id")
+    .leftJoin("agent", "a", "inv.target_type = 'agent' AND inv.target_id = a.id")
+    .leftJoin(
+      "review_campaign",
+      "rc",
+      "inv.target_type = 'review_campaign' AND inv.target_id = rc.id",
+    )
+    .leftJoin(
       "project_membership",
       "pm",
-      "pm.project_id = inv.target_id AND pm.user_id = inv.user_id",
+      "inv.target_type = 'project' AND pm.project_id = inv.target_id AND pm.user_id = inv.user_id",
+    )
+    .leftJoin(
+      "agent_membership",
+      "am",
+      "inv.target_type = 'agent' AND am.agent_id = inv.target_id AND am.user_id = inv.user_id",
+    )
+    .leftJoin(
+      "review_campaign_membership",
+      "rcm",
+      "inv.target_type = 'review_campaign' AND rcm.campaign_id = inv.target_id AND rcm.user_id = inv.user_id AND rcm.role = inv.role",
     )
     .where("inv.status = :status", { status: "pending" })
+    .andWhere("inv.deleted_at IS NULL")
+    .andWhere("inv.accepted_at IS NULL")
+    .andWhere("(inv.target_type <> 'project' OR pm.id IS NULL)")
+    .andWhere("(inv.target_type <> 'agent' OR am.id IS NULL)")
+    .andWhere("(inv.target_type <> 'review_campaign' OR rcm.id IS NULL)")
     .orderBy("o.name", "ASC")
+    .addOrderBy("p.name", "ASC")
+    .addOrderBy("inv.target_type", "ASC")
     .addOrderBy("inv.invited_at", "ASC")
     .getRawMany()
 
   return rows.map((row: Record<string, unknown>, index: number) => {
-    const auth0Id = row.auth0Id as string
+    const auth0Id = row.auth0Id as string | null
     return {
       index: index + 1,
       invitationId: row.invitationId as string,
-      membershipId: row.membershipId as string,
-      email: row.email,
-      userName: row.userName,
+      email: row.email as string,
+      userName: row.userName as string | null,
       auth0Id,
-      hasAccount: !auth0Id.startsWith(PLACEHOLDER_AUTH0_ID_PREFIX),
-      projectName: row.projectName,
-      organizationName: row.organizationName,
-      role: row.role,
-      sentAt: row.sentAt,
+      hasAccount: !!auth0Id && !auth0Id.startsWith(PLACEHOLDER_AUTH0_ID_PREFIX),
+      targetType: row.targetType as InvitationTargetType,
+      targetName: resolveTargetName(row),
+      projectName: row.projectName as string,
+      organizationName: row.organizationName as string,
+      role: row.role as string,
+      sentAt: row.sentAt as Date,
     } as PendingInvitation
   })
 }
@@ -79,8 +115,12 @@ function printInvitations(invitations: PendingInvitation[]): void {
   logger.log("")
   for (const invitation of invitations) {
     const accountStatus = invitation.hasAccount ? "has account" : "no account"
+    const targetLabel =
+      invitation.targetType === "project"
+        ? invitation.projectName
+        : `${invitation.projectName} / ${invitation.targetType}: ${invitation.targetName}`
     logger.log(
-      `  [${invitation.index}] ${invitation.email} — ${invitation.organizationName} / ${invitation.projectName} (${invitation.role}) — ${accountStatus} — sent ${invitation.sentAt.toISOString()}`,
+      `  [${invitation.index}] ${invitation.email} — ${invitation.organizationName} / ${targetLabel} (${invitation.role}) — ${accountStatus} — sent ${invitation.sentAt.toISOString()}`,
     )
   }
   logger.log("")
@@ -99,14 +139,7 @@ async function resendInvitation(
 
   await dataSource
     .createQueryBuilder()
-    .update("project_membership")
-    .set({ invitationToken: ticketId })
-    .where("id = :id", { id: invitation.membershipId })
-    .execute()
-
-  await dataSource
-    .createQueryBuilder()
-    .update("invitation")
+    .update(Invitation)
     .set({ invitationToken: ticketId })
     .where("id = :id", { id: invitation.invitationId })
     .execute()
@@ -142,13 +175,16 @@ async function bootstrapCli(): Promise<void> {
     }
 
     if (selection.toLowerCase() === "export") {
-      const header = "email,userName,organizationName,projectName,role,hasAccount,sentAt"
+      const header =
+        "email,userName,organizationName,projectName,targetType,targetName,role,hasAccount,sentAt"
       const rows = invitations.map((invitation) =>
         [
           invitation.email,
           invitation.userName ?? "",
           invitation.organizationName,
           invitation.projectName,
+          invitation.targetType,
+          invitation.targetName,
           invitation.role,
           invitation.hasAccount ? "yes" : "no",
           invitation.sentAt.toISOString(),

--- a/apps/web/src/common/features/agents/locales/agent.en.json
+++ b/apps/web/src/common/features/agents/locales/agent.en.json
@@ -99,7 +99,24 @@
       "output": "Output",
       "form": "Form",
       "sources": "Sources",
+      "orchestration": "Orchestration",
       "embed": "Embed"
+    },
+    "orchestration": {
+      "selectedTitle": "Sub-agents",
+      "availableTitle": "Available conversation agents",
+      "emptyTitle": "No sub-agents",
+      "emptyDescription": "This agent answers directly without delegating to another agent.",
+      "noAvailableAgents": "No other conversation agents are available.",
+      "missingAgent": "Missing agent",
+      "add": "Add",
+      "remove": "Remove",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "toolName": "Tool name",
+      "toolNamePlaceholder": "ask_specialist_agent",
+      "description": "Tool description",
+      "defaultDescription": "Route specialized requests to {{name}}."
     },
     "embed": {
       "loading": "Loading embed configuration…",

--- a/apps/web/src/common/features/agents/locales/agent.fr.json
+++ b/apps/web/src/common/features/agents/locales/agent.fr.json
@@ -99,7 +99,24 @@
       "output": "Sortie",
       "form": "Formulaire",
       "sources": "Sources",
+      "orchestration": "Orchestration",
       "embed": "Intégration"
+    },
+    "orchestration": {
+      "selectedTitle": "Sous-agents",
+      "availableTitle": "Agents conversationnels disponibles",
+      "emptyTitle": "Aucun sous-agent",
+      "emptyDescription": "Cet agent répond directement sans déléguer à un autre agent.",
+      "noAvailableAgents": "Aucun autre agent conversationnel n'est disponible.",
+      "missingAgent": "Agent manquant",
+      "add": "Ajouter",
+      "remove": "Retirer",
+      "enabled": "Activé",
+      "disabled": "Désactivé",
+      "toolName": "Nom de l'outil",
+      "toolNamePlaceholder": "ask_specialist_agent",
+      "description": "Description de l'outil",
+      "defaultDescription": "Transmettre les demandes spécialisées à {{name}}."
     },
     "embed": {
       "loading": "Chargement de la configuration d'intégration…",

--- a/apps/web/src/di/services.ts
+++ b/apps/web/src/di/services.ts
@@ -14,6 +14,7 @@ import type { IReviewerSpi } from "@/reviewer/features/review-campaigns/reviewer
 import type { IAgentEmbedConfigsSpi } from "@/studio/features/agent-embed-configs/agent-embed-configs.spi"
 import type { IAgentMembershipsSpi } from "@/studio/features/agent-memberships/agent-memberships.spi"
 import type { IAgentMessageFeedbackSpi } from "@/studio/features/agent-message-feedback/agent-message-feedback.spi"
+import type { IAgentSubAgentsSpi } from "@/studio/features/agent-sub-agents/agent-sub-agents.spi"
 import type { IAgentAnalyticsSpi } from "@/studio/features/analytics/agent/agent-analytics.spi"
 import type { IProjectAnalyticsSpi } from "@/studio/features/analytics/project/analytics.spi"
 import type { IDocumentTagsSpi } from "@/studio/features/document-tags/document-tags.spi"
@@ -31,6 +32,7 @@ export type Services = {
   agentEmbedConfigs: IAgentEmbedConfigsSpi
   agentMemberships: IAgentMembershipsSpi
   agentMessageFeedback: IAgentMessageFeedbackSpi
+  agentSubAgents: IAgentSubAgentsSpi
   agents: IAgentsSpi
   agentSessionMessages: IAgentSessionMessagesSpi
   backoffice: IBackofficeSpi

--- a/apps/web/src/external/axios.services.ts
+++ b/apps/web/src/external/axios.services.ts
@@ -13,6 +13,7 @@ import reviewCampaignsReviewer from "@/reviewer/features/review-campaigns/extern
 import agentEmbedConfigs from "@/studio/features/agent-embed-configs/external/agent-embed-configs.api"
 import agentMemberships from "@/studio/features/agent-memberships/external/agent-memberships.api"
 import agentMessageFeedback from "@/studio/features/agent-message-feedback/external/agent-message-feedback.api"
+import agentSubAgents from "@/studio/features/agent-sub-agents/external/agent-sub-agents.api"
 import agentAnalytics from "@/studio/features/analytics/agent/external/agent-analytics.api"
 import projectAnalytics from "@/studio/features/analytics/project/external/analytics.api"
 import documentTags from "@/studio/features/document-tags/external/document-tags.api"
@@ -30,6 +31,7 @@ export const services = {
   agentEmbedConfigs,
   agentMemberships,
   agentMessageFeedback,
+  agentSubAgents,
   agents,
   agentSessionMessages,
   backoffice,

--- a/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
+++ b/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
@@ -55,12 +55,10 @@ export const ConversationAgent: Story = {
       const subAgents =
         withSubAgents && childAgents[0]
           ? [
-              agentSubAgentFactory
-                .transient({ parentAgent, childAgent: childAgents[0] })
-                .build({
-                  toolName: "ask_research_agent",
-                  description: "Use for research and source discovery questions.",
-                }),
+              agentSubAgentFactory.transient({ parentAgent, childAgent: childAgents[0] }).build({
+                toolName: "ask_research_agent",
+                description: "Use for research and source discovery questions.",
+              }),
             ]
           : []
 

--- a/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
+++ b/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { buildDecorator, render } from "@/stories/decorators"
+import {
+  buildStudioData,
+  type StudioStoryArgs,
+  studioStoryArgs,
+  studioStoryArgTypes,
+} from "@/stories/routes/studio/helpers"
+import { mergeSeeds, seed } from "@/stories/seed"
+import { agentSubAgentFactory } from "@/studio/features/agent-sub-agents/agent-sub-agents.factory"
+import { StudioRoutes } from "@/studio/routes/helpers"
+import { studioRoutes } from "@/studio/routes/StudioRoutes"
+
+type StoryArgs = StudioStoryArgs & {
+  withSubAgents?: boolean
+}
+
+const meta = {
+  title: "routes/studio/project/agent/edit",
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    ...studioStoryArgTypes,
+    withSubAgents: { control: "boolean" },
+  },
+  args: {
+    ...studioStoryArgs,
+    featureFlags: [...studioStoryArgs.featureFlags, "agent-orchestration"],
+    withAgents: true,
+    withSubAgents: true,
+  },
+  render: render({ routes: studioRoutes, path: StudioRoutes.agentEdit.path }),
+} satisfies Meta<StoryArgs>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ConversationAgent: Story = {
+  decorators: [
+    buildDecorator<StoryArgs>(({ withSubAgents, ...args }) => {
+      const { baseSeeds, agents } = buildStudioData({ ...args, withAgents: true })
+      const [rawParentAgent, ...rawChildAgents] = agents
+      if (!rawParentAgent) {
+        throw new Error("Agent editor route story requires a parent agent")
+      }
+      const parentAgent = {
+        ...rawParentAgent,
+        name: "Helpful Assistant",
+        type: "conversation" as const,
+      }
+      const childAgents = rawChildAgents.map((agent, index) => ({
+        ...agent,
+        name: index === 0 ? "Research Agent" : "Summary Bot",
+        type: "conversation" as const,
+      }))
+      const subAgents =
+        withSubAgents && childAgents[0]
+          ? [
+              agentSubAgentFactory
+                .transient({ parentAgent, childAgent: childAgents[0] })
+                .build({
+                  toolName: "ask_research_agent",
+                  description: "Use for research and source discovery questions.",
+                }),
+            ]
+          : []
+
+      return {
+        state: mergeSeeds(
+          baseSeeds,
+          seed.agents([parentAgent, ...childAgents], { currentId: parentAgent.id }),
+          seed.studio.agentSubAgents(subAgents),
+          seed.studio.documentTags([]),
+        ),
+      }
+    }),
+  ],
+}

--- a/apps/web/src/stories/routes/studio/agent/forms/AgentEditor.stories.tsx
+++ b/apps/web/src/stories/routes/studio/agent/forms/AgentEditor.stories.tsx
@@ -18,6 +18,10 @@ const supportCategory = projectAgentCategoryFactory.build({ name: "Support" })
 const project = projectFactory
   .transient({ organization })
   .build({ agentCategories: [billingCategory, supportCategory] })
+const projectWithOrchestration = {
+  ...project,
+  featureFlags: ["agent-orchestration" as const],
+}
 
 const productTag = documentTagFactory.transient({ project }).build({ name: "Product" })
 const pricingTag = documentTagFactory.transient({ project }).build({ name: "Pricing" })
@@ -33,6 +37,20 @@ const conversationAgent = agentFactory.transient({ project }).build({
   projectAgentCategoryIds: [billingCategory.id],
   usedProjectAgentCategoryIds: [billingCategory.id],
   greetingMessage: "Hi! How can I help you today?",
+})
+
+const resourceAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Resource Navigator",
+  defaultPrompt: "Find relevant services, contacts, and eligibility details.",
+  documentsRagMode: DocumentsRagMode.None,
+})
+
+const policyAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Policy Analyst",
+  defaultPrompt: "Interpret policy documents and summarize operational constraints.",
+  documentsRagMode: DocumentsRagMode.Tags,
 })
 
 const extractionAgent = agentFactory.transient({ project }).build({
@@ -69,6 +87,15 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const ConversationEdit: Story = {
+  decorators: [
+    withRedux({
+      state: mergeSeeds(
+        seed.currentProject(projectWithOrchestration),
+        seed.studio.documentTags(documentTags),
+        seed.agents([conversationAgent, resourceAgent, policyAgent]),
+      ),
+    }),
+  ],
   args: {
     agent: conversationAgent,
   },

--- a/apps/web/src/stories/routes/studio/agent/forms/AgentSubAgentsTab.stories.tsx
+++ b/apps/web/src/stories/routes/studio/agent/forms/AgentSubAgentsTab.stories.tsx
@@ -1,0 +1,129 @@
+import { DocumentsRagMode } from "@caseai-connect/api-contracts"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { agentFactory } from "@/common/features/agents/agent.factory"
+import { organizationFactory } from "@/common/features/organizations/organization.factory"
+import { projectFactory } from "@/common/features/projects/projects.factory"
+import {
+  type AgentSubAgentFormValue,
+  AgentSubAgentsTab,
+} from "@/studio/features/agents/components/AgentSubAgentsTab"
+
+const organization = organizationFactory.build()
+const project = projectFactory.transient({ organization }).build()
+
+const masterAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Workspace Copilot",
+  documentsRagMode: DocumentsRagMode.All,
+})
+
+const resourceAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Resource Navigator",
+  defaultPrompt: "Find relevant services, contacts, and eligibility details.",
+  documentsRagMode: DocumentsRagMode.None,
+})
+
+const policyAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Policy Analyst",
+  defaultPrompt: "Interpret policy documents and summarize operational constraints.",
+  documentsRagMode: DocumentsRagMode.Tags,
+})
+
+const intakeAgent = agentFactory.transient({ project }).build({
+  type: "form",
+  name: "Intake Form",
+  documentsRagMode: DocumentsRagMode.None,
+})
+
+const draftingAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Drafting Assistant",
+  defaultPrompt: "Prepare concise drafts from approved context and prior decisions.",
+  documentsRagMode: DocumentsRagMode.None,
+})
+
+const agents = [masterAgent, resourceAgent, policyAgent, intakeAgent, draftingAgent]
+
+type StoryArgs = {
+  value: AgentSubAgentFormValue[]
+}
+
+function StatefulStory({ value: initialValue }: StoryArgs) {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <AgentSubAgentsTab
+        parentAgentId={masterAgent.id}
+        agents={agents}
+        value={value}
+        onChange={setValue}
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: "routes/studio/project/agent/AgentSubAgentsTab",
+  component: StatefulStory,
+  parameters: { layout: "fullscreen" },
+  args: {
+    value: [],
+  },
+} satisfies Meta<typeof StatefulStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {}
+
+export const WithSubAgents: Story = {
+  args: {
+    value: [
+      {
+        id: "sub-agent-resource",
+        agentId: resourceAgent.id,
+        toolName: "ask_resource_navigator",
+        description: "Route resource lookup and eligibility questions to Resource Navigator.",
+        enabled: true,
+      },
+      {
+        id: "sub-agent-policy",
+        agentId: policyAgent.id,
+        toolName: "ask_policy_analyst",
+        description: "Use Policy Analyst for questions that need regulatory or policy framing.",
+        enabled: false,
+      },
+    ],
+  },
+}
+
+export const NoAvailableConversationAgents: Story = {
+  args: {
+    value: [
+      {
+        id: "sub-agent-resource",
+        agentId: resourceAgent.id,
+        toolName: "ask_resource_navigator",
+        description: "Route resource lookup and eligibility questions to Resource Navigator.",
+        enabled: true,
+      },
+      {
+        id: "sub-agent-policy",
+        agentId: policyAgent.id,
+        toolName: "ask_policy_analyst",
+        description: "Use Policy Analyst for questions that need regulatory or policy framing.",
+        enabled: true,
+      },
+      {
+        id: "sub-agent-drafting",
+        agentId: draftingAgent.id,
+        toolName: "ask_drafting_assistant",
+        description: "Use Drafting Assistant for short operational drafts.",
+        enabled: true,
+      },
+    ],
+  },
+}

--- a/apps/web/src/stories/seed.ts
+++ b/apps/web/src/stories/seed.ts
@@ -15,6 +15,7 @@ import type { Project } from "@/common/features/projects/projects.models"
 import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data-status"
 import type { AgentMembership } from "@/studio/features/agent-memberships/agent-memberships.models"
 import type { AgentMessageFeedback } from "@/studio/features/agent-message-feedback/agent-message-feedback.models"
+import type { AgentSubAgent } from "@/studio/features/agent-sub-agents/agent-sub-agents.models"
 import type {
   AnalyticsCategoryDailyPoint,
   AnalyticsDailyPoint,
@@ -265,6 +266,10 @@ export const seed = {
       feedbacksByAgentId: Record<string, AgentMessageFeedback[]>,
     ): StoryPreloadedState {
       return { agentMessageFeedback: { data: ads.fulfilled(feedbacksByAgentId) } }
+    },
+
+    agentSubAgents(subAgents: AgentSubAgent[]): StoryPreloadedState {
+      return { agentSubAgents: { data: ads.fulfilled(subAgents) } }
     },
   },
 

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.factory.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.factory.ts
@@ -10,33 +10,31 @@ type AgentSubAgentTransientParams = {
 
 class AgentSubAgentFactory extends Factory<AgentSubAgent, AgentSubAgentTransientParams> {}
 
-export const agentSubAgentFactory = AgentSubAgentFactory.define(
-  ({ params, transientParams }) => {
-    const { parentAgent, childAgent } = transientParams
-    if (!parentAgent) {
-      throw new Error("Parent agent must be provided in transient params to build an AgentSubAgent")
-    }
-    if (!childAgent) {
-      throw new Error("Child agent must be provided in transient params to build an AgentSubAgent")
-    }
+export const agentSubAgentFactory = AgentSubAgentFactory.define(({ params, transientParams }) => {
+  const { parentAgent, childAgent } = transientParams
+  if (!parentAgent) {
+    throw new Error("Parent agent must be provided in transient params to build an AgentSubAgent")
+  }
+  if (!childAgent) {
+    throw new Error("Child agent must be provided in transient params to build an AgentSubAgent")
+  }
 
-    return {
-      id: params.id ?? faker.string.uuid(),
-      parentAgentId: params.parentAgentId ?? parentAgent.id,
-      childAgentId: params.childAgentId ?? childAgent.id,
-      toolName: params.toolName ?? buildDefaultToolName(childAgent.name),
-      description: params.description ?? faker.lorem.sentence(),
-      enabled: params.enabled ?? true,
-      childAgent: {
-        id: params.childAgent?.id ?? childAgent.id,
-        name: params.childAgent?.name ?? childAgent.name,
-        type: params.childAgent?.type ?? childAgent.type,
-      },
-      createdAt: params.createdAt ?? faker.date.past().getTime(),
-      updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
-    }
-  },
-)
+  return {
+    id: params.id ?? faker.string.uuid(),
+    parentAgentId: params.parentAgentId ?? parentAgent.id,
+    childAgentId: params.childAgentId ?? childAgent.id,
+    toolName: params.toolName ?? buildDefaultToolName(childAgent.name),
+    description: params.description ?? faker.lorem.sentence(),
+    enabled: params.enabled ?? true,
+    childAgent: {
+      id: params.childAgent?.id ?? childAgent.id,
+      name: params.childAgent?.name ?? childAgent.name,
+      type: params.childAgent?.type ?? childAgent.type,
+    },
+    createdAt: params.createdAt ?? faker.date.past().getTime(),
+    updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
+  }
+})
 
 function buildDefaultToolName(agentName: string): string {
   const slug = agentName

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.factory.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.factory.ts
@@ -1,0 +1,48 @@
+import { faker } from "@faker-js/faker"
+import { Factory } from "fishery"
+import type { Agent } from "@/common/features/agents/agents.models"
+import type { AgentSubAgent } from "./agent-sub-agents.models"
+
+type AgentSubAgentTransientParams = {
+  parentAgent: Agent
+  childAgent: Agent
+}
+
+class AgentSubAgentFactory extends Factory<AgentSubAgent, AgentSubAgentTransientParams> {}
+
+export const agentSubAgentFactory = AgentSubAgentFactory.define(
+  ({ params, transientParams }) => {
+    const { parentAgent, childAgent } = transientParams
+    if (!parentAgent) {
+      throw new Error("Parent agent must be provided in transient params to build an AgentSubAgent")
+    }
+    if (!childAgent) {
+      throw new Error("Child agent must be provided in transient params to build an AgentSubAgent")
+    }
+
+    return {
+      id: params.id ?? faker.string.uuid(),
+      parentAgentId: params.parentAgentId ?? parentAgent.id,
+      childAgentId: params.childAgentId ?? childAgent.id,
+      toolName: params.toolName ?? buildDefaultToolName(childAgent.name),
+      description: params.description ?? faker.lorem.sentence(),
+      enabled: params.enabled ?? true,
+      childAgent: {
+        id: params.childAgent?.id ?? childAgent.id,
+        name: params.childAgent?.name ?? childAgent.name,
+        type: params.childAgent?.type ?? childAgent.type,
+      },
+      createdAt: params.createdAt ?? faker.date.past().getTime(),
+      updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
+    }
+  },
+)
+
+function buildDefaultToolName(agentName: string): string {
+  const slug = agentName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+  return `ask_${slug || "sub_agent"}`
+}

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
@@ -1,0 +1,59 @@
+import { createListenerMiddleware } from "@reduxjs/toolkit"
+import { hasAgentChanged } from "@/common/features/agents/agents.selectors"
+import { notificationsActions } from "@/common/features/notifications/notifications.slice"
+import type { AppDispatch, RootState } from "@/common/store/types"
+import { selectAgentSubAgentsMounted } from "./agent-sub-agents.selectors"
+import { agentSubAgentsActions } from "./agent-sub-agents.slice"
+
+const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
+
+function registerListeners() {
+  listenerMiddleware.startListening({
+    actionCreator: agentSubAgentsActions.mount,
+    effect: async (_, listenerApi) => {
+      await listenerApi.dispatch(agentSubAgentsActions.list())
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: agentSubAgentsActions.unmount,
+    effect: (_, listenerApi) => {
+      listenerApi.dispatch(agentSubAgentsActions.reset())
+    },
+  })
+
+  listenerMiddleware.startListening({
+    predicate(_, currentState, originalState) {
+      return selectAgentSubAgentsMounted(currentState) && hasAgentChanged(originalState, currentState)
+    },
+    effect: async (_, listenerApi) => {
+      await listenerApi.dispatch(agentSubAgentsActions.list())
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: agentSubAgentsActions.updateAll.fulfilled,
+    effect: (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Sub-agents updated successfully",
+          type: "success",
+        }),
+      )
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: agentSubAgentsActions.updateAll.rejected,
+    effect: (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Failed to update sub-agents",
+          type: "error",
+        }),
+      )
+    },
+  })
+}
+
+export const agentSubAgentsMiddleware = { listenerMiddleware, registerListeners }

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
@@ -24,7 +24,9 @@ function registerListeners() {
 
   listenerMiddleware.startListening({
     predicate(_, currentState, originalState) {
-      return selectAgentSubAgentsMounted(currentState) && hasAgentChanged(originalState, currentState)
+      return (
+        selectAgentSubAgentsMounted(currentState) && hasAgentChanged(originalState, currentState)
+      )
     },
     effect: async (_, listenerApi) => {
       await listenerApi.dispatch(agentSubAgentsActions.list())

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.middleware.ts
@@ -35,6 +35,13 @@ function registerListeners() {
 
   listenerMiddleware.startListening({
     actionCreator: agentSubAgentsActions.updateAll.fulfilled,
+    effect: async (_, listenerApi) => {
+      await listenerApi.dispatch(agentSubAgentsActions.list())
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: agentSubAgentsActions.updateAll.fulfilled,
     effect: (_, listenerApi) => {
       listenerApi.dispatch(
         notificationsActions.show({

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.models.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.models.ts
@@ -1,0 +1,4 @@
+import type { AgentSubAgentDto, ReplaceAgentSubAgentDto } from "@caseai-connect/api-contracts"
+
+export type AgentSubAgent = AgentSubAgentDto
+export type ReplaceAgentSubAgent = ReplaceAgentSubAgentDto

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.selectors.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.selectors.ts
@@ -1,0 +1,5 @@
+import type { RootState } from "@/common/store"
+
+export const selectAgentSubAgentsData = (state: RootState) => state.agentSubAgents.data
+
+export const selectAgentSubAgentsMounted = (state: RootState) => state.agentSubAgents.mounted

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.slice.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.slice.ts
@@ -40,13 +40,6 @@ const slice = createSlice({
         state.data.status = ADS.Error
         state.data.error = action.error.message || "Failed to load sub-agents"
       })
-      .addCase(agentSubAgentsThunks.updateAll.fulfilled, (state, action) => {
-        state.data = {
-          status: ADS.Fulfilled,
-          error: null,
-          value: action.payload,
-        }
-      })
   },
 })
 

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.slice.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.slice.ts
@@ -1,0 +1,56 @@
+import { createSlice } from "@reduxjs/toolkit"
+import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data-status"
+import type { AgentSubAgent } from "./agent-sub-agents.models"
+import { agentSubAgentsThunks } from "./agent-sub-agents.thunks"
+
+interface State {
+  data: AsyncData<AgentSubAgent[]>
+  mounted: boolean
+}
+
+const initialState: State = {
+  data: defaultAsyncData,
+  mounted: false,
+}
+
+const slice = createSlice({
+  name: "agentSubAgents",
+  initialState,
+  reducers: {
+    mount: (state) => {
+      state.mounted = true
+    },
+    unmount: () => initialState,
+    reset: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(agentSubAgentsThunks.list.pending, (state) => {
+        if (!ADS.isFulfilled(state.data)) state.data.status = ADS.Loading
+        state.data.error = null
+      })
+      .addCase(agentSubAgentsThunks.list.fulfilled, (state, action) => {
+        state.data = {
+          status: ADS.Fulfilled,
+          error: null,
+          value: action.payload,
+        }
+      })
+      .addCase(agentSubAgentsThunks.list.rejected, (state, action) => {
+        state.data.status = ADS.Error
+        state.data.error = action.error.message || "Failed to load sub-agents"
+      })
+      .addCase(agentSubAgentsThunks.updateAll.fulfilled, (state, action) => {
+        state.data = {
+          status: ADS.Fulfilled,
+          error: null,
+          value: action.payload,
+        }
+      })
+  },
+})
+
+export type { State as AgentSubAgentsState }
+export const agentSubAgentsInitialState = initialState
+export const agentSubAgentsActions = { ...slice.actions, ...agentSubAgentsThunks }
+export const agentSubAgentsSlice = slice

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.spi.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.spi.ts
@@ -1,0 +1,17 @@
+import type { AgentSubAgent, ReplaceAgentSubAgent } from "./agent-sub-agents.models"
+
+export interface IAgentSubAgentsSpi {
+  getAll(params: {
+    organizationId: string
+    projectId: string
+    agentId: string
+  }): Promise<AgentSubAgent[]>
+  updateAll(
+    params: {
+      organizationId: string
+      projectId: string
+      agentId: string
+    },
+    payload: { subAgents: ReplaceAgentSubAgent[] },
+  ): Promise<AgentSubAgent[]>
+}

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.thunks.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.thunks.ts
@@ -22,19 +22,16 @@ const updateAll = createAsyncThunk<
   AgentSubAgent[],
   { subAgents: ReplaceAgentSubAgent[] },
   ThunkConfig
->(
-  "agentSubAgents/updateAll",
-  async ({ subAgents }, { extra: { services }, getState }) => {
-    const state = getState()
-    hasFeatureOrThrow({ state, feature: "agent-orchestration" })
-    const organizationId = getCurrentId({ state, name: "organizationId" })
-    const projectId = getCurrentId({ state, name: "projectId" })
-    const agentId = getCurrentId({ state, name: "agentId" })
-    return await services.agentSubAgents.updateAll(
-      { organizationId, projectId, agentId },
-      { subAgents },
-    )
-  },
-)
+>("agentSubAgents/updateAll", async ({ subAgents }, { extra: { services }, getState }) => {
+  const state = getState()
+  hasFeatureOrThrow({ state, feature: "agent-orchestration" })
+  const organizationId = getCurrentId({ state, name: "organizationId" })
+  const projectId = getCurrentId({ state, name: "projectId" })
+  const agentId = getCurrentId({ state, name: "agentId" })
+  return await services.agentSubAgents.updateAll(
+    { organizationId, projectId, agentId },
+    { subAgents },
+  )
+})
 
 export const agentSubAgentsThunks = { list, updateAll }

--- a/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.thunks.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/agent-sub-agents.thunks.ts
@@ -1,0 +1,40 @@
+import { createAsyncThunk } from "@reduxjs/toolkit"
+import { getCurrentId } from "@/common/features/helpers"
+import { hasFeatureOrThrow } from "@/common/hooks/use-feature-flags"
+import type { RootState, ThunkExtraArg } from "@/common/store"
+import type { AgentSubAgent, ReplaceAgentSubAgent } from "./agent-sub-agents.models"
+
+type ThunkConfig = { state: RootState; extra: ThunkExtraArg }
+
+const list = createAsyncThunk<AgentSubAgent[], void, ThunkConfig>(
+  "agentSubAgents/list",
+  async (_, { extra: { services }, getState }) => {
+    const state = getState()
+    hasFeatureOrThrow({ state, feature: "agent-orchestration" })
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const agentId = getCurrentId({ state, name: "agentId" })
+    return await services.agentSubAgents.getAll({ organizationId, projectId, agentId })
+  },
+)
+
+const updateAll = createAsyncThunk<
+  AgentSubAgent[],
+  { subAgents: ReplaceAgentSubAgent[] },
+  ThunkConfig
+>(
+  "agentSubAgents/updateAll",
+  async ({ subAgents }, { extra: { services }, getState }) => {
+    const state = getState()
+    hasFeatureOrThrow({ state, feature: "agent-orchestration" })
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const agentId = getCurrentId({ state, name: "agentId" })
+    return await services.agentSubAgents.updateAll(
+      { organizationId, projectId, agentId },
+      { subAgents },
+    )
+  },
+)
+
+export const agentSubAgentsThunks = { list, updateAll }

--- a/apps/web/src/studio/features/agent-sub-agents/external/agent-sub-agents.api.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/external/agent-sub-agents.api.ts
@@ -1,0 +1,34 @@
+import { AgentSubAgentsRoutes, type AgentSubAgentDto } from "@caseai-connect/api-contracts"
+import { getAxiosInstance } from "@/external/axios"
+import type { AgentSubAgent } from "../agent-sub-agents.models"
+import type { IAgentSubAgentsSpi } from "../agent-sub-agents.spi"
+
+export default {
+  getAll: async (params) => {
+    const axios = getAxiosInstance()
+    const response = await axios.get<typeof AgentSubAgentsRoutes.getAll.response>(
+      AgentSubAgentsRoutes.getAll.getPath(params),
+    )
+    return response.data.data.map(toAgentSubAgent)
+  },
+  updateAll: async (params, payload) => {
+    const axios = getAxiosInstance()
+    const response = await axios.put<typeof AgentSubAgentsRoutes.updateAll.response>(
+      AgentSubAgentsRoutes.updateAll.getPath(params),
+      { payload } satisfies typeof AgentSubAgentsRoutes.updateAll.request,
+    )
+    return response.data.data.map(toAgentSubAgent)
+  },
+} satisfies IAgentSubAgentsSpi
+
+const toAgentSubAgent = (dto: AgentSubAgentDto): AgentSubAgent => ({
+  id: dto.id,
+  parentAgentId: dto.parentAgentId,
+  childAgentId: dto.childAgentId,
+  toolName: dto.toolName,
+  description: dto.description,
+  enabled: dto.enabled,
+  childAgent: dto.childAgent,
+  createdAt: dto.createdAt,
+  updatedAt: dto.updatedAt,
+})

--- a/apps/web/src/studio/features/agent-sub-agents/external/agent-sub-agents.api.ts
+++ b/apps/web/src/studio/features/agent-sub-agents/external/agent-sub-agents.api.ts
@@ -1,4 +1,4 @@
-import { AgentSubAgentsRoutes, type AgentSubAgentDto } from "@caseai-connect/api-contracts"
+import { type AgentSubAgentDto, AgentSubAgentsRoutes } from "@caseai-connect/api-contracts"
 import { getAxiosInstance } from "@/external/axios"
 import type { AgentSubAgent } from "../agent-sub-agents.models"
 import type { IAgentSubAgentsSpi } from "../agent-sub-agents.spi"

--- a/apps/web/src/studio/features/agents/components/AgentActions.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentActions.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@caseai-connect/ui/shad/button"
-import { ExternalLinkIcon, UsersIcon } from "lucide-react"
+import { ExternalLinkIcon, PenLineIcon, UsersIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import type { Agent } from "@/common/features/agents/agents.models"
@@ -7,7 +7,6 @@ import { useAbility } from "@/common/hooks/use-ability"
 import { DeskRoutes } from "@/desk/routes/helpers"
 import { AgentDeletorWithTrigger } from "@/studio/features/agents/components/AgentDeletor"
 import { StudioRoutes } from "@/studio/routes/helpers"
-import { AgentEditorWithTrigger } from "./AgentEditor"
 
 export function AgentActions({ organizationId, agent }: { organizationId: string; agent: Agent }) {
   const { t } = useTranslation()
@@ -20,6 +19,12 @@ export function AgentActions({ organizationId, agent }: { organizationId: string
 
   const { abilities } = useAbility()
   const canManageAgent = abilities.canManageAgent({ agentId: agent.id })
+  const editPath = StudioRoutes.agentEdit.build({
+    organizationId,
+    projectId: agent.projectId,
+    agentId: agent.id,
+  })
+  const navigate = useNavigate()
   return (
     <>
       <Button variant="secondary" asChild>
@@ -37,7 +42,12 @@ export function AgentActions({ organizationId, agent }: { organizationId: string
             agentId={agent.id}
           />
 
-          {agent.type !== "extraction" && <AgentEditorWithTrigger agent={agent} />}
+          {agent.type !== "extraction" && (
+            <Button variant="outline" onClick={() => navigate(editPath)}>
+              <PenLineIcon />
+              {t("actions:edit")}
+            </Button>
+          )}
 
           <AgentDeletorWithTrigger organizationId={organizationId} agent={agent} />
         </>

--- a/apps/web/src/studio/features/agents/components/AgentEditor.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentEditor.tsx
@@ -8,18 +8,21 @@ import {
 } from "@caseai-connect/ui/shad/sheet"
 import { useTranslation } from "react-i18next"
 import type { Agent } from "@/common/features/agents/agents.models"
-import { selectAgentsData } from "@/common/features/agents/agents.selectors"
 import { selectCurrentProjectData } from "@/common/features/projects/projects.selectors"
 import { useValue } from "@/common/hooks/use-value.ts"
 import { useAppDispatch } from "@/common/store/hooks"
 import type { AgentSubAgent } from "@/studio/features/agent-sub-agents/agent-sub-agents.models"
-import { selectAgentSubAgentsData } from "@/studio/features/agent-sub-agents/agent-sub-agents.selectors"
 import { agentSubAgentsActions } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
 import { useDocumentTags } from "@/studio/features/document-tags/document-tags.helpers"
 import { updateAgent } from "../agents.thunks"
 import type { AgentSubAgentFormValue } from "./AgentSubAgentsTab"
 import type { AgentFormData } from "./agent-form.shared"
 import { BaseAgentForm } from "./BaseAgentForm"
+
+export type AgentEditorOrchestration = {
+  agents: Agent[]
+  subAgents: AgentSubAgent[]
+}
 
 export function AgentEditorWithoutTrigger({
   agent,
@@ -60,19 +63,33 @@ function Content({ agent, onSuccess }: { agent: Agent; onSuccess: () => void }) 
   )
 }
 
-export function AgentEditor({ agent, className }: { agent: Agent; className?: string }) {
+export function AgentEditor({
+  agent,
+  className,
+  orchestration,
+}: {
+  agent: Agent
+  className?: string
+  orchestration?: AgentEditorOrchestration
+}) {
   return (
     <div className={className}>
-      <UpdateForm agent={agent} />
+      <UpdateForm agent={agent} orchestration={orchestration} />
     </div>
   )
 }
 
-function UpdateForm({ agent, onSuccess }: { agent: Agent; onSuccess?: () => void }) {
+function UpdateForm({
+  agent,
+  onSuccess,
+  orchestration,
+}: {
+  agent: Agent
+  onSuccess?: () => void
+  orchestration?: AgentEditorOrchestration
+}) {
   const dispatch = useAppDispatch()
   const currentProject = useValue(selectCurrentProjectData)
-  const agents = useValue(selectAgentsData)
-  const subAgents = useValue(selectAgentSubAgentsData).map(toSubAgentFormValue)
   const { documentTags } = useDocumentTags()
 
   const handleSubmit = (fields: AgentFormData) => {
@@ -123,9 +140,9 @@ function UpdateForm({ agent, onSuccess }: { agent: Agent; onSuccess?: () => void
       onSubmit={handleSubmit}
       documentTags={documentTags}
       projectAgentCategories={currentProject.agentCategories}
-      availableAgents={agents}
-      subAgents={subAgents}
-      onSubAgentsSubmit={handleSubAgentsSubmit}
+      availableAgents={orchestration?.agents}
+      subAgents={orchestration?.subAgents.map(toSubAgentFormValue)}
+      onSubAgentsSubmit={orchestration ? handleSubAgentsSubmit : undefined}
     />
   )
 }

--- a/apps/web/src/studio/features/agents/components/AgentEditor.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentEditor.tsx
@@ -1,6 +1,3 @@
-"use client"
-
-import { Button } from "@caseai-connect/ui/shad/button"
 import { ScrollArea } from "@caseai-connect/ui/shad/scroll-area"
 import {
   Sheet,
@@ -8,42 +5,21 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
-  SheetTrigger,
 } from "@caseai-connect/ui/shad/sheet"
-import { PenLineIcon } from "lucide-react"
-import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { Agent } from "@/common/features/agents/agents.models"
+import { selectAgentsData } from "@/common/features/agents/agents.selectors"
 import { selectCurrentProjectData } from "@/common/features/projects/projects.selectors"
-import { ADS } from "@/common/store/async-data-status"
-import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { useValue } from "@/common/hooks/use-value.ts"
+import { useAppDispatch } from "@/common/store/hooks"
+import type { AgentSubAgent } from "@/studio/features/agent-sub-agents/agent-sub-agents.models"
+import { selectAgentSubAgentsData } from "@/studio/features/agent-sub-agents/agent-sub-agents.selectors"
+import { agentSubAgentsActions } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
 import { useDocumentTags } from "@/studio/features/document-tags/document-tags.helpers"
 import { updateAgent } from "../agents.thunks"
+import type { AgentSubAgentFormValue } from "./AgentSubAgentsTab"
 import type { AgentFormData } from "./agent-form.shared"
 import { BaseAgentForm } from "./BaseAgentForm"
-
-export function AgentEditorWithTrigger({ agent }: { agent: Agent }) {
-  const [open, setOpen] = useState(false)
-  const { t } = useTranslation()
-
-  const handleSuccess = () => {
-    setOpen(false)
-  }
-
-  if (!agent) return null
-  return (
-    <Sheet modal open={open} onOpenChange={(open: boolean) => setOpen(open)}>
-      <SheetTrigger asChild>
-        <Button variant="outline">
-          <PenLineIcon />
-          {t("actions:edit")}
-        </Button>
-      </SheetTrigger>
-
-      <Content agent={agent} onSuccess={handleSuccess} />
-    </Sheet>
-  )
-}
 
 export function AgentEditorWithoutTrigger({
   agent,
@@ -94,11 +70,10 @@ export function AgentEditor({ agent, className }: { agent: Agent; className?: st
 
 function UpdateForm({ agent, onSuccess }: { agent: Agent; onSuccess?: () => void }) {
   const dispatch = useAppDispatch()
-  const currentProject = useAppSelector(selectCurrentProjectData)
+  const currentProject = useValue(selectCurrentProjectData)
+  const agents = useValue(selectAgentsData)
+  const subAgents = useValue(selectAgentSubAgentsData).map(toSubAgentFormValue)
   const { documentTags } = useDocumentTags()
-  const projectAgentCategories = ADS.isFulfilled(currentProject)
-    ? currentProject.value.agentCategories
-    : []
 
   const handleSubmit = (fields: AgentFormData) => {
     if (!("documentTagIds" in fields)) {
@@ -128,13 +103,39 @@ function UpdateForm({ agent, onSuccess }: { agent: Agent; onSuccess?: () => void
     onSuccess?.()
   }
 
+  const handleSubAgentsSubmit = (values: AgentSubAgentFormValue[]) => {
+    dispatch(
+      agentSubAgentsActions.updateAll({
+        subAgents: values.map((subAgent) => ({
+          childAgentId: subAgent.agentId,
+          toolName: subAgent.toolName,
+          description: subAgent.description,
+          enabled: subAgent.enabled,
+        })),
+      }),
+    )
+  }
+
   return (
     <BaseAgentForm
       agentType={agent.type}
       editableAgent={agent}
       onSubmit={handleSubmit}
       documentTags={documentTags}
-      projectAgentCategories={projectAgentCategories}
+      projectAgentCategories={currentProject.agentCategories}
+      availableAgents={agents}
+      subAgents={subAgents}
+      onSubAgentsSubmit={handleSubAgentsSubmit}
     />
   )
+}
+
+function toSubAgentFormValue(subAgent: AgentSubAgent): AgentSubAgentFormValue {
+  return {
+    id: subAgent.id,
+    agentId: subAgent.childAgentId,
+    toolName: subAgent.toolName,
+    description: subAgent.description,
+    enabled: subAgent.enabled,
+  }
 }

--- a/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
@@ -1,0 +1,223 @@
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import { Button } from "@caseai-connect/ui/shad/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@caseai-connect/ui/shad/empty"
+import { Field, FieldGroup, FieldLabel } from "@caseai-connect/ui/shad/field"
+import { Input } from "@caseai-connect/ui/shad/input"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@caseai-connect/ui/shad/item"
+import { Switch } from "@caseai-connect/ui/shad/switch"
+import { Textarea } from "@caseai-connect/ui/shad/textarea"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@caseai-connect/ui/shad/tooltip"
+import { BotIcon, PlusIcon, Trash2Icon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+
+export type AgentSubAgentFormValue = {
+  id: string
+  agentId: string
+  toolName: string
+  description: string
+  enabled: boolean
+}
+
+export function AgentSubAgentsTab({
+  parentAgentId,
+  agents,
+  value,
+  onChange,
+}: {
+  parentAgentId: string
+  agents: Agent[]
+  value: AgentSubAgentFormValue[]
+  onChange: (value: AgentSubAgentFormValue[]) => void
+}) {
+  const { t } = useTranslation()
+  const selectedAgentIds = new Set(value.map((subAgent) => subAgent.agentId))
+  const availableAgents = agents
+    .filter(
+      (agent) =>
+        agent.type === "conversation" &&
+        agent.id !== parentAgentId &&
+        !selectedAgentIds.has(agent.id),
+    )
+    .sort((leftAgent, rightAgent) => leftAgent.name.localeCompare(rightAgent.name))
+
+  const updateSubAgent = (
+    subAgentId: string,
+    fields: Partial<Omit<AgentSubAgentFormValue, "id" | "agentId">>,
+  ) => {
+    onChange(
+      value.map((subAgent) => (subAgent.id === subAgentId ? { ...subAgent, ...fields } : subAgent)),
+    )
+  }
+
+  const addSubAgent = (agent: Agent) => {
+    onChange([
+      ...value,
+      {
+        id: `sub-agent-${agent.id}`,
+        agentId: agent.id,
+        toolName: buildDefaultToolName(agent.name),
+        description: t("agent:orchestration.defaultDescription", { name: agent.name }),
+        enabled: true,
+      },
+    ])
+  }
+
+  const removeSubAgent = (subAgentId: string) => {
+    onChange(value.filter((subAgent) => subAgent.id !== subAgentId))
+  }
+
+  return (
+    <FieldGroup>
+      <Field>
+        <FieldLabel>{t("agent:orchestration.selectedTitle")}</FieldLabel>
+        {value.length === 0 ? (
+          <Empty className="border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <BotIcon />
+              </EmptyMedia>
+              <EmptyTitle>{t("agent:orchestration.emptyTitle")}</EmptyTitle>
+              <EmptyDescription>{t("agent:orchestration.emptyDescription")}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <ItemGroup className="gap-3">
+            {value.map((subAgent) => {
+              const agent = agents.find((candidate) => candidate.id === subAgent.agentId)
+              const title = agent?.name ?? t("agent:orchestration.missingAgent")
+              return (
+                <div key={subAgent.id} className="rounded-md border">
+                  <Item>
+                    <ItemMedia variant="icon">
+                      <BotIcon />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>
+                        {title}
+                        <Badge variant={subAgent.enabled ? "default" : "secondary"}>
+                          {subAgent.enabled
+                            ? t("agent:orchestration.enabled")
+                            : t("agent:orchestration.disabled")}
+                        </Badge>
+                      </ItemTitle>
+                      <ItemDescription>{subAgent.toolName}</ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <Switch
+                        checked={subAgent.enabled}
+                        onCheckedChange={(enabled) => updateSubAgent(subAgent.id, { enabled })}
+                        aria-label={t("agent:orchestration.enabled")}
+                      />
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 text-muted-foreground hover:text-destructive"
+                            aria-label={t("agent:orchestration.remove")}
+                            onClick={() => removeSubAgent(subAgent.id)}
+                          >
+                            <Trash2Icon className="size-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t("agent:orchestration.remove")}</TooltipContent>
+                      </Tooltip>
+                    </ItemActions>
+                  </Item>
+                  <div className="grid gap-4 border-t p-4 md:grid-cols-[minmax(12rem,18rem)_1fr]">
+                    <Field>
+                      <FieldLabel htmlFor={`sub-agent-tool-name-${subAgent.id}`}>
+                        {t("agent:orchestration.toolName")}
+                      </FieldLabel>
+                      <Input
+                        id={`sub-agent-tool-name-${subAgent.id}`}
+                        value={subAgent.toolName}
+                        placeholder={t("agent:orchestration.toolNamePlaceholder")}
+                        onChange={(event) =>
+                          updateSubAgent(subAgent.id, { toolName: event.target.value })
+                        }
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor={`sub-agent-description-${subAgent.id}`}>
+                        {t("agent:orchestration.description")}
+                      </FieldLabel>
+                      <Textarea
+                        id={`sub-agent-description-${subAgent.id}`}
+                        value={subAgent.description}
+                        rows={2}
+                        className="min-h-20"
+                        onChange={(event) =>
+                          updateSubAgent(subAgent.id, { description: event.target.value })
+                        }
+                      />
+                    </Field>
+                  </div>
+                </div>
+              )
+            })}
+          </ItemGroup>
+        )}
+      </Field>
+
+      <Field>
+        <FieldLabel>{t("agent:orchestration.availableTitle")}</FieldLabel>
+        {availableAgents.length === 0 ? (
+          <p className="rounded-md border border-dashed px-4 py-3 text-sm text-muted-foreground">
+            {t("agent:orchestration.noAvailableAgents")}
+          </p>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2">
+            {availableAgents.map((agent) => (
+              <Item key={agent.id} variant="outline">
+                <ItemMedia variant="icon">
+                  <BotIcon />
+                </ItemMedia>
+                <ItemContent>
+                  <ItemTitle>{agent.name}</ItemTitle>
+                  <ItemDescription>{agent.defaultPrompt}</ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => addSubAgent(agent)}
+                  >
+                    <PlusIcon />
+                    {t("agent:orchestration.add")}
+                  </Button>
+                </ItemActions>
+              </Item>
+            ))}
+          </div>
+        )}
+      </Field>
+    </FieldGroup>
+  )
+}
+
+function buildDefaultToolName(agentName: string): string {
+  const slug = agentName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+  return `ask_${slug || "sub_agent"}`
+}

--- a/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
+++ b/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import {
   AgentLocale,
   AgentModel,
@@ -32,7 +30,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@caseai-connect/ui/sha
 import { Textarea } from "@caseai-connect/ui/shad/textarea"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { XIcon } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Controller, type FieldErrors, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import type { z } from "zod"
@@ -46,6 +44,9 @@ import { getTagNameById } from "@/studio/features/document-tags/document-tags.he
 import type { DocumentTag } from "@/studio/features/document-tags/document-tags.models"
 import { DocumentTagPicker } from "@/studio/features/documents/components/DocumentTagPicker"
 import { type AgentFormData, getDefaultFormValues } from "./agent-form.shared"
+import { type AgentSubAgentFormValue, AgentSubAgentsTab } from "./AgentSubAgentsTab"
+
+const EMPTY_SUB_AGENTS: AgentSubAgentFormValue[] = []
 
 function extractModelListFromAgentType(
   _agentType: "conversation" | "extraction" | "form",
@@ -75,11 +76,19 @@ export function BaseAgentForm({
   agentType,
   documentTags,
   projectAgentCategories,
+  availableAgents = [],
+  subAgents = EMPTY_SUB_AGENTS,
+  onSubAgentsSubmit,
+  defaultActiveTab = "general",
 }: {
   documentTags: DocumentTag[]
   projectAgentCategories: ProjectAgentCategory[]
   agentType: Agent["type"]
   editableAgent?: Agent
+  availableAgents?: Agent[]
+  subAgents?: AgentSubAgentFormValue[]
+  onSubAgentsSubmit?: (value: AgentSubAgentFormValue[]) => Promise<void> | void
+  defaultActiveTab?: "general" | "model" | "output" | "sources" | "orchestration" | "embed"
   onSubmit: (values: AgentFormData) => Promise<void> | void
 }) {
   const project = useValue(selectCurrentProjectData)
@@ -114,12 +123,24 @@ export function BaseAgentForm({
     control,
     handleSubmit,
     formState: { errors },
-    reset,
+    reset: resetAgentForm,
     watch,
   } = useForm<FormValues>({
     resolver: zodResolver(agentSchema),
     defaultValues,
   })
+
+  const {
+    control: subAgentsControl,
+    handleSubmit: handleSubAgentsFormSubmit,
+    reset: resetSubAgentsForm,
+  } = useForm<{ subAgents: AgentSubAgentFormValue[] }>({
+    defaultValues: { subAgents },
+  })
+
+  useEffect(() => {
+    resetSubAgentsForm({ subAgents })
+  }, [resetSubAgentsForm, subAgents])
   const documentsRagMode = watch("documentsRagMode")
   const documentTagErrorMessage = (() => {
     if (editableAgent && "documentTagIds" in errors) {
@@ -132,15 +153,21 @@ export function BaseAgentForm({
   })()
 
   const hasEmbed = hasSources && !!editableAgent && hasFeature("agent-embed")
+  const hasOrchestration = hasSources && !!editableAgent && hasFeature("agent-orchestration")
 
-  const [activeTab, setActiveTab] = useState<"general" | "model" | "output" | "sources" | "embed">(
-    "general",
-  )
+  const [activeTab, setActiveTab] = useState<
+    "general" | "model" | "output" | "sources" | "orchestration" | "embed"
+  >(defaultActiveTab)
 
   const handleFormSubmit = async (data: FormValues) => {
     await onSubmit(data as AgentFormData)
-    reset(data)
+    resetAgentForm(data)
   }
+
+  const handleOrchestrationSubmit = handleSubAgentsFormSubmit(async (data) => {
+    onSubAgentsSubmit?.(data.subAgents)
+    resetSubAgentsForm(data)
+  })
 
   const handleInvalidSubmit = (formErrors: FieldErrors<FormValues>) => {
     const firstErrorTab = pickTabForErrors(formErrors as Record<string, unknown>)
@@ -166,6 +193,9 @@ export function BaseAgentForm({
                 </TabsTrigger>
               )}
               {hasSources && <TabsTrigger value="sources">{t("agent:tabs.sources")}</TabsTrigger>}
+              {hasOrchestration && (
+                <TabsTrigger value="orchestration">{t("agent:tabs.orchestration")}</TabsTrigger>
+              )}
               {hasEmbed && <TabsTrigger value="embed">{t("agent:tabs.embed")}</TabsTrigger>}
             </TabsList>
 
@@ -493,9 +523,37 @@ export function BaseAgentForm({
                 <AgentEmbedTab agent={editableAgent} />
               </TabsContent>
             )}
+            {hasOrchestration && editableAgent && (
+              <TabsContent value="orchestration">
+                <Controller
+                  control={subAgentsControl}
+                  name="subAgents"
+                  render={({ field }) => (
+                    <AgentSubAgentsTab
+                      parentAgentId={editableAgent.id}
+                      agents={availableAgents}
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+              </TabsContent>
+            )}
           </Tabs>
 
-          {activeTab !== "embed" && (
+          {activeTab === "orchestration" && hasOrchestration && (
+            <Field orientation="horizontal" className="justify-end">
+              <Button
+                type="button"
+                className="w-fit"
+                onClick={handleOrchestrationSubmit}
+              >
+                {t("actions:update")}
+              </Button>
+            </Field>
+          )}
+
+          {activeTab !== "embed" && activeTab !== "orchestration" && (
             <Field orientation="horizontal" className="justify-end">
               <Button type="submit" className="w-fit">
                 {editableAgent ? t("actions:update") : t("actions:create")}

--- a/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
+++ b/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
@@ -43,8 +43,8 @@ import { AgentEmbedTab } from "@/studio/features/agent-embed-configs/components/
 import { getTagNameById } from "@/studio/features/document-tags/document-tags.helpers"
 import type { DocumentTag } from "@/studio/features/document-tags/document-tags.models"
 import { DocumentTagPicker } from "@/studio/features/documents/components/DocumentTagPicker"
-import { type AgentFormData, getDefaultFormValues } from "./agent-form.shared"
 import { type AgentSubAgentFormValue, AgentSubAgentsTab } from "./AgentSubAgentsTab"
+import { type AgentFormData, getDefaultFormValues } from "./agent-form.shared"
 
 const EMPTY_SUB_AGENTS: AgentSubAgentFormValue[] = []
 
@@ -543,11 +543,7 @@ export function BaseAgentForm({
 
           {activeTab === "orchestration" && hasOrchestration && (
             <Field orientation="horizontal" className="justify-end">
-              <Button
-                type="button"
-                className="w-fit"
-                onClick={handleOrchestrationSubmit}
-              >
+              <Button type="button" className="w-fit" onClick={handleOrchestrationSubmit}>
                 {t("actions:update")}
               </Button>
             </Field>

--- a/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
+++ b/apps/web/src/studio/features/agents/components/BaseAgentForm.tsx
@@ -153,7 +153,8 @@ export function BaseAgentForm({
   })()
 
   const hasEmbed = hasSources && !!editableAgent && hasFeature("agent-embed")
-  const hasOrchestration = hasSources && !!editableAgent && hasFeature("agent-orchestration")
+  const hasOrchestration =
+    hasSources && !!editableAgent && hasFeature("agent-orchestration") && !!onSubAgentsSubmit
 
   const [activeTab, setActiveTab] = useState<
     "general" | "model" | "output" | "sources" | "orchestration" | "embed"

--- a/apps/web/src/studio/routes/AgentEditorRoute.tsx
+++ b/apps/web/src/studio/routes/AgentEditorRoute.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { Grid, GridHeader } from "@/common/components/grid/Grid"
-import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
+import { selectAgentsData, selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
 import { selectCurrentProjectData } from "@/common/features/projects/projects.selectors"
 import { useGetAgentRoute } from "@/common/hooks/use-get-path"
 import { useMount } from "@/common/hooks/use-mount"
@@ -11,10 +11,14 @@ import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
 import { selectAgentSubAgentsData } from "@/studio/features/agent-sub-agents/agent-sub-agents.selectors"
 import { agentSubAgentsActions } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
-import { AgentEditor } from "@/studio/features/agents/components/AgentEditor"
+import {
+  AgentEditor,
+  type AgentEditorOrchestration,
+} from "@/studio/features/agents/components/AgentEditor"
 
 export function AgentEditorRoute() {
   const agent = useAppSelector(selectCurrentAgentData)
+  const agents = useAppSelector(selectAgentsData)
   const project = useAppSelector(selectCurrentProjectData)
   const subAgents = useAppSelector(selectAgentSubAgentsData)
   const hasOrchestration =
@@ -27,8 +31,8 @@ export function AgentEditorRoute() {
 
   if (hasOrchestration) {
     return (
-      <AsyncRoute data={[agent, subAgents]}>
-        <WithData />
+      <AsyncRoute data={[agent, agents, subAgents]}>
+        <WithOrchestrationData />
       </AsyncRoute>
     )
   }
@@ -40,7 +44,13 @@ export function AgentEditorRoute() {
   )
 }
 
-function WithData() {
+function WithOrchestrationData() {
+  const agents = useValue(selectAgentsData)
+  const subAgents = useValue(selectAgentSubAgentsData)
+  return <WithData orchestration={{ agents, subAgents }} />
+}
+
+function WithData({ orchestration }: { orchestration?: AgentEditorOrchestration }) {
   const agent = useValue(selectCurrentAgentData)
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -54,7 +64,12 @@ function WithData() {
         title={t(`agent:update.${agent.type}.title`)}
         description={t(`agent:update.${agent.type}.description`)}
       />
-      <AgentEditor key={agent.id} agent={agent} className="bg-white p-6" />
+      <AgentEditor
+        key={agent.id}
+        agent={agent}
+        className="bg-white p-6"
+        orchestration={orchestration}
+      />
     </Grid>
   )
 }

--- a/apps/web/src/studio/routes/AgentEditorRoute.tsx
+++ b/apps/web/src/studio/routes/AgentEditorRoute.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
+import { Grid, GridHeader } from "@/common/components/grid/Grid"
+import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
+import { selectCurrentProjectData } from "@/common/features/projects/projects.selectors"
+import { useGetAgentRoute } from "@/common/hooks/use-get-path"
+import { useMount } from "@/common/hooks/use-mount"
+import { useValue } from "@/common/hooks/use-value"
+import { AsyncRoute } from "@/common/routes/AsyncRoute"
+import { ADS } from "@/common/store/async-data-status"
+import { useAppSelector } from "@/common/store/hooks"
+import { selectAgentSubAgentsData } from "@/studio/features/agent-sub-agents/agent-sub-agents.selectors"
+import { agentSubAgentsActions } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
+import { AgentEditor } from "@/studio/features/agents/components/AgentEditor"
+
+export function AgentEditorRoute() {
+  const agent = useAppSelector(selectCurrentAgentData)
+  const project = useAppSelector(selectCurrentProjectData)
+  const subAgents = useAppSelector(selectAgentSubAgentsData)
+  const hasOrchestration =
+    ADS.isFulfilled(agent) &&
+    agent.value.type === "conversation" &&
+    ADS.isFulfilled(project) &&
+    project.value.featureFlags.includes("agent-orchestration")
+
+  useMount({ actions: agentSubAgentsActions, condition: hasOrchestration })
+
+  if (hasOrchestration) {
+    return (
+      <AsyncRoute data={[agent, subAgents]}>
+        <WithData />
+      </AsyncRoute>
+    )
+  }
+
+  return (
+    <AsyncRoute data={[agent]}>
+      <WithData />
+    </AsyncRoute>
+  )
+}
+
+function WithData() {
+  const agent = useValue(selectCurrentAgentData)
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const agentRoute = useGetAgentRoute()
+  const handleBack = () => navigate(agentRoute)
+
+  return (
+    <Grid cols={0} total={0}>
+      <GridHeader
+        onBack={handleBack}
+        title={t(`agent:update.${agent.type}.title`)}
+        description={t(`agent:update.${agent.type}.description`)}
+      />
+      <AgentEditor key={agent.id} agent={agent} className="bg-white p-6" />
+    </Grid>
+  )
+}

--- a/apps/web/src/studio/routes/StudioRoutes.tsx
+++ b/apps/web/src/studio/routes/StudioRoutes.tsx
@@ -19,6 +19,7 @@ import { CampaignsRoute } from "@/studio/routes/CampaignsRoute"
 import { StudioLayout } from "../components/StudioLayout"
 import { AgentList } from "../features/analytics/agent/components/AgentList"
 import { AgentAnalyticsRoute } from "./AgentAnalyticsRoute"
+import { AgentEditorRoute } from "./AgentEditorRoute"
 import { AgentMembershipsRoute } from "./AgentMembershipsRoute"
 import { ProjectDocumentsRoute, WebSourcesDocumentsRoute } from "./DocumentsRoute"
 import { EvaluationRoute } from "./EvaluationRoute"
@@ -117,6 +118,10 @@ export const studioRoutes = {
             {
               element: <RestrictedAccess ability="canManageAgent" />,
               children: [
+                {
+                  path: StudioRoutes.agentEdit.path,
+                  element: <AgentEditorRoute />,
+                },
                 {
                   path: StudioRoutes.agentAnalytics.path,
                   element: (

--- a/apps/web/src/studio/routes/helpers.ts
+++ b/apps/web/src/studio/routes/helpers.ts
@@ -18,6 +18,7 @@ const reviewCampaignReport = reviewCampaigns.extend("/:reviewCampaignId/report")
 
 // AGENT-LEVEL
 const agentSession = agent.extend("/as/:agentSessionId")
+const agentEdit = agent.extend("/edit")
 const feedback = agent.extend("/f")
 const agentMemberships = agent.extend("/members")
 const agentAnalytics = agent.extend("/analytics")
@@ -25,6 +26,7 @@ const agentAnalytics = agent.extend("/analytics")
 export const StudioRoutes = {
   agent,
   agentAnalytics,
+  agentEdit,
   agentMemberships,
   agentSession,
   document,

--- a/apps/web/src/studio/store/slices.ts
+++ b/apps/web/src/studio/store/slices.ts
@@ -14,6 +14,8 @@ import { agentMembershipsMiddleware } from "@/studio/features/agent-memberships/
 import { agentMembershipsSlice } from "@/studio/features/agent-memberships/agent-memberships.slice"
 import { agentMessageFeedbackMiddleware } from "@/studio/features/agent-message-feedback/agent-message-feedback.middleware"
 import { agentMessageFeedbackSlice } from "@/studio/features/agent-message-feedback/agent-message-feedback.slice"
+import { agentSubAgentsMiddleware } from "@/studio/features/agent-sub-agents/agent-sub-agents.middleware"
+import { agentSubAgentsSlice } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
 import { agentAnalyticsMiddleware } from "@/studio/features/analytics/agent/agent-analytics.middleware"
 import { agentAnalyticsSlice } from "@/studio/features/analytics/agent/agent-analytics.slice"
 import { projectAnalyticsMiddleware } from "@/studio/features/analytics/project/analytics.middleware"
@@ -42,6 +44,7 @@ const studioMiddlewareList = [
   agentEmbedConfigsMiddleware,
   agentMembershipsMiddleware,
   agentMessageFeedbackMiddleware,
+  agentSubAgentsMiddleware,
   agentSessionMessagesMiddleware,
   agentsMiddleware,
   baseAgentSessionsMiddleware,
@@ -63,6 +66,7 @@ export const studioSliceList = [
   agentEmbedConfigsSlice,
   agentMembershipsSlice,
   agentMessageFeedbackSlice,
+  agentSubAgentsSlice,
   agentSessionMessagesSlice,
   agentsSlice,
   conversationAgentSessionsSlice,

--- a/packages/api-contracts/src/agents/agents.dto.ts
+++ b/packages/api-contracts/src/agents/agents.dto.ts
@@ -4,7 +4,7 @@ import {
   documentTagSchema,
   updateDocumentTagsSchema,
 } from "../document-tags/document-tag.dto"
-import { timeTypeSchema, type TimeType } from "../generic"
+import { type TimeType, timeTypeSchema } from "../generic"
 
 export enum AgentModel {
   Gemini25Flash = "gemini-2.5-flash",

--- a/packages/api-contracts/src/agents/agents.dto.ts
+++ b/packages/api-contracts/src/agents/agents.dto.ts
@@ -4,7 +4,7 @@ import {
   documentTagSchema,
   updateDocumentTagsSchema,
 } from "../document-tags/document-tag.dto"
-import type { TimeType } from "../generic"
+import { timeTypeSchema, type TimeType } from "../generic"
 
 export enum AgentModel {
   Gemini25Flash = "gemini-2.5-flash",
@@ -109,6 +109,48 @@ const agentValidationSchema = z.object({
 
 export type AgentType = z.infer<typeof agentValidationSchema.shape.type>
 export type AgentTemperature = z.infer<typeof agentValidationSchema.shape.temperature>
+
+const agentSubAgentToolNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[a-zA-Z0-9_-]+$/, {
+    message: "Tool name can only contain letters, numbers, underscores, and hyphens",
+  })
+
+const replaceAgentSubAgentSchema = z.object({
+  childAgentId: z.string().uuid(),
+  toolName: agentSubAgentToolNameSchema,
+  description: z.string().trim().max(2000).default(""),
+  enabled: z.boolean(),
+})
+
+export const replaceAgentSubAgentsSchema = z.object({
+  subAgents: z.array(replaceAgentSubAgentSchema).max(20),
+})
+
+export const agentSubAgentSchema = z.object({
+  id: z.string().uuid(),
+  parentAgentId: z.string().uuid(),
+  childAgentId: z.string().uuid(),
+  toolName: z.string(),
+  description: z.string(),
+  enabled: z.boolean(),
+  childAgent: z
+    .object({
+      id: z.string().uuid(),
+      name: z.string(),
+      type: agentValidationSchema.shape.type,
+    })
+    .optional(),
+  createdAt: timeTypeSchema,
+  updatedAt: timeTypeSchema,
+})
+
+export type ReplaceAgentSubAgentDto = z.infer<typeof replaceAgentSubAgentSchema>
+export type ReplaceAgentSubAgentsDto = z.infer<typeof replaceAgentSubAgentsSchema>
+export type AgentSubAgentDto = z.infer<typeof agentSubAgentSchema>
 
 const refineOutputJsonSchema = {
   fn: (data: Partial<AgentDto>) =>

--- a/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
+++ b/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
@@ -7,6 +7,8 @@ export enum ToolName {
   McpSmartSearch = "smart_search",
 }
 
+export type AgentSessionToolName = ToolName | (string & {})
+
 export type AgentSessionMessageDto = {
   id: string
   role: "user" | "assistant" | "tool"
@@ -18,7 +20,7 @@ export type AgentSessionMessageDto = {
   completedAt?: string
   toolCalls?: Array<{
     id: string
-    name: ToolName
+    name: AgentSessionToolName
     arguments: Record<string, unknown>
   }>
 }
@@ -47,7 +49,7 @@ export type PresignAgentSessionMessageAttachmentDocumentResponseDto = {
 export type StreamEventPayload =
   | { type: "start"; messageId: string }
   | { type: "chunk"; content: string; messageId: string }
-  | { type: "notify_client"; toolName: ToolName }
+  | { type: "notify_client"; toolName: AgentSessionToolName }
   | { type: "end"; messageId: string; fullContent: string }
   | { type: "error"; messageId: string; error: string }
 

--- a/packages/api-contracts/src/agents/sub-agents/agent-sub-agents.routes.ts
+++ b/packages/api-contracts/src/agents/sub-agents/agent-sub-agents.routes.ts
@@ -1,0 +1,17 @@
+import type { RequestPayload, ResponseData } from "../../generic"
+import { defineRoute } from "../../helpers"
+import type { AgentSubAgentDto, ReplaceAgentSubAgentsDto } from "../agents.dto"
+
+export const AgentSubAgentsRoutes = {
+  getAll: defineRoute<ResponseData<AgentSubAgentDto[]>>({
+    method: "get",
+    path: "organizations/:organizationId/projects/:projectId/agents/:agentId/sub-agents",
+  }),
+  updateAll: defineRoute<
+    ResponseData<AgentSubAgentDto[]>,
+    RequestPayload<ReplaceAgentSubAgentsDto>
+  >({
+    method: "put",
+    path: "organizations/:organizationId/projects/:projectId/agents/:agentId/sub-agents",
+  }),
+}

--- a/packages/api-contracts/src/feature-flags/feature-flags.dto.ts
+++ b/packages/api-contracts/src/feature-flags/feature-flags.dto.ts
@@ -1,33 +1,46 @@
+type ValidFeatureFlagKey<Key extends string> = Key extends `${string}_${string}` ? never : Key
+
+function featureFlag<Key extends string>(flag: {
+  key: ValidFeatureFlagKey<Key>
+  description: string
+}) {
+  return flag
+}
+
 export const FeatureFlags = [
-  {
+  featureFlag({
     key: "evaluation",
     description:
       "Evaluate the performance of your agents with a set of pre-defined evaluation tasks",
-  },
-  {
+  }),
+  featureFlag({
     key: "sources-tool",
     description: "Access and utilize the sources tool.",
-  },
-  {
+  }),
+  featureFlag({
     key: "gemma",
     description: "Access and utilize gemma models.",
-  },
-  {
+  }),
+  featureFlag({
     key: "medgemma",
     description: "Access and utilize medgemma models.",
-  },
-  {
+  }),
+  featureFlag({
     key: "project-analytics",
     description: "View project-level analytics and usage charts in the studio.",
-  },
-  {
+  }),
+  featureFlag({
     key: "web-sources",
     description: "Crawl a website and index its pages as documents.",
-  },
-  {
+  }),
+  featureFlag({
     key: "agent-embed",
     description: "Embed conversation agents as a chat widget on external websites.",
-  },
+  }),
+  featureFlag({
+    key: "agent-orchestration",
+    description: "Compose conversation agents with sub-agents.",
+  }),
 ] as const
 export type FeatureFlagKey = (typeof FeatureFlags)[number]["key"]
 export type FeatureFlagsDto = FeatureFlagKey[]

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -13,6 +13,8 @@ export { AgentMessageFeedbackRoutes } from "./agent-message-feedback/agent-messa
 // Agent
 export * from "./agents/agents.dto"
 export { AgentsRoutes } from "./agents/agents.routes"
+// Agent Sub-Agents
+export { AgentSubAgentsRoutes } from "./agents/sub-agents/agent-sub-agents.routes"
 // Conversation Agent Sessions
 export type * from "./agents/conversation-agent-sessions/conversation-agent-sessions.dto"
 export { ConversationAgentSessionsRoutes } from "./agents/conversation-agent-sessions/conversation-agent-sessions.routes"

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -13,8 +13,6 @@ export { AgentMessageFeedbackRoutes } from "./agent-message-feedback/agent-messa
 // Agent
 export * from "./agents/agents.dto"
 export { AgentsRoutes } from "./agents/agents.routes"
-// Agent Sub-Agents
-export { AgentSubAgentsRoutes } from "./agents/sub-agents/agent-sub-agents.routes"
 // Conversation Agent Sessions
 export type * from "./agents/conversation-agent-sessions/conversation-agent-sessions.dto"
 export { ConversationAgentSessionsRoutes } from "./agents/conversation-agent-sessions/conversation-agent-sessions.routes"
@@ -27,6 +25,8 @@ export { FormAgentSessionsRoutes } from "./agents/form-agent-sessions/form-agent
 // Agent Session Messages
 export * from "./agents/shared/agent-session-messages/agent-session-messages.dto"
 export { AgentSessionMessagesRoutes } from "./agents/shared/agent-session-messages/agent-session-messages.routes"
+// Agent Sub-Agents
+export { AgentSubAgentsRoutes } from "./agents/sub-agents/agent-sub-agents.routes"
 // Analytics
 export type * from "./analytics/analytics.dto"
 export { AgentAnalyticsRoutes, AnalyticsRoutes } from "./analytics/analytics.routes"


### PR DESCRIPTION
## Summary
- Add sub-agents as a configurable capability for conversation agents, with API contracts, persistence, migrations, and backend validation.
- Wire sub-agent tools into conversation streaming so enabled sub-agents can be delegated to at runtime behind the `agent-orchestration` feature flag.
- Update the Studio agent editor to manage sub-agents, with stories, locale strings, and the new route flow.
- Document the change in the changelog and standardize semantic commit guidance in repo instructions.

## Testing
- API and shared contract typechecks passed.
- Focused backend specs passed for sub-agent tool exposure and sub-agent service behavior.
- Parallel test execution was validated through the repo worker-database runner.
- Web and web-embed typechecks passed.