### PR TITLE
feat: share extraction document list with details and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Extraction documents and evaluation dataset files now share a single list where each item can be opened in a details panel and deleted individually or in bulk
+- The document details panel now displays file sizes in a human-readable format (e.g. "22.3 MB")
 
 ### Changed
 

--- a/apps/api/src/domains/documents/documents.controller.ts
+++ b/apps/api/src/domains/documents/documents.controller.ts
@@ -470,23 +470,23 @@ function parseCrawledPages(
 function toDocumentDto(entity: Document): DocumentDto {
   const isWebCrawl = entity.sourceType === "webCrawl"
   return {
-    id: entity.id,
-    projectId: entity.projectId,
-    title: entity.title,
     content: isWebCrawl ? undefined : entity.content,
-    pages: isWebCrawl ? parseCrawledPages(entity.content) : undefined,
-    fileName: entity.fileName,
     createdAt: entity.createdAt.getTime(),
-    updatedAt: entity.updatedAt.getTime(),
     deletedAt: entity.deletedAt?.getTime() || undefined,
+    embeddingError: entity.embeddingError ?? null,
+    embeddingStatus: entity.embeddingStatus,
+    fileName: entity.fileName,
+    id: entity.id,
     language: entity.language === "fr" ? "fr" : "en",
     mimeType: entity.mimeType as MimeTypes,
+    pages: isWebCrawl ? parseCrawledPages(entity.content) : undefined,
+    projectId: entity.projectId,
     size: entity.size,
-    storageRelativePath: entity.storageRelativePath,
     sourceType: entity.sourceType,
     sourceUrl: entity.sourceUrl ?? null,
-    embeddingStatus: entity.embeddingStatus,
-    embeddingError: entity.embeddingError ?? null,
+    storageRelativePath: entity.storageRelativePath,
     tagIds: entity.tags?.map((tag) => tag.id) || [],
+    title: entity.title,
+    updatedAt: entity.updatedAt.getTime(),
   }
 }

--- a/apps/api/src/domains/evaluations/extraction/datasets/evaluation-extraction-datasets.controller.ts
+++ b/apps/api/src/domains/evaluations/extraction/datasets/evaluation-extraction-datasets.controller.ts
@@ -4,6 +4,7 @@ import {
   type EvaluationExtractionDatasetFileDto,
   type EvaluationExtractionDatasetRecordRowDto,
   EvaluationExtractionDatasetsRoutes,
+  type MimeTypes,
   type PaginatedEvaluationExtractionDatasetRecordsDto,
 } from "@caseai-connect/api-contracts"
 import {
@@ -214,16 +215,20 @@ export class EvaluationExtractionDatasetsController {
 }
 
 function toEvaluationExtractionDatasetFileDto(
-  document: Document,
+  entity: Document,
 ): EvaluationExtractionDatasetFileDto {
   return {
-    createdAt: document.createdAt.getTime(),
-    fileName: document.fileName,
-    id: document.id,
-    projectId: document.projectId,
-    size: document.size,
-    storageRelativePath: document.storageRelativePath,
-    updatedAt: document.updatedAt.getTime(),
+    createdAt: entity.createdAt.getTime(),
+    fileName: entity.fileName,
+    id: entity.id,
+    language: entity.language === "fr" ? "fr" : "en",
+    mimeType: entity.mimeType as MimeTypes,
+    projectId: entity.projectId,
+    size: entity.size,
+    sourceType: entity.sourceType,
+    storageRelativePath: entity.storageRelativePath,
+    title: entity.title,
+    updatedAt: entity.updatedAt.getTime(),
   }
 }
 function toEvaluationExtractionDatasetFileColumnDto(

--- a/apps/web/src/common/components/DocumentSelectionList.tsx
+++ b/apps/web/src/common/components/DocumentSelectionList.tsx
@@ -1,0 +1,302 @@
+import type { TimeType } from "@caseai-connect/api-contracts"
+import { Button } from "@caseai-connect/ui/shad/button"
+import { Checkbox } from "@caseai-connect/ui/shad/checkbox"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@caseai-connect/ui/shad/sheet"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@caseai-connect/ui/shad/table"
+import { ArrowRightIcon, InfoIcon, Trash2Icon, XIcon } from "lucide-react"
+import { type ReactNode, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ConfirmDialog } from "@/common/components/ConfirmDialog"
+import { MarkdownWrapper } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/MarkdownWrapper"
+import { buildDate, buildSince } from "@/common/utils/build-date"
+import { formatBytes } from "@/common/utils/format-bytes"
+import { DocumentTagItem } from "@/studio/features/document-tags/components/DocumentTagItem"
+import type { DocumentTag } from "@/studio/features/document-tags/document-tags.models"
+import { EmbeddingStatusBadge } from "@/studio/features/documents/components/EmbeddingStatusBadge"
+import type { Document } from "@/studio/features/documents/documents.models"
+
+export type DocumentSelectionItem = {
+  id: string
+  fileName?: string
+  createdAt: TimeType
+}
+
+type Props<TDocument extends DocumentSelectionItem & DocumentDetails> = {
+  documents: TDocument[]
+  emptyState: ReactNode
+  onSelect: (document: TDocument) => void
+  onDelete: (documentIds: string[]) => void
+}
+
+type ActiveAction<TDocument> =
+  | { type: "delete"; documentIds: string[] }
+  | { type: "details"; document: TDocument }
+
+/**
+ * Presentational list of documents with a primary "select" action per row,
+ * per-row details, plus single and bulk delete. Callers own data loading, the
+ * empty state and the select/delete handlers — this component renders the
+ * table, the bulk-action bar, the delete confirmation and the details sheet.
+ */
+export function DocumentSelectionList<TDocument extends DocumentSelectionItem & DocumentDetails>({
+  documents,
+  emptyState,
+  onSelect,
+  onDelete,
+}: Props<TDocument>) {
+  const { t } = useTranslation()
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
+  const [activeAction, setActiveAction] = useState<ActiveAction<TDocument> | null>(null)
+
+  if (documents.length === 0) return <>{emptyState}</>
+
+  const selectedCount = documents.filter((document) => selectedIds.has(document.id)).length
+  const allSelected = selectedCount === documents.length
+  const someSelected = selectedCount > 0 && !allSelected
+
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const toggleAll = () => {
+    setSelectedIds(allSelected ? new Set() : new Set(documents.map((document) => document.id)))
+  }
+
+  const toggleOne = (documentId: string) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous)
+      if (next.has(documentId)) {
+        next.delete(documentId)
+      } else {
+        next.add(documentId)
+      }
+      return next
+    })
+  }
+
+  const handleConfirmDelete = () => {
+    if (activeAction?.type === "delete") onDelete(activeAction.documentIds)
+    setActiveAction(null)
+    clearSelection()
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {selectedCount > 0 && (
+        <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2">
+          <Button variant="ghost" size="icon" className="size-8" onClick={clearSelection}>
+            <XIcon className="size-4" />
+          </Button>
+          <span className="text-sm font-medium">
+            {t("documentList:selected", { count: selectedCount })}
+          </span>
+          <div className="ml-auto">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setActiveAction({
+                  type: "delete",
+                  documentIds: documents
+                    .filter((document) => selectedIds.has(document.id))
+                    .map((document) => document.id),
+                })
+              }
+            >
+              <Trash2Icon className="size-4" />
+              {t("actions:delete")}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-10 rounded-tl-lg bg-muted">
+              <Checkbox
+                checked={allSelected ? true : someSelected ? "indeterminate" : false}
+                onCheckedChange={toggleAll}
+                aria-label={t("actions:selectAll")}
+              />
+            </TableHead>
+            <TableHead className="font-medium bg-muted">{t("documentList:props.name")}</TableHead>
+            <TableHead className="font-medium bg-muted">
+              {t("documentList:props.createdAt")}
+            </TableHead>
+            <TableHead className="w-10 bg-muted" />
+            <TableHead className="w-60 rounded-tr-lg bg-muted" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {documents.map((document) => {
+            const selected = selectedIds.has(document.id)
+            return (
+              <TableRow key={document.id} data-state={selected ? "selected" : undefined}>
+                <TableCell>
+                  <Checkbox
+                    checked={selected}
+                    onCheckedChange={() => toggleOne(document.id)}
+                    aria-label={t("actions:select")}
+                  />
+                </TableCell>
+                <TableCell>{document.fileName}</TableCell>
+                <TableCell className="text-muted-foreground">
+                  {buildSince(document.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 text-muted-foreground"
+                      aria-label={t("actions:view")}
+                      onClick={() => setActiveAction({ type: "details", document })}
+                    >
+                      <InfoIcon className="size-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 text-muted-foreground hover:text-destructive"
+                      aria-label={t("actions:delete")}
+                      onClick={() =>
+                        setActiveAction({ type: "delete", documentIds: [document.id] })
+                      }
+                    >
+                      <Trash2Icon className="size-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center justify-end gap-2">
+                    <Button variant="outline" onClick={() => onSelect(document)}>
+                      {t("actions:select")} <ArrowRightIcon className="size-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+
+      <ConfirmDialog
+        open={activeAction?.type === "delete"}
+        title={t("documentList:delete.title", {
+          count: activeAction?.type === "delete" ? activeAction.documentIds.length : 0,
+        })}
+        description={t("documentList:delete.description")}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setActiveAction(null)}
+      />
+
+      {activeAction?.type === "details" && (
+        <DocumentDetailsSheet
+          document={activeAction.document}
+          open
+          onOpenChange={(open) => !open && setActiveAction(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * The fields the details sheet renders. The metadata is always present, while
+ * embedding/tag/content data is optional so the sheet works for both full
+ * documents and lighter models that only carry file metadata.
+ */
+type DocumentDetails = Pick<
+  Document,
+  "title" | "fileName" | "createdAt" | "updatedAt" | "size" | "language" | "mimeType" | "sourceType"
+> &
+  Partial<Pick<Document, "embeddingStatus" | "embeddingError" | "content" | "tagIds">>
+
+export function DocumentDetailsSheet({
+  document,
+  documentTags = [],
+  open,
+  onOpenChange,
+}: {
+  document: DocumentDetails
+  documentTags?: DocumentTag[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const hasEmbeddingInfo = ["project", "webCrawl"].includes(document.sourceType)
+  const { t } = useTranslation()
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{document.title}</SheetTitle>
+        </SheetHeader>
+        <div className="flex flex-col gap-4 px-4 pb-4">
+          <div className="flex flex-col gap-4">
+            <MetaField
+              label={t("document:props.createdAt")}
+              value={buildDate(document.createdAt)}
+            />
+
+            <MetaField
+              label={t("document:props.updatedAt")}
+              value={buildDate(document.updatedAt)}
+            />
+
+            <MetaField label={t("document:props.fileName")} value={document.fileName} />
+
+            <MetaField
+              label={t("document:props.size")}
+              value={document.size != null ? formatBytes(document.size) : undefined}
+            />
+
+            <MetaField label={t("document:props.language")} value={document.language} />
+
+            <MetaField label={t("document:props.mimeType")} value={document.mimeType} />
+
+            {hasEmbeddingInfo && document.embeddingStatus && (
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">{t("document:props.embeddingStatus")}:</span>
+                <EmbeddingStatusBadge status={document.embeddingStatus} />
+              </div>
+            )}
+
+            {hasEmbeddingInfo && document.embeddingError && (
+              <MetaField
+                label={t("document:props.embeddingError")}
+                value={document.embeddingError}
+              />
+            )}
+          </div>
+          {document.tagIds && document.tagIds.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">{t("document:props.tags")}</span>
+              {document.tagIds.map((tagId) => {
+                const tag = documentTags.find((documentTag) => documentTag.id === tagId)
+                if (!tag) return null
+                return <DocumentTagItem key={tagId} tag={tag} readonly />
+              })}
+            </div>
+          )}
+          {document.content && <MarkdownWrapper content={document.content} />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export function MetaField({ label, value }: { label: string; value?: string }) {
+  if (!value) return null
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-medium">{label}:</span>
+      <span className="text-muted-foreground">{value}</span>
+    </div>
+  )
+}

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.middleware.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.middleware.ts
@@ -8,7 +8,8 @@ import { extractionAgentSessionsActions } from "./extraction-agent-sessions.slic
 // Create typed listener middleware
 export const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
 
-const { mount, executeOne, listMyDocuments, getAll } = extractionAgentSessionsActions
+const { mount, executeOne, listMyDocuments, deleteMyDocuments, getAll } =
+  extractionAgentSessionsActions
 
 function registerListeners() {
   // Load conversation agent sessions when agent is loaded
@@ -57,6 +58,30 @@ function registerListeners() {
       listenerApi.dispatch(
         notificationsActions.show({
           title: "Extraction execution failed",
+          type: "error",
+        }),
+      )
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: deleteMyDocuments.fulfilled,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Document(s) deleted successfully",
+          type: "success",
+        }),
+      )
+      listenerApi.dispatch(listMyDocuments())
+    },
+  })
+  listenerMiddleware.startListening({
+    actionCreator: deleteMyDocuments.rejected,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Failed to delete document(s)",
           type: "error",
         }),
       )

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.thunks.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.thunks.ts
@@ -81,6 +81,20 @@ const executeOne = createAsyncThunk<
   },
 )
 
+const deleteMyDocuments = createAsyncThunk<void, { documentIds: string[] }, ThunkConfig>(
+  "extractionAgentSessions/deleteMyDocuments",
+  async ({ documentIds }, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    await Promise.all(
+      documentIds.map((documentId) =>
+        services.documents.deleteOne({ organizationId, projectId, documentId }),
+      ),
+    )
+  },
+)
+
 const getOne = createAsyncThunk<ExtractionAgentSession, { agentSessionId: string }, ThunkConfig>(
   "extractionAgentSessions/getOne",
   async ({ agentSessionId }, { extra: { services }, getState }) => {
@@ -102,5 +116,6 @@ export const extractionAgentSessionsThunks = {
   getOne,
   executeOne,
   listMyDocuments,
+  deleteMyDocuments,
   getAll,
 }

--- a/apps/web/src/common/features/agents/components/DocumentList.tsx
+++ b/apps/web/src/common/features/agents/components/DocumentList.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@caseai-connect/ui/shad/button"
 import { Card, CardContent } from "@caseai-connect/ui/shad/card"
 import {
   Empty,
@@ -7,22 +6,15 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@caseai-connect/ui/shad/empty"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@caseai-connect/ui/shad/table"
 import { FileIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { DocumentSelectionList } from "@/common/components/DocumentSelectionList"
 import { Loader } from "@/common/components/Loader"
 import { ADS } from "@/common/store/async-data-status"
-import { useAppSelector } from "@/common/store/hooks"
-import { buildSince } from "@/common/utils/build-date"
+import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import type { Document } from "@/studio/features/documents/documents.models"
 import { selectExtractionAgentSessionsDocuments } from "../agent-sessions/extraction/extraction-agent-sessions.selectors"
+import { extractionAgentSessionsActions } from "../agent-sessions/extraction/extraction-agent-sessions.slice"
 
 type OnSelectDocument = { onSelectDocument: (document: Document) => void }
 
@@ -34,62 +26,20 @@ export function DocumentList({ onSelectDocument }: OnSelectDocument) {
 }
 
 function WithData({ documents, onSelectDocument }: { documents: Document[] } & OnSelectDocument) {
-  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   return (
     <Card className="border-0 shadow-none">
       <CardContent className="p-0">
-        {documents.length === 0 ? (
-          <EmptyDocument />
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="font-medium rounded-tl-lg bg-muted">
-                  {t("extractionAgentSession:document.props.name")}
-                </TableHead>
-                <TableHead className="font-medium bg-muted">
-                  {t("extractionAgentSession:document.props.createdAt")}
-                </TableHead>
-                <TableHead className="w-10 rounded-tr-lg bg-muted" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {documents.map((document) => (
-                <DocumentRow
-                  key={document.id}
-                  document={document}
-                  onSelect={() => onSelectDocument(document)}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        )}
+        <DocumentSelectionList
+          documents={documents}
+          emptyState={<EmptyDocument />}
+          onSelect={onSelectDocument}
+          onDelete={(documentIds) =>
+            dispatch(extractionAgentSessionsActions.deleteMyDocuments({ documentIds }))
+          }
+        />
       </CardContent>
     </Card>
-  )
-}
-
-function DocumentRow({ document, onSelect }: { document: Document; onSelect: () => void }) {
-  const date = buildSince(document.createdAt)
-  return (
-    <TableRow>
-      <TableCell>{document.fileName}</TableCell>
-      <TableCell className="text-muted-foreground">{date}</TableCell>
-      <TableCell>
-        <DocumentActions onSelect={onSelect} />
-      </TableCell>
-    </TableRow>
-  )
-}
-
-function DocumentActions({ onSelect }: { onSelect: () => void }) {
-  const { t } = useTranslation()
-  return (
-    <div className="flex items-center gap-2">
-      <Button variant="outline" onClick={onSelect}>
-        {t("actions:select")}
-      </Button>
-    </div>
   )
 }
 

--- a/apps/web/src/common/utils/format-bytes.ts
+++ b/apps/web/src/common/utils/format-bytes.ts
@@ -1,0 +1,12 @@
+const UNITS = ["B", "KB", "MB", "GB", "TB"] as const
+
+/**
+ * Formats a byte count into a human-readable size (e.g. 23376865 -> "22.3 MB").
+ */
+export function formatBytes(bytes: number, fractionDigits = 1): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B"
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), UNITS.length - 1)
+  const value = bytes / 1024 ** exponent
+  const formatted = exponent === 0 ? value.toString() : value.toFixed(fractionDigits)
+  return `${formatted} ${UNITS[exponent]}`
+}

--- a/apps/web/src/eval/features/evaluation-extraction-datasets/components/FileList.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-datasets/components/FileList.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@caseai-connect/ui/shad/button"
 import {
   Card,
   CardAction,
@@ -7,21 +6,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@caseai-connect/ui/shad/card"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@caseai-connect/ui/shad/table"
-import { Loader } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { DocumentSelectionList } from "@/common/components/DocumentSelectionList"
+import { Loader } from "@/common/components/Loader"
 import { ADS } from "@/common/store/async-data-status"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
-import { buildSince } from "@/common/utils/build-date"
 import type { EvaluationExtractionDatasetFile } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.models"
 import { selectFilesData } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.selectors"
+import { evaluationExtractionDatasetsActions } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.slice"
 import { currentIdsActions } from "@/eval/store/currentIds.slice"
 import { EmptyFile } from "./EmptyFile"
 import { UploadFile } from "./UploadFile"
@@ -34,6 +26,7 @@ export function FileList() {
 }
 
 function WithData({ files }: { files: EvaluationExtractionDatasetFile[] }) {
+  const dispatch = useAppDispatch()
   const { t } = useTranslation()
   return (
     <Card className="border-0 shadow-none">
@@ -47,57 +40,15 @@ function WithData({ files }: { files: EvaluationExtractionDatasetFile[] }) {
 
       <CardContent>
         <UploaderState />
-        {files.length === 0 ? (
-          <EmptyFile />
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="font-medium rounded-tl-lg bg-muted">
-                  {t("evaluation:file.props.name")}
-                </TableHead>
-                <TableHead className="font-medium bg-muted">
-                  {t("evaluation:file.props.createdAt")}
-                </TableHead>
-                <TableHead className="w-10 rounded-tr-lg bg-muted" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {files.map((file) => (
-                <FileRow key={file.id} file={file} />
-              ))}
-            </TableBody>
-          </Table>
-        )}
+        <DocumentSelectionList
+          documents={files}
+          emptyState={<EmptyFile />}
+          onSelect={(file) => dispatch(currentIdsActions.setFileId(file.id))}
+          onDelete={(fileIds) =>
+            dispatch(evaluationExtractionDatasetsActions.deleteFiles({ fileIds }))
+          }
+        />
       </CardContent>
     </Card>
-  )
-}
-
-function FileRow({ file }: { file: EvaluationExtractionDatasetFile }) {
-  const date = buildSince(file.createdAt)
-  return (
-    <TableRow>
-      <TableCell>{file.fileName}</TableCell>
-      <TableCell className="text-muted-foreground">{date}</TableCell>
-      <TableCell>
-        <FileActions file={file} />
-      </TableCell>
-    </TableRow>
-  )
-}
-
-function FileActions({ file }: { file: EvaluationExtractionDatasetFile }) {
-  const dispatch = useAppDispatch()
-  const { t } = useTranslation()
-  const handleSelect = () => {
-    dispatch(currentIdsActions.setFileId(file.id))
-  }
-  return (
-    <div className="flex items-center gap-2">
-      <Button variant="outline" onClick={handleSelect}>
-        {t("actions:select")}
-      </Button>
-    </div>
   )
 }

--- a/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.middleware.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.middleware.ts
@@ -133,7 +133,7 @@ function registerFileListeners() {
   listenerMiddleware.startListening({
     matcher: isAnyOf(
       evaluationExtractionDatasetsActions.uploadFile.fulfilled,
-      evaluationExtractionDatasetsActions.deleteFile.fulfilled,
+      evaluationExtractionDatasetsActions.deleteFiles.fulfilled,
     ),
     effect: async (_, listenerApi) => {
       await Promise.all([listenerApi.dispatch(evaluationExtractionDatasetsActions.listFiles())])
@@ -175,18 +175,18 @@ function registerFileListeners() {
   })
 
   listenerMiddleware.startListening({
-    actionCreator: evaluationExtractionDatasetsActions.deleteFile.fulfilled,
+    actionCreator: evaluationExtractionDatasetsActions.deleteFiles.fulfilled,
     effect: async (_, listenerApi) => {
       listenerApi.dispatch(
         notificationsActions.show({
-          title: "File deleted successfully",
+          title: "File(s) deleted successfully",
           type: "success",
         }),
       )
     },
   })
   listenerMiddleware.startListening({
-    actionCreator: evaluationExtractionDatasetsActions.deleteFile.rejected,
+    actionCreator: evaluationExtractionDatasetsActions.deleteFiles.rejected,
     effect: async (_, listenerApi) => {
       listenerApi.dispatch(
         notificationsActions.show({

--- a/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.thunks.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.thunks.ts
@@ -142,17 +142,17 @@ const uploadFile = createAsyncThunk<void, { file: File }, ThunkConfig>(
   },
 )
 
-const deleteFile = createAsyncThunk<void, { fileId: string }, ThunkConfig>(
-  "datasets/deleteFile",
-  async ({ fileId }, { extra: { services }, getState }) => {
+const deleteFiles = createAsyncThunk<void, { fileIds: string[] }, ThunkConfig>(
+  "datasets/deleteFiles",
+  async ({ fileIds }, { extra: { services }, getState }) => {
     const state = getState()
     const organizationId = getCurrentId({ state, name: "organizationId" })
     const projectId = getCurrentId({ state, name: "projectId" })
-    await services.documents.deleteOne({
-      organizationId,
-      projectId,
-      documentId: fileId,
-    })
+    await Promise.all(
+      fileIds.map((fileId) =>
+        services.documents.deleteOne({ organizationId, projectId, documentId: fileId }),
+      ),
+    )
   },
 )
 
@@ -191,5 +191,5 @@ export const evaluationExtractionDatasetsThunks = {
   getFileColumns,
   uploadFile,
   updateOne,
-  deleteFile,
+  deleteFiles,
 }

--- a/apps/web/src/eval/features/evaluation-extraction-datasets/external/evaluation-extraction-datasets.api.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-datasets/external/evaluation-extraction-datasets.api.ts
@@ -98,10 +98,14 @@ function toEvaluationExtractionDatasetFile(
     createdAt: dto.createdAt,
     fileName: dto.fileName,
     id: dto.id,
+    language: dto.language,
+    mimeType: dto.mimeType,
     projectId: dto.projectId,
     size: dto.size,
     storageRelativePath: dto.storageRelativePath,
+    title: dto.title,
     updatedAt: dto.updatedAt,
+    sourceType: dto.sourceType,
   }
 }
 

--- a/apps/web/src/locales/document-list.en.json
+++ b/apps/web/src/locales/document-list.en.json
@@ -1,0 +1,15 @@
+{
+  "documentList": {
+    "props": {
+      "name": "Name",
+      "createdAt": "Created at"
+    },
+    "selected_one": "{{count}} selected",
+    "selected_other": "{{count}} selected",
+    "delete": {
+      "title_one": "Delete document",
+      "title_other": "Delete {{count}} documents",
+      "description": "This action is irreversible. The selected document(s) will be permanently deleted."
+    }
+  }
+}

--- a/apps/web/src/locales/document-list.fr.json
+++ b/apps/web/src/locales/document-list.fr.json
@@ -1,0 +1,15 @@
+{
+  "documentList": {
+    "props": {
+      "name": "Nom",
+      "createdAt": "Créé le"
+    },
+    "selected_one": "{{count}} sélectionné",
+    "selected_other": "{{count}} sélectionnés",
+    "delete": {
+      "title_one": "Supprimer le document",
+      "title_other": "Supprimer {{count}} documents",
+      "description": "Cette action est irréversible. Le ou les documents sélectionnés seront définitivement supprimés."
+    }
+  }
+}

--- a/apps/web/src/studio/features/documents/components/DocumentList.tsx
+++ b/apps/web/src/studio/features/documents/components/DocumentList.tsx
@@ -19,7 +19,6 @@ import {
 import { Field, FieldGroup, FieldLabel, FieldSet } from "@caseai-connect/ui/shad/field"
 import { Input } from "@caseai-connect/ui/shad/input"
 import { Item } from "@caseai-connect/ui/shad/item"
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@caseai-connect/ui/shad/sheet"
 import {
   Table,
   TableBody,
@@ -45,12 +44,12 @@ import { useReducer, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { ConfirmDialog } from "@/common/components/ConfirmDialog"
+import { DocumentDetailsSheet } from "@/common/components/DocumentSelectionList"
 import { GridHeader } from "@/common/components/grid/Grid"
-import { MarkdownWrapper } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/MarkdownWrapper"
 import { useGetProjectRoute } from "@/common/hooks/use-get-path"
 import { useValue } from "@/common/hooks/use-value"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
-import { buildDate, buildSince } from "@/common/utils/build-date"
+import { buildSince } from "@/common/utils/build-date"
 import { generateId } from "@/common/utils/generate-id"
 import {
   getTagNameById,
@@ -76,7 +75,6 @@ import {
   reprocessDocument,
   updateDocument,
 } from "@/studio/features/documents/documents.thunks"
-import { DocumentTagItem } from "../../document-tags/components/DocumentTagItem"
 import { DocumentTagsSheet } from "../../document-tags/components/DocumentTagsSheet"
 
 export function DocumentList() {
@@ -597,53 +595,12 @@ function DocumentActions({
         </DialogContent>
       </Dialog>
 
-      <Sheet
+      <DocumentDetailsSheet
+        document={document}
+        documentTags={documentTags}
         open={activeAction === "details"}
         onOpenChange={(open) => !open && setActiveAction(null)}
-      >
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle>{document.title}</SheetTitle>
-          </SheetHeader>
-          <div className="flex flex-col gap-4 px-4 pb-4">
-            <div className="flex flex-col gap-4">
-              <MetaField
-                label={t("document:props.createdAt")}
-                value={buildDate(document.createdAt)}
-              />
-              <MetaField
-                label={t("document:props.updatedAt")}
-                value={buildDate(document.updatedAt)}
-              />
-              <MetaField label={t("document:props.fileName")} value={document.fileName} />
-              <MetaField label={t("document:props.size")} value={document.size?.toString()} />
-              <MetaField label={t("document:props.language")} value={document.language} />
-              <MetaField label={t("document:props.mimeType")} value={document.mimeType} />
-              <div className="flex flex-col gap-1">
-                <span className="font-medium">{t("document:props.embeddingStatus")}:</span>
-                <EmbeddingStatusBadge status={document.embeddingStatus} />
-              </div>
-              {document.embeddingError && (
-                <MetaField
-                  label={t("document:props.embeddingError")}
-                  value={document.embeddingError}
-                />
-              )}
-            </div>
-            {document.tagIds.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <span className="text-sm font-medium">{t("document:props.tags")}</span>
-                {document.tagIds.map((tagId) => {
-                  const tag = documentTags.find((documentTag) => documentTag.id === tagId)
-                  if (!tag) return null
-                  return <DocumentTagItem key={tagId} tag={tag} readonly />
-                })}
-              </div>
-            )}
-            {document.content && <MarkdownWrapper content={document.content} />}
-          </div>
-        </SheetContent>
-      </Sheet>
+      />
     </>
   )
 }
@@ -740,16 +697,6 @@ function DocumentEditForm({ document, onSuccess }: { document: Document; onSucce
       <div className="flex justify-end">
         <Button onClick={handleSave}>{t("actions:update")}</Button>
       </div>
-    </div>
-  )
-}
-
-function MetaField({ label, value }: { label: string; value?: string }) {
-  if (!value) return null
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="font-medium">{label}:</span>
-      <span className="text-muted-foreground">{value}</span>
     </div>
   )
 }

--- a/packages/api-contracts/src/documents/documents.dto.ts
+++ b/packages/api-contracts/src/documents/documents.dto.ts
@@ -53,24 +53,24 @@ export type DocumentUploadOptionalTagFields = {
 }
 
 export type DocumentDto = {
-  createdAt: TimeType
-  id: string
-  projectId: string
-  updatedAt: TimeType
-  deletedAt?: TimeType
-  title: string
   content?: string
-  pages?: { url: string; markdown: string }[]
+  createdAt: TimeType
+  deletedAt?: TimeType
+  embeddingError: string | null
+  embeddingStatus: DocumentEmbeddingStatus
   fileName?: string
+  id: string
   language: "en" | "fr"
   mimeType?: MimeTypes
+  pages?: { url: string; markdown: string }[]
+  projectId: string
   size?: number
-  storageRelativePath?: string
   sourceType: DocumentSourceType
   sourceUrl?: string | null
-  embeddingStatus: DocumentEmbeddingStatus
-  embeddingError: string | null
+  storageRelativePath?: string
   tagIds: DocumentTagDto["id"][]
+  title: string
+  updatedAt: TimeType
 }
 
 export type CrawlUrlRequestDto = {

--- a/packages/api-contracts/src/evaluations/evaluation-extraction-datasets.dto.ts
+++ b/packages/api-contracts/src/evaluations/evaluation-extraction-datasets.dto.ts
@@ -1,15 +1,21 @@
+import type { DocumentDto } from "../documents/documents.dto"
 import type { TimeType } from "../generic"
 
 // DATASET FILE
-export type EvaluationExtractionDatasetFileDto = {
-  createdAt: TimeType
-  fileName?: string
-  id: string
-  projectId: string
-  size?: number
-  storageRelativePath?: string
-  updatedAt: TimeType
-}
+export type EvaluationExtractionDatasetFileDto = Pick<
+  DocumentDto,
+  | "createdAt"
+  | "fileName"
+  | "id"
+  | "language"
+  | "mimeType"
+  | "projectId"
+  | "size"
+  | "sourceType"
+  | "storageRelativePath"
+  | "title"
+  | "updatedAt"
+>
 export type EvaluationExtractionDatasetFileColumnDto = {
   id: string
   name: string


### PR DESCRIPTION
- add reusable DocumentSelectionList (select, details sheet, single/bulk delete)
- enable deleting extraction documents and evaluation dataset files
- extend evaluation dataset file DTO to reuse the document details sheet
- show human-readable file sizes in document details