### PR TITLE
fix(extraction): refresh document list after CSV upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Fixed
 - Agent extraction PDF upload correctly shows the last extraction result after upload completes
 - Deleting an extraction run requires confirmation
+- Uploaded documents now appear in the extraction document list after upload (CSV uploads were not refreshing the list)
 
 ### Security
 

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.middleware.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.middleware.ts
@@ -2,6 +2,7 @@ import { createListenerMiddleware, isAnyOf } from "@reduxjs/toolkit"
 import { getCurrentId } from "@/common/features/helpers"
 import { notificationsActions } from "@/common/features/notifications/notifications.slice"
 import type { AppDispatch, RootState } from "@/common/store"
+import { agentCsvExtractionRunsThunks } from "../../csv-extraction-runs/agent-csv-extraction-runs.thunks"
 import { deleteAgentSession } from "../shared/base-agent-session/base-agent-sessions.thunks"
 import { extractionAgentSessionsActions } from "./extraction-agent-sessions.slice"
 
@@ -23,7 +24,12 @@ function registerListeners() {
   })
 
   listenerMiddleware.startListening({
-    matcher: isAnyOf(mount, executeOne.fulfilled, executeOne.rejected),
+    matcher: isAnyOf(
+      mount,
+      executeOne.fulfilled,
+      executeOne.rejected,
+      agentCsvExtractionRunsThunks.uploadCsvFile.fulfilled,
+    ),
     effect: async (_, listenerApi) => {
       listenerApi.dispatch(listMyDocuments())
     },


### PR DESCRIPTION
## Summary

After uploading a CSV file in the extraction agent, the document list was never refreshed — the uploaded document would not appear until the user navigated away and back. This happened because the `listMyDocuments` middleware listener only matched `mount`, `executeOne.fulfilled`, and `executeOne.rejected`. CSV uploads go through `uploadCsvFile` (not `executeOne`), so the refresh was never triggered.

Added `agentCsvExtractionRunsThunks.uploadCsvFile.fulfilled` to the matcher so `listMyDocuments` is called immediately after a CSV upload completes.