### PR TITLE
fix: pin transformers<5.0.0 in workers docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -83,7 +83,7 @@ RUN python3 -m venv /opt/docling-venv \
     --index-url https://download.pytorch.org/whl/cu121 \
     torch==2.5.1 \
     torchvision==0.20.1 \
-  && /opt/docling-venv/bin/pip install --no-cache-dir docling \
+  && /opt/docling-venv/bin/pip install --no-cache-dir docling "transformers>=4.34.0,<5.0.0" \
   && /opt/docling-venv/bin/pip install --no-cache-dir \
     llama-index-core \
     llama-index-readers-docling \


### PR DESCRIPTION
This was causing the following error in infra -> https://github.com/bayesimpact/infra/actions/runs/26908223254/job/79380072657