### PR TITLE
fix(extraction): show last extraction after PDF upload and confirm before delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Agent extraction PDF upload correctly shows the last extraction result after upload completes
+- Deleting an extraction run requires confirmation
 
 ### Security
 
@@ -22,7 +24,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
-- Users without admin or owner permissions can now upload documents in the agent extraction app
+- Users without admin or owner permissions can upload documents in the agent extraction app
 
 ### Security
 

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.en.json
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.en.json
@@ -40,6 +40,13 @@
       "button": "History",
       "title": "History",
       "description": "View the history of your agent sessions"
+    },
+    "delete": {
+      "confirm": {
+        "title": "Delete extraction",
+        "description": "This extraction will be permanently deleted. This action cannot be undone.",
+        "submit": "Delete"
+      }
     }
   }
 }

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.fr.json
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.fr.json
@@ -40,6 +40,13 @@
       "button": "Historique",
       "title": "Historique",
       "description": "Consultez l'historique de vos sessions d'agent"
+    },
+    "delete": {
+      "confirm": {
+        "title": "Supprimer l'extraction",
+        "description": "Cette extraction sera supprimée définitivement. Cette action est irréversible.",
+        "submit": "Supprimer"
+      }
     }
   }
 }

--- a/apps/web/src/common/features/agents/components/ExtractionAgentSessionItem.tsx
+++ b/apps/web/src/common/features/agents/components/ExtractionAgentSessionItem.tsx
@@ -11,6 +11,7 @@ import { Trash2Icon } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
+import { ConfirmDialog } from "@/common/components/ConfirmDialog"
 import { GridCard } from "@/common/components/grid/Grid"
 import { Loader } from "@/common/components/Loader"
 import type { ExtractionAgentSessionSummary } from "@/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.models"
@@ -89,8 +90,11 @@ export function CsvExtractionSessionItem({
     )
   }
 
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+
   const handleDelete = () => {
     dispatch(agentCsvExtractionRunsActions.deleteOne({ agentCsvExtractionRunId: agentSession.id }))
+    setConfirmDeleteOpen(false)
   }
 
   return (
@@ -120,12 +124,20 @@ export function CsvExtractionSessionItem({
             />
           )}
           {canDelete && (
-            <Button variant="ghost" size="sm" onClick={handleDelete}>
+            <Button variant="ghost" size="sm" onClick={() => setConfirmDeleteOpen(true)}>
               <Trash2Icon />
             </Button>
           )}
         </div>
       </GridCard.Body>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        title={t("agentCsvExtractionRun:delete.confirm.title")}
+        description={t("agentCsvExtractionRun:delete.confirm.description")}
+        confirmLabel={t("agentCsvExtractionRun:delete.confirm.submit")}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDeleteOpen(false)}
+      />
     </GridCard>
   )
 }
@@ -139,9 +151,11 @@ export function Actions({
   isSuccess: boolean
   canDelete?: boolean
 }) {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const [isLoading, setIsLoading] = useState(false)
   const [runResult, setRunResult] = useState<Record<string, unknown>>()
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const handleGetRunResult = async (
     agentSessionId: string,
@@ -172,6 +186,7 @@ export function Actions({
         agentSessionId: agentSession.id,
       }),
     )
+    setConfirmDeleteOpen(false)
   }
 
   return (
@@ -202,10 +217,18 @@ export function Actions({
         buttonProps={{ size: "sm", variant: "outline" }}
       />
       {canDelete && (
-        <Button variant="ghost" size="sm" onClick={handleDelete}>
+        <Button variant="ghost" size="sm" onClick={() => setConfirmDeleteOpen(true)}>
           <Trash2Icon />
         </Button>
       )}
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        title={t("extractionAgentSession:delete.confirm.title")}
+        description={t("extractionAgentSession:delete.confirm.description")}
+        confirmLabel={t("extractionAgentSession:delete.confirm.submit")}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDeleteOpen(false)}
+      />
     </div>
   )
 }

--- a/apps/web/src/common/features/agents/csv-extraction-runs/locales/agent-csv-extraction-run.en.json
+++ b/apps/web/src/common/features/agents/csv-extraction-runs/locales/agent-csv-extraction-run.en.json
@@ -54,6 +54,13 @@
       "errorDetails": "Error Details",
       "noRecords": "No records found",
       "processingDescription": "{{processed}} of {{total}} records processed."
+    },
+    "delete": {
+      "confirm": {
+        "title": "Delete CSV extraction",
+        "description": "This CSV extraction will be permanently deleted. This action cannot be undone.",
+        "submit": "Delete"
+      }
     }
   }
 }

--- a/apps/web/src/common/features/agents/csv-extraction-runs/locales/agent-csv-extraction-run.fr.json
+++ b/apps/web/src/common/features/agents/csv-extraction-runs/locales/agent-csv-extraction-run.fr.json
@@ -54,6 +54,13 @@
       "errorDetails": "Détails de l'erreur",
       "noRecords": "Aucun enregistrement trouvé",
       "processingDescription": "{{processed}} sur {{total}} enregistrements traités."
+    },
+    "delete": {
+      "confirm": {
+        "title": "Supprimer l'extraction CSV",
+        "description": "Cette extraction CSV sera supprimée définitivement. Cette action est irréversible.",
+        "submit": "Supprimer"
+      }
     }
   }
 }

--- a/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
@@ -3,9 +3,10 @@ import { Button } from "@caseai-connect/ui/shad/button"
 import { useSidebar } from "@caseai-connect/ui/shad/sidebar"
 import { Spinner } from "@caseai-connect/ui/shad/spinner"
 import { AlertCircleIcon, Trash2Icon } from "lucide-react"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
+import { ConfirmDialog } from "@/common/components/ConfirmDialog"
 import { GridHeader } from "@/common/components/grid/Grid"
 import {
   selectCurrentCsvRunData,
@@ -54,6 +55,9 @@ function WithData() {
   const isCancelling = useAppSelector(selectIsCancellingCsvRun)
   const isRetrying = useAppSelector(selectIsRetryingCsvRun)
   const agentPath = useGetAgentRoute()
+
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+
   const handleBack = () => navigate(agentPath)
 
   const canCancel = run.status === "pending" || run.status === "running"
@@ -81,6 +85,7 @@ function WithData() {
 
   const handleDelete = () => {
     dispatch(agentCsvExtractionRunsActions.deleteOne({ agentCsvExtractionRunId: run.id }))
+    setConfirmDeleteOpen(false)
     handleBack()
   }
 
@@ -124,11 +129,19 @@ function WithData() {
               <DocumentOpener documentId={run.csvExportDocumentId} />
             ) : null}
 
-            <Button variant="secondary" size="icon" onClick={handleDelete}>
+            <Button variant="secondary" size="icon" onClick={() => setConfirmDeleteOpen(true)}>
               <Trash2Icon />
             </Button>
           </>
         }
+      />
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        title={t("agentCsvExtractionRun:delete.confirm.title")}
+        description={t("agentCsvExtractionRun:delete.confirm.description")}
+        confirmLabel={t("agentCsvExtractionRun:delete.confirm.submit")}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDeleteOpen(false)}
       />
       <div className="p-6 flex flex-col gap-6">
         <AgentCsvExtractionRunSummary run={run} />

--- a/apps/web/src/common/routes/agents/extraction/AgentExtractionRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentExtractionRoute.tsx
@@ -6,7 +6,10 @@ import { useNavigate, useOutlet } from "react-router-dom"
 import type { Document } from "@/studio/features/documents/documents.models"
 import { FileUploader } from "../../../components/FileUploader"
 import { GridHeader } from "../../../components/grid/Grid"
-import { selectIsExtracting } from "../../../features/agents/agent-sessions/extraction/extraction-agent-sessions.selectors"
+import {
+  selectExtractionAgentSessionsDocuments,
+  selectIsExtracting,
+} from "../../../features/agents/agent-sessions/extraction/extraction-agent-sessions.selectors"
 import { extractionAgentSessionsActions } from "../../../features/agents/agent-sessions/extraction/extraction-agent-sessions.slice"
 import { selectCurrentAgentData } from "../../../features/agents/agents.selectors"
 import { DocumentList } from "../../../features/agents/components/DocumentList"
@@ -16,20 +19,50 @@ import { CsvExtractor } from "../../../features/agents/csv-extraction-runs/compo
 import { useGetAgentRoute } from "../../../hooks/use-get-path"
 import { useValue } from "../../../hooks/use-value"
 import { useAppDispatch, useAppSelector } from "../../../store/hooks"
+import { AsyncRoute } from "../../AsyncRoute"
 import type { BuildAgentExtractionCsvRunRoute } from "../../build-routes/context"
 import { ErrorRoute } from "../../ErrorRoute"
 
-export function AgentExtractionRoute({
+export function AgentExtractionRoute(props: { buildCsvRunPath: BuildAgentExtractionCsvRunRoute }) {
+  const documents = useAppSelector(selectExtractionAgentSessionsDocuments)
+  const agent = useValue(selectCurrentAgentData)
+  const [csvDocumentId, setCsvDocumentId] = useState<string | null>(null)
+  const [openLastExtraction, setOpenLastExtraction] = useState(false)
+
+  if (agent.type !== "extraction")
+    return <ErrorRoute error={`${agent.name} is not an extraction agent`} />
+  return (
+    <AsyncRoute data={[documents]}>
+      <WithData
+        {...props}
+        agentId={agent.id}
+        csvDocumentId={csvDocumentId}
+        setCsvDocumentId={setCsvDocumentId}
+        openLastExtraction={openLastExtraction}
+        setOpenLastExtraction={setOpenLastExtraction}
+      />
+    </AsyncRoute>
+  )
+}
+
+function WithData({
   buildCsvRunPath,
+  agentId,
+  csvDocumentId,
+  setCsvDocumentId,
+  openLastExtraction,
+  setOpenLastExtraction,
 }: {
   buildCsvRunPath: BuildAgentExtractionCsvRunRoute
+  agentId: string
+  csvDocumentId: string | null
+  setCsvDocumentId: (id: string | null) => void
+  openLastExtraction: boolean
+  setOpenLastExtraction: (open: boolean) => void
 }) {
   const dispatch = useAppDispatch()
   const outlet = useOutlet()
   const navigate = useNavigate()
-  const agent = useValue(selectCurrentAgentData)
-  const [csvDocumentId, setCsvDocumentId] = useState<string | null>(null)
-  const [openLastExtraction, setOpenLastExtraction] = useState(false)
   const agentPath = useGetAgentRoute()
 
   const handleBack = () => navigate(agentPath)
@@ -37,15 +70,13 @@ export function AgentExtractionRoute({
   const handleSuccess = ({ isCsv, documentId }: { isCsv: boolean; documentId?: string }) => {
     if (isCsv && documentId) {
       setCsvDocumentId(documentId)
-      dispatch(agentCsvExtractionRunsThunks.getFileColumns({ agentId: agent.id, documentId }))
+      dispatch(agentCsvExtractionRunsThunks.getFileColumns({ agentId, documentId }))
     } else {
       setOpenLastExtraction(true)
     }
   }
 
-  if (agent.type !== "extraction")
-    return <ErrorRoute error={`${agent.name} is not an extraction agent`} />
-
+  if (openLastExtraction) return <LastExtraction onBack={handleBack} />
   if (outlet) return outlet
   if (csvDocumentId)
     return (
@@ -55,8 +86,7 @@ export function AgentExtractionRoute({
         documentId={csvDocumentId}
       />
     )
-  if (openLastExtraction) return <LastExtraction onBack={handleBack} />
-  return <FileManager agentId={agent.id} onSuccess={handleSuccess} />
+  return <FileManager agentId={agentId} onSuccess={handleSuccess} />
 }
 
 function FileManager({


### PR DESCRIPTION
## Summary

- After uploading a PDF, the last extraction result is now correctly shown — state was being reset when `AsyncRoute` remounted `WithData` on document store updates; fixed by lifting `openLastExtraction` and `csvDocumentId` state up to `AgentExtractionRoute`
- Deleting an extraction session (PDF/image or CSV) now opens a `ConfirmDialog` instead of deleting immediately, in three places: `ExtractionAgentSessionItem`, `CsvExtractionSessionItem`, and `AgentCsvExtractionRunRoute`