### PR TITLE
core: select worker queues per instance and split worker images

### DIFF
--- a/.claude/skills/security-check/skill.md
+++ b/.claude/skills/security-check/skill.md
@@ -1,6 +1,6 @@
 ---
 name: security-check
-description: Run Trivy vulnerability scan on Docker images (API and Workers). Builds images, scans for CRITICAL/HIGH CVEs, and reports findings.
+description: Run Trivy vulnerability scan on Docker images (API, CPU workers, GPU workers). Builds images, scans for CRITICAL/HIGH CVEs, and reports findings.
 user_invocable: true
 ---
 
@@ -9,8 +9,8 @@ Run a local Trivy security scan matching the CI pipeline configuration.
 ## Steps
 
 1. Run `make trivy-scan` from the repo root using the Bash tool. This will:
-   - Build the Docker images (`caseai-connect/api:local` and `caseai-connect/workers:local`)
-   - Scan both images with Trivy for CRITICAL and HIGH vulnerabilities
+   - Build the Docker images (`caseai-connect/api:local`, `caseai-connect/cpu-workers:local`, and `caseai-connect/gpu-workers:local`)
+   - Scan all three images with Trivy for CRITICAL and HIGH vulnerabilities
    - Apply `.trivyignore.yaml` exclusions
 
 2. If the scan **passes** (exit code 0): report that no unignored CRITICAL/HIGH vulnerabilities were found.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,18 +43,31 @@ jobs:
           trivyignores: '.trivyignore.yaml'
           output: 'trivy-api-results.txt'
 
-      - name: Run Trivy vulnerability scanner on Workers
+      - name: Run Trivy vulnerability scanner on CPU Workers
         if: always()
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: 'caseai-connect/workers:local'
+          image-ref: 'caseai-connect/cpu-workers:local'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
           pkg-types: 'os,library'
           severity: 'CRITICAL,HIGH'
           trivyignores: '.trivyignore.yaml'
-          output: 'trivy-workers-results.txt'
+          output: 'trivy-cpu-workers-results.txt'
+
+      - name: Run Trivy vulnerability scanner on GPU Workers
+        if: always()
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: 'caseai-connect/gpu-workers:local'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          pkg-types: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
+          output: 'trivy-gpu-workers-results.txt'
 
       - name: Trivy scan summary
         if: always()
@@ -78,5 +91,6 @@ jobs:
           {
             echo "## Trivy Vulnerability Scan Results"
             print_report "API Image" trivy-api-results.txt
-            print_report "Workers Image" trivy-workers-results.txt
+            print_report "CPU Workers Image" trivy-cpu-workers-results.txt
+            print_report "GPU Workers Image" trivy-gpu-workers-results.txt
           } >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - In-platform help chat: set `VITE_HELP_AGENT_EMBED_TOKEN` to inject the embed launcher into the Studio — a floating chat bubble lets users ask questions about the platform directly from within the app
 
 ### Changed
+- Workers can run as separate CPU and GPU pools: each worker instance now selects which queues it consumes via the required `WORKER_QUEUE_NAMES` env var (fails fast if unset or unknown), instead of every instance consuming all queues
+- Workers ship as two Docker images — a CPU image (no Docling) and a GPU image (Docling/Torch included) — built from the `cpu-workers-runtime` and `gpu-workers-runtime` targets
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ TEST_MCP_ENCRYPTION_KEY ?= 00000000000000000000000000000000000000000000000000000
 
 # Local image tags (no GCP references)
 localApiImage = caseai-connect/api:local
-localWorkersImage = caseai-connect/workers:local
+localCpuWorkersImage = caseai-connect/cpu-workers:local
+localGpuWorkersImage = caseai-connect/gpu-workers:local
 smokeComposeFile = infra/docker-compose.api-workers-smoke.yaml
+smokeEnv = API_IMAGE=${localApiImage} CPU_WORKERS_IMAGE=${localCpuWorkersImage} GPU_WORKERS_IMAGE=${localGpuWorkersImage}
 
 # ==============================================================================
 # Change Detection
@@ -64,15 +66,19 @@ check-web-changes:
 
 trivy-scan: docker-build
 	trivy image --ignore-unfixed --pkg-types os,library --severity CRITICAL,HIGH --ignorefile .trivyignore.yaml ${localApiImage}
-	trivy image --ignore-unfixed --pkg-types os,library --severity CRITICAL,HIGH --ignorefile .trivyignore.yaml ${localWorkersImage}
+	trivy image --ignore-unfixed --pkg-types os,library --severity CRITICAL,HIGH --ignorefile .trivyignore.yaml ${localCpuWorkersImage}
+	trivy image --ignore-unfixed --pkg-types os,library --severity CRITICAL,HIGH --ignorefile .trivyignore.yaml ${localGpuWorkersImage}
 
-docker-build: docker-build-api docker-build-workers
+docker-build: docker-build-api docker-build-cpu-workers docker-build-gpu-workers
 
 docker-build-api:
 	docker build --platform=linux/amd64 --target api-runtime -t ${localApiImage} -f apps/api/Dockerfile .
 
-docker-build-workers:
-	docker build --platform=linux/amd64 --target workers-runtime -t ${localWorkersImage} -f apps/api/Dockerfile .
+docker-build-cpu-workers:
+	docker build --platform=linux/amd64 --target cpu-workers-runtime -t ${localCpuWorkersImage} -f apps/api/Dockerfile .
+
+docker-build-gpu-workers:
+	docker build --platform=linux/amd64 --target gpu-workers-runtime -t ${localGpuWorkersImage} -f apps/api/Dockerfile .
 
 docker-check: docker-build-api
 	@echo "Starting docker container and checking for successful startup..."
@@ -95,12 +101,15 @@ docker-check: docker-build-api
 	docker kill $$CONTAINER_ID >/dev/null 2>&1; \
 	exit 1
 
-docker-workers-check: docker-build-workers
-	@echo "Starting docker workers with smoke dependencies and checking for successful startup..."
-	@API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} up -d postgres redis workers; \
-	CONTAINER_ID=$$(API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} ps -q workers); \
+# Smoke-tests both worker images. GPU must ship Docling; CPU must boot without it.
+docker-workers-check: docker-gpu-workers-check docker-cpu-workers-check
+
+docker-gpu-workers-check: docker-build-gpu-workers
+	@echo "Starting GPU workers (Docling) with smoke dependencies and checking for successful startup..."
+	@$(smokeEnv) docker compose -f ${smokeComposeFile} up -d postgres redis gpu-workers; \
+	CONTAINER_ID=$$($(smokeEnv) docker compose -f ${smokeComposeFile} ps -q gpu-workers); \
 	echo "Container ID: $$CONTAINER_ID"; \
-	echo "Verifying Docling CLI in workers container..."; \
+	echo "Verifying Docling CLI in GPU workers container..."; \
 	j=1; \
 	DOC_VERSION=""; \
 	while [ $$j -le 15 ]; do \
@@ -110,18 +119,18 @@ docker-workers-check: docker-build-workers
 			break; \
 		fi; \
 		if ! docker ps -q --no-trunc | grep -q "$$CONTAINER_ID"; then \
-			echo "✗ Workers container exited before Docling CLI check completed"; \
+			echo "✗ GPU workers container exited before Docling CLI check completed"; \
 			docker logs $$CONTAINER_ID 2>&1; \
-			API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+			$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
 			exit 1; \
 		fi; \
 		sleep 1; \
 		j=$$((j + 1)); \
 	done; \
 	if [ -z "$$DOC_VERSION" ]; then \
-		echo "✗ Docling CLI check failed in workers container"; \
+		echo "✗ Docling CLI check failed in GPU workers container"; \
 		docker logs $$CONTAINER_ID 2>&1; \
-		API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+		$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
 		exit 1; \
 	fi; \
 	i=1; \
@@ -130,38 +139,73 @@ docker-workers-check: docker-build-workers
 		LOGS=$$(docker logs $$CONTAINER_ID 2>&1); \
 		echo "$$LOGS"; \
 		if echo "$$LOGS" | grep -q "Workers app started"; then \
-			echo "✓ Docker workers container started successfully"; \
-			API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+			echo "✓ GPU workers container started successfully"; \
+			$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
 			exit 0; \
 		fi; \
 		sleep 1; \
 		i=$$((i + 1)); \
 	done; \
-	echo "✗ Failed to find 'Workers app started' in docker logs"; \
-	API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+	echo "✗ Failed to find 'Workers app started' in GPU workers logs"; \
+	$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+	exit 1
+
+docker-cpu-workers-check: docker-build-cpu-workers
+	@echo "Starting CPU workers (no Docling) with smoke dependencies and checking for successful startup..."
+	@$(smokeEnv) docker compose -f ${smokeComposeFile} up -d postgres redis cpu-workers; \
+	CONTAINER_ID=$$($(smokeEnv) docker compose -f ${smokeComposeFile} ps -q cpu-workers); \
+	echo "Container ID: $$CONTAINER_ID"; \
+	echo "Verifying Docling is absent from CPU workers container..."; \
+	if docker exec $$CONTAINER_ID sh -c 'command -v docling' >/dev/null 2>&1; then \
+		echo "✗ Docling unexpectedly present in CPU workers image"; \
+		$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+		exit 1; \
+	fi; \
+	echo "✓ Docling not installed in CPU workers image"; \
+	i=1; \
+	while [ $$i -le 45 ]; do \
+		echo "Checking logs (attempt $$i/45)..."; \
+		LOGS=$$(docker logs $$CONTAINER_ID 2>&1); \
+		echo "$$LOGS"; \
+		if echo "$$LOGS" | grep -q "Workers app started"; then \
+			echo "✓ CPU workers container started successfully"; \
+			$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+			exit 0; \
+		fi; \
+		if ! docker ps -q --no-trunc | grep -q "$$CONTAINER_ID"; then \
+			echo "✗ CPU workers container exited before startup completed"; \
+			docker logs $$CONTAINER_ID 2>&1; \
+			$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+		i=$$((i + 1)); \
+	done; \
+	echo "✗ Failed to find 'Workers app started' in CPU workers logs"; \
+	$(smokeEnv) docker compose -f ${smokeComposeFile} down -v >/dev/null 2>&1; \
 	exit 1
 
 docker-smoke-up: docker-build
-	API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} up -d --build
+	$(smokeEnv) docker compose -f ${smokeComposeFile} up -d --build
 
 docker-smoke-ps:
-	API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} ps
+	$(smokeEnv) docker compose -f ${smokeComposeFile} ps
 
 docker-smoke-logs:
-	API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} logs --tail=200 api workers postgres redis
+	$(smokeEnv) docker compose -f ${smokeComposeFile} logs --tail=200 api cpu-workers gpu-workers postgres redis
 
 docker-smoke-check: docker-smoke-up
 	@echo "Waiting for services to settle..."
 	@sleep 8
-	@API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} ps
-	@if API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} ps --status exited | grep -Eq "api|workers"; then \
+	@$(smokeEnv) docker compose -f ${smokeComposeFile} ps
+	@if $(smokeEnv) docker compose -f ${smokeComposeFile} ps --status exited | grep -Eq "api|workers"; then \
 		echo "✗ API or workers exited unexpectedly. Check logs with: make docker-smoke-logs"; \
 		exit 1; \
 	fi
 	@echo "✓ API and workers are still running"
 
 docker-smoke-down:
-	API_IMAGE=${localApiImage} WORKERS_IMAGE=${localWorkersImage} docker compose -f ${smokeComposeFile} down -v
+	$(smokeEnv) docker compose -f ${smokeComposeFile} down -v
 
 # ==============================================================================
 # Web-embed deployment

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ make docker-smoke-down PROJECT=connect REGION=eu
 Notes:
 
 - The smoke stack is defined in `infra/docker-compose.api-workers-smoke.yaml`.
-- API uses Docker target `api-runtime`; workers use `workers-runtime`.
+- API uses Docker target `api-runtime`; workers ship as two images — `cpu-workers-runtime` (no Docling) and `gpu-workers-runtime` (Docling). Both run the same entrypoint; queue selection is per-instance via `WORKER_QUEUE_NAMES`.
 - Smoke stack ports:
   - API: `http://localhost:3003`
   - Postgres: `localhost:55432`

--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -57,6 +57,16 @@ DOCUMENT_EMBEDDING_STUCK_SWEEP_INTERVAL_SECONDS=900
 # Optional override for the maintenance queue name (default: document-embeddings-stuck-sweep)
 # DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME=document-embeddings-stuck-sweep
 
+# Workers — which queues this process consumes (comma-separated). REQUIRED; the
+# process fails to start if unset or if a name is unknown. In production the GPU
+# and CPU instance types each set their own subset; locally we run a single
+# process that consumes every queue.
+WORKER_QUEUE_NAMES=evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling,document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings
+
+# Workers — which queue the /healthz Redis ping uses. REQUIRED; must be one of
+# the queues this instance consumes (see WORKER_QUEUE_NAMES).
+WORKERS_HEALTH_QUEUE_NAME=document-embeddings
+
 # MCP Server Encryption (64-char hex, 32 bytes)
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 MCP_ENCRYPTION_KEY=your-64-char-hex-key-here

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -59,9 +59,20 @@ FROM runtime-base AS api-runtime
 CMD ["node", "--enable-source-maps", "/app/apps/api/dist/main.js"]
 
 #
-# 🚀 Workers Runtime (Docling enabled)
+# 🚀 CPU Workers Runtime (no Docling)
 #
-FROM runtime-base AS workers-runtime
+# Runs the same workers entrypoint as the GPU image; which queues it consumes is
+# selected at runtime via WORKER_QUEUE_NAMES, and Docling is left disabled
+# (DOCUMENT_EXTRACTOR_DOCLING_ENABLED=false). No Python/Torch/Docling layers.
+#
+FROM runtime-base AS cpu-workers-runtime
+
+CMD ["node", "--enable-source-maps", "/app/apps/api/dist/workers-main.js"]
+
+#
+# 🚀 GPU Workers Runtime (Docling enabled)
+#
+FROM runtime-base AS gpu-workers-runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 python3-pip python3-venv \

--- a/apps/api/bin/docling_nodes.ps1
+++ b/apps/api/bin/docling_nodes.ps1
@@ -29,7 +29,7 @@ if (-not $PythonBin) {
     [Console]::Error.WriteLine("  - $PythonBinDocker")
     [Console]::Error.WriteLine("  - $PythonBinRepoWin")
     [Console]::Error.WriteLine("  - $PythonBinRepoUnix")
-    [Console]::Error.WriteLine("Create the repo venv (.venv) locally, or run inside the Docker workers-runtime image.")
+    [Console]::Error.WriteLine("Create the repo venv (.venv) locally, or run inside the Docker gpu-workers-runtime image.")
     exit 1
 }
 

--- a/apps/api/bin/document_chunker
+++ b/apps/api/bin/document_chunker
@@ -23,7 +23,7 @@ if [[ -z "${PYTHON_BIN}" || ! -x "${PYTHON_BIN}" ]]; then
   echo "Looked for:" >&2
   echo "  - ${PYTHON_BIN_DOCKER}" >&2
   echo "  - ${PYTHON_BIN_REPO}" >&2
-  echo "Create the repo venv (.venv) locally, or run inside the Docker workers-runtime image." >&2
+  echo "Create the repo venv (.venv) locally, or run inside the Docker gpu-workers-runtime image." >&2
   exit 1
 fi
 

--- a/apps/api/jest.setup-early.ts
+++ b/apps/api/jest.setup-early.ts
@@ -3,3 +3,9 @@
  * Prevents Bull Board `forFeature` from being registered without `forRoot` when `.env` / shell sets `BULL_BOARD_ENABLED`.
  */
 delete process.env.BULL_BOARD_ENABLED
+
+// Worker queue selection fails fast when unset (see worker-pools.ts). Provide
+// defaults so specs importing worker constants/modules don't throw at import.
+process.env.WORKER_QUEUE_NAMES ??=
+  "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling,document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings"
+process.env.WORKERS_HEALTH_QUEUE_NAME ??= "document-embeddings"

--- a/apps/api/src/common/workers-health/workers-health.constants.ts
+++ b/apps/api/src/common/workers-health/workers-health.constants.ts
@@ -1,0 +1,24 @@
+import { KNOWN_WORKER_QUEUE_NAMES } from "@/worker-pools"
+
+const WORKERS_HEALTH_QUEUE_NAME_ENV = "WORKERS_HEALTH_QUEUE_NAME"
+
+function resolveWorkersHealthQueueName(): string {
+  const queueName = process.env[WORKERS_HEALTH_QUEUE_NAME_ENV]
+  if (!queueName) {
+    throw new Error(
+      `${WORKERS_HEALTH_QUEUE_NAME_ENV} must be set to one of the queues this instance consumes. ` +
+        `Valid queues: ${KNOWN_WORKER_QUEUE_NAMES.join(", ")}.`,
+    )
+  }
+
+  if (!KNOWN_WORKER_QUEUE_NAMES.includes(queueName)) {
+    throw new Error(
+      `${WORKERS_HEALTH_QUEUE_NAME_ENV}="${queueName}" is not a known queue. ` +
+        `Valid queues: ${KNOWN_WORKER_QUEUE_NAMES.join(", ")}.`,
+    )
+  }
+
+  return queueName
+}
+
+export const WORKERS_HEALTH_QUEUE_NAME = resolveWorkersHealthQueueName()

--- a/apps/api/src/common/workers-health/workers-health.controller.spec.ts
+++ b/apps/api/src/common/workers-health/workers-health.controller.spec.ts
@@ -4,7 +4,7 @@ import { Test } from "@nestjs/testing"
 import { getDataSourceToken } from "@nestjs/typeorm"
 import request from "supertest"
 import type { App } from "supertest/types"
-import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "@/domains/documents/embeddings/document-embeddings.constants"
+import { WORKERS_HEALTH_QUEUE_NAME } from "./workers-health.constants"
 import { WorkersHealthController } from "./workers-health.controller"
 
 describe("WorkersHealthController", () => {
@@ -22,7 +22,7 @@ describe("WorkersHealthController", () => {
       controllers: [WorkersHealthController],
       providers: [
         { provide: getDataSourceToken(), useValue: dataSource },
-        { provide: getQueueToken(DOCUMENT_EMBEDDINGS_QUEUE_NAME), useValue: queue },
+        { provide: getQueueToken(WORKERS_HEALTH_QUEUE_NAME), useValue: queue },
       ],
     }).compile()
     app = module.createNestApplication()

--- a/apps/api/src/common/workers-health/workers-health.controller.ts
+++ b/apps/api/src/common/workers-health/workers-health.controller.ts
@@ -3,7 +3,7 @@ import { Controller, Get, HttpException, HttpStatus, Logger } from "@nestjs/comm
 import { InjectDataSource } from "@nestjs/typeorm"
 import type { Queue } from "bullmq"
 import type { DataSource } from "typeorm"
-import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "@/domains/documents/embeddings/document-embeddings.constants"
+import { WORKERS_HEALTH_QUEUE_NAME } from "./workers-health.constants"
 
 type CheckResult = { ok: true } | { ok: false; error: string }
 
@@ -13,7 +13,7 @@ export class WorkersHealthController {
 
   constructor(
     @InjectDataSource() private readonly dataSource: DataSource,
-    @InjectQueue(DOCUMENT_EMBEDDINGS_QUEUE_NAME) private readonly bullmqQueue: Queue,
+    @InjectQueue(WORKERS_HEALTH_QUEUE_NAME) private readonly bullmqQueue: Queue,
   ) {}
 
   @Get()

--- a/apps/api/src/common/workers-health/workers-health.module.ts
+++ b/apps/api/src/common/workers-health/workers-health.module.ts
@@ -1,12 +1,12 @@
 import { BullModule } from "@nestjs/bullmq"
 import { Module } from "@nestjs/common"
-import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "@/domains/documents/embeddings/document-embeddings.constants"
+import { WORKERS_HEALTH_QUEUE_NAME } from "./workers-health.constants"
 import { WorkersHealthController } from "./workers-health.controller"
 
 @Module({
   imports: [
     BullModule.registerQueue({
-      name: DOCUMENT_EMBEDDINGS_QUEUE_NAME,
+      name: WORKERS_HEALTH_QUEUE_NAME,
     }),
   ],
   controllers: [WorkersHealthController],

--- a/apps/api/src/worker-pools.spec.ts
+++ b/apps/api/src/worker-pools.spec.ts
@@ -1,0 +1,43 @@
+import {
+  KNOWN_WORKER_QUEUE_NAMES,
+  parseEnabledWorkerQueueNames,
+  WORKER_QUEUE_NAMES_ENV,
+} from "./worker-pools"
+
+describe("parseEnabledWorkerQueueNames", () => {
+  const originalValue = process.env[WORKER_QUEUE_NAMES_ENV]
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[WORKER_QUEUE_NAMES_ENV]
+    } else {
+      process.env[WORKER_QUEUE_NAMES_ENV] = originalValue
+    }
+  })
+
+  it("throws when the env var is unset", () => {
+    delete process.env[WORKER_QUEUE_NAMES_ENV]
+    expect(() => parseEnabledWorkerQueueNames()).toThrow(WORKER_QUEUE_NAMES_ENV)
+  })
+
+  it("throws when the env var is empty or only separators", () => {
+    process.env[WORKER_QUEUE_NAMES_ENV] = " , , "
+    expect(() => parseEnabledWorkerQueueNames()).toThrow(WORKER_QUEUE_NAMES_ENV)
+  })
+
+  it("throws and names the offending queue when an unknown queue is listed", () => {
+    process.env[WORKER_QUEUE_NAMES_ENV] = `${KNOWN_WORKER_QUEUE_NAMES[0]},not-a-real-queue`
+    expect(() => parseEnabledWorkerQueueNames()).toThrow("not-a-real-queue")
+  })
+
+  it("trims whitespace and drops empty entries from a valid list", () => {
+    const [first, second] = KNOWN_WORKER_QUEUE_NAMES
+    process.env[WORKER_QUEUE_NAMES_ENV] = `  ${first} , ${second} ,`
+    expect(parseEnabledWorkerQueueNames()).toEqual([first, second])
+  })
+
+  it("returns every known queue when all are listed", () => {
+    process.env[WORKER_QUEUE_NAMES_ENV] = KNOWN_WORKER_QUEUE_NAMES.join(",")
+    expect(parseEnabledWorkerQueueNames()).toEqual([...KNOWN_WORKER_QUEUE_NAMES])
+  })
+})

--- a/apps/api/src/worker-pools.ts
+++ b/apps/api/src/worker-pools.ts
@@ -1,0 +1,65 @@
+import {
+  AGENT_CSV_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  AGENT_CSV_EXTRACTION_RUN_QUEUE_NAME,
+} from "./domains/agents/csv-extraction-runs/agent-csv-extraction-run.constants"
+import { URL_CRAWLING_QUEUE_NAME } from "./domains/documents/crawling/url-crawling.constants"
+import { WEB_SOURCE_EMBEDDINGS_QUEUE_NAME } from "./domains/documents/crawling/web-source-embeddings.constants"
+import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "./domains/documents/embeddings/document-embeddings.constants"
+import { DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME } from "./domains/documents/embeddings/document-embeddings-stuck.constants"
+import {
+  EVALUATION_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  EVALUATION_EXTRACTION_RUN_QUEUE_NAME,
+} from "./domains/evaluations/extraction/runs/evaluation-extraction-run.constants"
+
+/**
+ * Every queue a worker process can consume. Built from the queue-name
+ * constants (not literals) so a deployment overriding a queue name keeps this
+ * list in sync with the modules that register the queues.
+ */
+export const KNOWN_WORKER_QUEUE_NAMES: readonly string[] = [
+  EVALUATION_EXTRACTION_RUN_QUEUE_NAME,
+  EVALUATION_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  AGENT_CSV_EXTRACTION_RUN_QUEUE_NAME,
+  AGENT_CSV_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  URL_CRAWLING_QUEUE_NAME,
+  DOCUMENT_EMBEDDINGS_QUEUE_NAME,
+  DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME,
+  WEB_SOURCE_EMBEDDINGS_QUEUE_NAME,
+]
+
+export const WORKER_QUEUE_NAMES_ENV = "WORKER_QUEUE_NAMES"
+
+/**
+ * Parse the comma-separated list of queue names this instance should consume,
+ * supplied via the `WORKER_QUEUE_NAMES` env var. Production runs two instance
+ * types (GPU / CPU); each sets this var to the subset of queues it owns.
+ *
+ * Fails fast (throws) when the var is missing/empty or names an unknown queue,
+ * so a misconfigured instance never silently consumes the wrong queues.
+ */
+export function parseEnabledWorkerQueueNames(): string[] {
+  const rawValue = process.env[WORKER_QUEUE_NAMES_ENV]
+  const queueNames = (rawValue ?? "")
+    .split(",")
+    .map((queueName) => queueName.trim())
+    .filter((queueName) => queueName.length > 0)
+
+  if (queueNames.length === 0) {
+    throw new Error(
+      `${WORKER_QUEUE_NAMES_ENV} must be set to a comma-separated list of queue names. ` +
+        `Valid queues: ${KNOWN_WORKER_QUEUE_NAMES.join(", ")}.`,
+    )
+  }
+
+  const unknownQueueNames = queueNames.filter(
+    (queueName) => !KNOWN_WORKER_QUEUE_NAMES.includes(queueName),
+  )
+  if (unknownQueueNames.length > 0) {
+    throw new Error(
+      `${WORKER_QUEUE_NAMES_ENV} contains unknown queue names: ${unknownQueueNames.join(", ")}. ` +
+        `Valid queues: ${KNOWN_WORKER_QUEUE_NAMES.join(", ")}.`,
+    )
+  }
+
+  return queueNames
+}

--- a/apps/api/src/workers-app.module.ts
+++ b/apps/api/src/workers-app.module.ts
@@ -1,16 +1,63 @@
 import { BullModule } from "@nestjs/bullmq"
-import { Module } from "@nestjs/common"
+import { Module, type Type } from "@nestjs/common"
 import { ConfigModule, ConfigService } from "@nestjs/config"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { getBullMqConnection } from "./bullmq.config"
 import { WorkersHealthModule } from "./common/workers-health/workers-health.module"
 import typeorm from "./config/typeorm"
+import {
+  AGENT_CSV_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  AGENT_CSV_EXTRACTION_RUN_QUEUE_NAME,
+} from "./domains/agents/csv-extraction-runs/agent-csv-extraction-run.constants"
 import { AgentCsvExtractionRunWorkersModule } from "./domains/agents/csv-extraction-runs/agent-csv-extraction-run-workers.module"
+import { URL_CRAWLING_QUEUE_NAME } from "./domains/documents/crawling/url-crawling.constants"
 import { UrlCrawlingWorkersModule } from "./domains/documents/crawling/url-crawling-workers.module"
+import { WEB_SOURCE_EMBEDDINGS_QUEUE_NAME } from "./domains/documents/crawling/web-source-embeddings.constants"
 import { WebSourceEmbeddingsWorkersModule } from "./domains/documents/crawling/web-source-embeddings-workers.module"
+import { DOCUMENT_EMBEDDINGS_QUEUE_NAME } from "./domains/documents/embeddings/document-embeddings.constants"
+import { DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME } from "./domains/documents/embeddings/document-embeddings-stuck.constants"
 import { DocumentEmbeddingsWorkersModule } from "./domains/documents/embeddings/document-embeddings-workers.module"
 import { StorageModule } from "./domains/documents/storage/storage.module"
+import {
+  EVALUATION_EXTRACTION_RUN_EXECUTE_QUEUE_NAME,
+  EVALUATION_EXTRACTION_RUN_QUEUE_NAME,
+} from "./domains/evaluations/extraction/runs/evaluation-extraction-run.constants"
 import { EvaluationExtractionRunWorkersModule } from "./domains/evaluations/extraction/runs/evaluation-extraction-run-workers.module"
+import { parseEnabledWorkerQueueNames } from "./worker-pools"
+
+/**
+ * Maps each worker module to the queues it owns. A module's `@Processor`s start
+ * consuming as soon as the module is imported, so selection happens per-module:
+ * a module is loaded when any of its queues is in the enabled set. Queues listed
+ * together always travel together (they belong to the same module).
+ */
+const WORKER_MODULE_REGISTRY: { module: Type<unknown>; queues: string[] }[] = [
+  {
+    module: EvaluationExtractionRunWorkersModule,
+    queues: [EVALUATION_EXTRACTION_RUN_QUEUE_NAME, EVALUATION_EXTRACTION_RUN_EXECUTE_QUEUE_NAME],
+  },
+  {
+    module: AgentCsvExtractionRunWorkersModule,
+    queues: [AGENT_CSV_EXTRACTION_RUN_QUEUE_NAME, AGENT_CSV_EXTRACTION_RUN_EXECUTE_QUEUE_NAME],
+  },
+  {
+    module: UrlCrawlingWorkersModule,
+    queues: [URL_CRAWLING_QUEUE_NAME],
+  },
+  {
+    module: DocumentEmbeddingsWorkersModule,
+    queues: [DOCUMENT_EMBEDDINGS_QUEUE_NAME, DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME],
+  },
+  {
+    module: WebSourceEmbeddingsWorkersModule,
+    queues: [WEB_SOURCE_EMBEDDINGS_QUEUE_NAME],
+  },
+]
+
+const enabledQueueNames = new Set(parseEnabledWorkerQueueNames())
+const enabledWorkerModules = WORKER_MODULE_REGISTRY.filter((entry) =>
+  entry.queues.some((queue) => enabledQueueNames.has(queue)),
+).map((entry) => entry.module)
 
 @Module({
   imports: [
@@ -29,11 +76,7 @@ import { EvaluationExtractionRunWorkersModule } from "./domains/evaluations/extr
         connection: getBullMqConnection(),
       }),
     }),
-    DocumentEmbeddingsWorkersModule,
-    AgentCsvExtractionRunWorkersModule,
-    EvaluationExtractionRunWorkersModule,
-    UrlCrawlingWorkersModule,
-    WebSourceEmbeddingsWorkersModule,
+    ...enabledWorkerModules,
     StorageModule,
     WorkersHealthModule,
   ],

--- a/docs/monthly-dependency-check.md
+++ b/docs/monthly-dependency-check.md
@@ -81,7 +81,7 @@ make docker-build
 make trivy-scan
 ```
 
-`make trivy-scan` runs trivy against both `caseai-connect/api:local` and `caseai-connect/workers:local` images with:
+`make trivy-scan` runs trivy against the `caseai-connect/api:local`, `caseai-connect/cpu-workers:local`, and `caseai-connect/gpu-workers:local` images with:
 - `--ignore-unfixed` — only report CVEs that have a fix available
 - `--pkg-types os,library` — scan OS packages and language libraries
 - `--severity CRITICAL,HIGH` — ignore low/medium findings

--- a/infra/docker-compose.api-workers-smoke.yaml
+++ b/infra/docker-compose.api-workers-smoke.yaml
@@ -60,12 +60,48 @@ services:
       - "3003:3000"
     restart: "no"
 
-  workers:
-    image: ${WORKERS_IMAGE:-agentstudio-workers-smoke:latest}
+  # CPU pool: no Docling, consumes the LLM/extraction/crawling queues.
+  cpu-workers:
+    image: ${CPU_WORKERS_IMAGE:-agentstudio-cpu-workers-smoke:latest}
     build:
       context: ..
       dockerfile: apps/api/Dockerfile
-      target: workers-runtime
+      target: cpu-workers-runtime
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://connect_admin:passpass@postgres:5432/connect
+      BULLMQ_REDIS_URL: redis://redis:6379
+      AUTH0_ISSUER_URL: https://example.auth0.com/
+      AUTH0_AUDIENCE: https://example.auth0.com/api/v2/
+      AUTH0_ORGANIZATION_ID: org_example
+      AUTH0_CLIENT_ID: example_client_id
+      AUTH0_M2M_CLIENT_ID: example_m2m_client_id
+      AUTH0_M2M_CLIENT_SECRET: example_m2m_client_secret
+      AUTH0_DB_CONNECTION_NAME: Username-Password-Authentication
+      GOOGLE_VERTEX_PROJECT: example-project
+      GOOGLE_VERTEX_LOCATION: europe-west1
+      DOCUMENT_EMBEDDING_MODELS: gemini-embedding-001
+      DOCUMENT_EMBEDDING_STUCK_THRESHOLD_SECONDS: 3600
+      DOCUMENT_EMBEDDING_STUCK_SWEEP_INTERVAL_SECONDS: 60
+      DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "false"
+      LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
+      MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      WORKER_QUEUE_NAMES: "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling"
+      WORKERS_HEALTH_QUEUE_NAME: evaluation-extraction-run-queue
+    restart: "no"
+
+  # GPU pool: ships Docling, consumes the embedding queues.
+  gpu-workers:
+    image: ${GPU_WORKERS_IMAGE:-agentstudio-gpu-workers-smoke:latest}
+    build:
+      context: ..
+      dockerfile: apps/api/Dockerfile
+      target: gpu-workers-runtime
     depends_on:
       postgres:
         condition: service_healthy
@@ -90,4 +126,6 @@ services:
       DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "true"
       LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
       MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      WORKER_QUEUE_NAMES: "document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings"
+      WORKERS_HEALTH_QUEUE_NAME: document-embeddings
     restart: "no"


### PR DESCRIPTION
Keep a single workers-main entrypoint but let each instance choose which
queues it consumes via the required WORKER_QUEUE_NAMES env var (fails fast
if unset or naming an unknown queue), so the same binary runs in both the
CPU and GPU pools. WorkersAppModule now imports only the worker modules
that own an enabled queue, and the /healthz queue is env-driven and
validated.

Ship workers as two Docker images instead of one: cpu-workers-runtime
(no Docling) and gpu-workers-runtime (Docling/Torch). Update the Makefile
build/scan/smoke targets, the smoke compose (cpu-workers + gpu-workers
services), security.yml Trivy scans, README, docs, and the Docling helper
messages accordingly.