### PR TITLE
refactor(web): simplify async data access with useValue/useCurrentId

### DIFF
--- a/apps/web/src/common/features/agents/components/DocumentList.tsx
+++ b/apps/web/src/common/features/agents/components/DocumentList.tsx
@@ -9,9 +9,8 @@ import {
 import { FileIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { DocumentSelectionList } from "@/common/components/DocumentSelectionList"
-import { Loader } from "@/common/components/Loader"
-import { ADS } from "@/common/store/async-data-status"
-import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { useValue } from "@/common/hooks/use-value"
+import { useAppDispatch } from "@/common/store/hooks"
 import type { Document } from "@/studio/features/documents/documents.models"
 import { selectExtractionAgentSessionsDocuments } from "../agent-sessions/extraction/extraction-agent-sessions.selectors"
 import { extractionAgentSessionsActions } from "../agent-sessions/extraction/extraction-agent-sessions.slice"
@@ -19,14 +18,8 @@ import { extractionAgentSessionsActions } from "../agent-sessions/extraction/ext
 type OnSelectDocument = { onSelectDocument: (document: Document) => void }
 
 export function DocumentList({ onSelectDocument }: OnSelectDocument) {
-  const documents = useAppSelector(selectExtractionAgentSessionsDocuments)
-  if (ADS.isFulfilled(documents))
-    return <WithData documents={documents.value} onSelectDocument={onSelectDocument} />
-  return <Loader />
-}
-
-function WithData({ documents, onSelectDocument }: { documents: Document[] } & OnSelectDocument) {
   const dispatch = useAppDispatch()
+  const documents = useValue(selectExtractionAgentSessionsDocuments)
   return (
     <Card className="border-0 shadow-none">
       <CardContent className="p-0">

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/RunEvaluationExtractionDialog.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/RunEvaluationExtractionDialog.tsx
@@ -24,7 +24,7 @@ import { useNavigate } from "react-router-dom"
 import { RunScopeSelector } from "@/common/components/shared/RunScopeSelector"
 import type { Agent } from "@/common/features/agents/agents.models"
 import { selectAgentsData } from "@/common/features/agents/agents.selectors"
-import { ADS } from "@/common/store/async-data-status"
+import { useValue } from "@/common/hooks/use-value"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import type {
   EvaluationExtractionDataset,
@@ -49,7 +49,7 @@ export function RunEvaluationExtractionDialog({
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const { buildRunPath } = useEvaluationExtractionRunPath()
-  const agentsData = useAppSelector(selectAgentsData)
+  const agentsData = useValue(selectAgentsData)
   const isExecuting = useAppSelector(selectIsExecuting)
   const [open, setOpen] = useState(false)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
@@ -58,8 +58,7 @@ export function RunEvaluationExtractionDialog({
   const [limitedCount, setLimitedCount] = useState(1)
 
   const extractionAgents = useMemo(() => {
-    if (!ADS.isFulfilled(agentsData)) return []
-    return agentsData.value.filter((agent) => agent.type === "extraction")
+    return agentsData.filter((agent) => agent.type === "extraction")
   }, [agentsData])
 
   const targetColumns = useMemo(

--- a/apps/web/src/studio/features/agent-memberships/components/AgentMembershipItem.tsx
+++ b/apps/web/src/studio/features/agent-memberships/components/AgentMembershipItem.tsx
@@ -5,13 +5,14 @@ import { useTranslation } from "react-i18next"
 import { ConfirmDialog } from "@/common/components/ConfirmDialog"
 import { GridCard } from "@/common/components/grid/Grid"
 import { selectMe } from "@/common/features/me/me.selectors"
-import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { useValue } from "@/common/hooks/use-value"
+import { useAppDispatch } from "@/common/store/hooks"
 import type { AgentMembership } from "@/studio/features/agent-memberships/agent-memberships.models"
 import { agentMembershipsActions } from "../agent-memberships.slice"
 
 export function AgentMembershipItem({ membership }: { membership: AgentMembership }) {
   const dispatch = useAppDispatch()
-  const me = useAppSelector(selectMe)
+  const me = useValue(selectMe)
   const { t } = useTranslation()
   const [confirmOpen, setConfirmOpen] = useState(false)
 
@@ -20,7 +21,7 @@ export function AgentMembershipItem({ membership }: { membership: AgentMembershi
     setConfirmOpen(false)
   }
 
-  const disabled = membership.role === "owner" || membership.userId === me?.value?.id
+  const disabled = membership.role === "owner" || membership.userId === me.id
 
   return (
     <>

--- a/apps/web/src/studio/features/agents/components/agent-form.shared.ts
+++ b/apps/web/src/studio/features/agents/components/agent-form.shared.ts
@@ -8,8 +8,7 @@ import {
 import { useFormContext } from "react-hook-form"
 import type { Agent } from "@/common/features/agents/agents.models"
 import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
-import { ADS } from "@/common/store/async-data-status"
-import { useAppSelector } from "@/common/store/hooks"
+import { useValue } from "@/common/hooks/use-value"
 import {
   agentDefaultOutputJsonSchemaMap,
   agentDefaultPromptMap,
@@ -91,6 +90,6 @@ export function isValidJsonObject(rawJson: string): boolean {
  */
 export function useAgentType(): Agent["type"] | undefined {
   const { watch } = useFormContext<AgentFormValues>()
-  const agentData = useAppSelector(selectCurrentAgentData)
-  return watch("type") ?? (ADS.isFulfilled(agentData) ? agentData.value.type : undefined)
+  const agentData = useValue(selectCurrentAgentData)
+  return watch("type") ?? agentData.type
 }

--- a/apps/web/src/studio/routes/AgentAnalyticsRoute.tsx
+++ b/apps/web/src/studio/routes/AgentAnalyticsRoute.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/common/features/agents/agents.selectors"
 import { getAgentIcon } from "@/common/features/agents/components/AgentIcon"
 import { useGetAgentRoute } from "@/common/hooks/use-get-path"
-import { useValue } from "@/common/hooks/use-value"
+import { useCurrentId, useValue } from "@/common/hooks/use-value"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import {
   selectAgentAnalyticsAvgUserQuestionsPerSessionPerDay,
@@ -45,7 +45,7 @@ function getInitialAnalyticsBounds() {
 }
 
 export function AgentAnalyticsRoute() {
-  const agentId = useAppSelector(selectCurrentAgentId)
+  const agentId = useCurrentId(selectCurrentAgentId)
   const dispatch = useAppDispatch()
   const [bounds, setBounds] = useState(getInitialAnalyticsBounds)
 
@@ -54,7 +54,6 @@ export function AgentAnalyticsRoute() {
     void dispatch(loadAgentAnalytics(bounds))
   }, [dispatch, bounds])
 
-  const agent = useAppSelector(selectCurrentAgentData)
   const conversations = useAppSelector(selectAgentAnalyticsConversationsPerDay)
   const avgQuestions = useAppSelector(selectAgentAnalyticsAvgUserQuestionsPerSessionPerDay)
   const conversationsByCategoryPerDay = useAppSelector(
@@ -63,7 +62,7 @@ export function AgentAnalyticsRoute() {
 
   if (!agentId) return <ErrorRoute error="Missing valid agent ID" />
   return (
-    <AsyncRoute data={[agent, conversations, avgQuestions, conversationsByCategoryPerDay]}>
+    <AsyncRoute data={[conversations, avgQuestions, conversationsByCategoryPerDay]}>
       <WithData onAnalyticsRangeChange={setBounds} />
     </AsyncRoute>
   )

--- a/apps/web/src/studio/routes/AgentEditorRoute.tsx
+++ b/apps/web/src/studio/routes/AgentEditorRoute.tsx
@@ -7,7 +7,6 @@ import { useGetAgentRoute } from "@/common/hooks/use-get-path"
 import { useMount } from "@/common/hooks/use-mount"
 import { useValue } from "@/common/hooks/use-value"
 import { AsyncRoute } from "@/common/routes/AsyncRoute"
-import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
 import { selectAgentSubAgentsData } from "@/studio/features/agent-sub-agents/agent-sub-agents.selectors"
 import { agentSubAgentsActions } from "@/studio/features/agent-sub-agents/agent-sub-agents.slice"
@@ -17,31 +16,23 @@ import {
 } from "@/studio/features/agents/components/AgentEditor"
 
 export function AgentEditorRoute() {
-  const agent = useAppSelector(selectCurrentAgentData)
-  const agents = useAppSelector(selectAgentsData)
-  const project = useAppSelector(selectCurrentProjectData)
+  const agent = useValue(selectCurrentAgentData)
+  const project = useValue(selectCurrentProjectData)
   const subAgents = useAppSelector(selectAgentSubAgentsData)
   const hasOrchestration =
-    ADS.isFulfilled(agent) &&
-    agent.value.type === "conversation" &&
-    ADS.isFulfilled(project) &&
-    project.value.featureFlags.includes("agent-orchestration")
+    agent.type === "conversation" && project.featureFlags.includes("agent-orchestration")
 
   useMount({ actions: agentSubAgentsActions, condition: hasOrchestration })
 
   if (hasOrchestration) {
     return (
-      <AsyncRoute data={[agent, agents, subAgents]}>
+      <AsyncRoute data={[subAgents]}>
         <WithOrchestrationData />
       </AsyncRoute>
     )
   }
 
-  return (
-    <AsyncRoute data={[agent]}>
-      <WithData />
-    </AsyncRoute>
-  )
+  return <WithData />
 }
 
 function WithOrchestrationData() {

--- a/apps/web/src/studio/routes/EvaluationRoute.tsx
+++ b/apps/web/src/studio/routes/EvaluationRoute.tsx
@@ -20,10 +20,9 @@ import { evaluationsActions } from "../features/evaluations/evaluations.slice"
 
 export function EvaluationRoute() {
   const evaluations = useAppSelector(selectEvaluationsData)
-  const agents = useAppSelector(selectAgentsData)
   useMount({ actions: evaluationsActions })
   return (
-    <AsyncRoute data={[agents, evaluations]}>
+    <AsyncRoute data={[evaluations]}>
       <WithData />
     </AsyncRoute>
   )

--- a/apps/web/src/studio/routes/ProjectAdminRoute.tsx
+++ b/apps/web/src/studio/routes/ProjectAdminRoute.tsx
@@ -1,14 +1,5 @@
-import { selectCurrentProjectData } from "@/common/features/projects/projects.selectors"
-import { useAppSelector } from "@/common/store/hooks"
-import { AsyncRoute } from "../../common/routes/AsyncRoute"
 import { ProjectAdminPage } from "../features/project-admin/components/ProjectAdminPage"
 
 export function ProjectAdminRoute() {
-  const project = useAppSelector(selectCurrentProjectData)
-
-  return (
-    <AsyncRoute data={[project]}>
-      <ProjectAdminPage />
-    </AsyncRoute>
-  )
+  return <ProjectAdminPage />
 }

--- a/apps/web/src/studio/routes/ProjectAnalyticsRoute.tsx
+++ b/apps/web/src/studio/routes/ProjectAnalyticsRoute.tsx
@@ -64,10 +64,9 @@ export function ProjectAnalyticsRoute() {
   const conversations = useAppSelector(selectAnalyticsConversationsPerDay)
   const avgQuestions = useAppSelector(selectAnalyticsAvgUserQuestionsPerSessionPerDay)
   const conversationsByCategoryPerDay = useAppSelector(selectAnalyticsConversationsByCategoryPerDay)
-  const agentsData = useAppSelector(selectAgentsData)
 
   return (
-    <AsyncRoute data={[agentsData, conversations, avgQuestions, conversationsByCategoryPerDay]}>
+    <AsyncRoute data={[conversations, avgQuestions, conversationsByCategoryPerDay]}>
       <WithData
         onAnalyticsRangeChange={setBounds}
         selectedAgentId={selectedAgentId}

--- a/apps/web/src/studio/routes/ResourceEditorRoute.tsx
+++ b/apps/web/src/studio/routes/ResourceEditorRoute.tsx
@@ -15,7 +15,7 @@ import { StudioRoutes } from "./helpers"
 export function ResourceEditorRoute() {
   const organizationId = useCurrentId(selectCurrentOrganizationId)
   const projectId = useCurrentId(selectCurrentProjectId)
-  const resourceLibraryId = useAppSelector(selectCurrentResourceLibraryId)
+  const resourceLibraryId = useCurrentId(selectCurrentResourceLibraryId)
   const resourceId = useAppSelector(selectCurrentResourceId)
   const data = useValue(selectResourceLibrariesData)
 

--- a/apps/web/src/studio/routes/ResourceLibrariesRoute.tsx
+++ b/apps/web/src/studio/routes/ResourceLibrariesRoute.tsx
@@ -1,20 +1,9 @@
 import { useOutlet } from "react-router-dom"
 import { useValue } from "@/common/hooks/use-value"
-import { AsyncRoute } from "@/common/routes/AsyncRoute"
-import { useAppSelector } from "@/common/store/hooks"
 import { ResourceLibrariesManager } from "@/studio/features/resource-libraries/components/ResourceLibrariesManager"
 import { selectResourceLibrariesData } from "@/studio/features/resource-libraries/resource-libraries.selectors"
 
 export function ResourceLibrariesRoute() {
-  const data = useAppSelector(selectResourceLibrariesData)
-  return (
-    <AsyncRoute data={[data]}>
-      <ManagerContent />
-    </AsyncRoute>
-  )
-}
-
-function ManagerContent() {
   const outlet = useOutlet()
   const resourceLibraries = useValue(selectResourceLibrariesData)
   if (outlet) return outlet


### PR DESCRIPTION
- replace manual ADS.isFulfilled checks with useValue across routes and components
- drop redundant AsyncRoute wrappers where data is already resolved
- remove now-unneeded WithData/WrapperContent split components