### PR TITLE
docs: add CITATION.cff + citing/credit policy

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+title: "Bayes Platform (AgentStudio)"
+abstract: >-
+  Open-source platform for building multi-agent AI systems for the public
+  interest, developed by the nonprofit Bayes Impact.
+type: software
+message: >-
+  If you build AI agents on the Bayes Platform, please cite it and add the
+  acknowledgment described in CITING.md. If your work was part of the Impulse
+  program, please mention it. See CITING.md for ready-to-paste text and for when
+  co-authorship is (and isn't) appropriate.
+authors:
+  - name: "Bayes Impact"
+    website: "https://www.bayesimpact.org"
+license: MIT
+repository-code: "https://github.com/bayesimpact/agent-studio"
+url: "https://www.bayesimpact.org"
+keywords:
+  - artificial intelligence
+  - multi-agent systems
+  - public services
+  - open source
+  - nonprofit
+# TODO: once a release DOI is minted (GitHub ↔ Zenodo integration) or a JOSS
+# software paper is published, set `version` + `date-released` per release, add
+# the `doi:` here, and add a `preferred-citation:` block pointing at that paper/DOI
+# so it becomes the canonical reference (see CITING.md). Until then, GitHub's
+# "Cite this repository" button uses the software metadata above.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,9 +6,8 @@ abstract: >-
 type: software
 message: >-
   If you build AI agents on the Bayes Platform, please cite it and add the
-  acknowledgment described in CITING.md. If your work was part of the Impulse
-  program, please mention it. See CITING.md for ready-to-paste text and for when
-  co-authorship is (and isn't) appropriate.
+  acknowledgment described in CITING.md. See CITING.md for ready-to-paste text and
+  for when co-authorship is (and isn't) appropriate.
 authors:
   - name: "Bayes Impact"
     website: "https://www.bayesimpact.org"

--- a/CITING.md
+++ b/CITING.md
@@ -1,0 +1,93 @@
+# Citing & crediting the Bayes Platform
+
+Built something on the Bayes Platform — especially through the **Impulse** program —
+and publishing a paper, report, or case study? Thank you. Here's how to credit it.
+
+**TL;DR:** please **cite** the platform and add a one-line **acknowledgment**. You do
+**not** need to offer co-authorship just for using the platform — that's not how tool
+and infrastructure credit works (see below). The agent and the results are yours; we
+just want the platform's role on the record.
+
+---
+
+## 1 · Cite the platform (in Methods)
+
+A one-line mention in your Methods/Tools section:
+
+> Agents were built using the open-source Bayes Platform (AgentStudio; Bayes Impact),
+> available at <https://github.com/bayesimpact/agent-studio>.
+
+BibTeX:
+
+```bibtex
+@software{bayes_platform,
+  author = {{Bayes Impact}},
+  title  = {{Bayes Platform (AgentStudio)}},
+  url    = {https://github.com/bayesimpact/agent-studio},
+  note   = {Open-source platform for multi-agent AI systems for the public interest},
+  year   = {2026}
+}
+```
+
+<!-- TODO: once a release DOI / JOSS paper exists, this becomes the canonical
+     citation (DOI + the paper). GitHub's "Cite this repository" button (from
+     CITATION.cff) will then export it automatically. -->
+
+> 💡 GitHub shows a **"Cite this repository"** button on this repo (powered by
+> `CITATION.cff`) that exports APA/BibTeX — point colleagues there.
+
+---
+
+## 2 · Add an acknowledgment (in Acknowledgments)
+
+Copy-paste, bilingual:
+
+**EN** — *The AI agents in this work were built on the open-source Bayes Platform
+(AgentStudio), developed by the nonprofit Bayes Impact (https://www.bayesimpact.org).
+This work was carried out as part of Bayes Impact's Impulse program.*
+
+**FR** — *Les agents IA de ce travail ont été développés sur la plateforme open-source
+Bayes Platform (AgentStudio), créée par l'association Bayes Impact
+(https://www.bayesimpact.org). Ce travail a été réalisé dans le cadre du programme
+Impulse de Bayes Impact.*
+
+(Drop the Impulse sentence if your work wasn't part of the program.)
+
+---
+
+## 3 · Co-authorship — only when it's actually earned
+
+We **do not ask for co-authorship in exchange for using the platform.** Under standard
+[authorship criteria (ICMJE)](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html),
+providing a tool or platform is an **acknowledgment**, not authorship — and listing
+people who didn't do authorship-level work ("guest authorship") is something good
+research integrity avoids.
+
+Co-authorship makes sense **only** when a specific Bayes contributor genuinely meets
+the criteria *for your paper* — e.g. they co-designed the agent or method, helped
+analyze or interpret the results, or helped draft the manuscript. In that case, treat
+it like any collaborator: that individual is offered authorship for that paper. It's a
+per-paper judgment, never a blanket requirement. If you think a Bayes teammate's
+involvement crossed that line, talk to them — we're glad to.
+
+---
+
+## 4 · Funder requirements (pass-through)
+
+If your work was supported through a Bayes program funded by a third party, that
+funder may have its **own** required wording (for example, Google.org-supported work
+uses the *"with support from Google.org"* lock-up and specific phrasing). When that
+applies, we'll flag it during the program — include the funder's wording **in addition
+to** the acknowledgment above, in a separate funding statement.
+
+---
+
+## 5 · Why we ask
+
+We're a nonprofit and the platform is open-source. Citations are how we **show our
+real-world impact** (to funders, to the field) and how the project stays **sustainably
+funded** — the same reason research-infrastructure projects like REDCap ask to be cited.
+It costs you a sentence and helps keep the platform free and improving for everyone.
+
+Questions, or want to discuss a collaboration or co-authored paper?
+**contact@bayesimpact.org**

--- a/CITING.md
+++ b/CITING.md
@@ -1,7 +1,7 @@
 # Citing & crediting the Bayes Platform
 
-Built something on the Bayes Platform — especially through the **Impulse** program —
-and publishing a paper, report, or case study? Thank you. Here's how to credit it.
+Built something on the **Bayes Platform** and publishing a paper, report, or case
+study? Thank you. Here's how to credit it.
 
 **TL;DR:** please **cite** the platform and add a one-line **acknowledgment**. You do
 **not** need to offer co-authorship just for using the platform — that's not how tool
@@ -42,16 +42,15 @@ BibTeX:
 
 Copy-paste, bilingual:
 
-**EN** — *The AI agents in this work were built on the open-source Bayes Platform
-(AgentStudio), developed by the nonprofit Bayes Impact (https://www.bayesimpact.org).
-This work was carried out as part of Bayes Impact's Impulse program.*
+**EN** — *The AI agents in this work were built on the open-source Bayes Platform,
+developed by the nonprofit Bayes Impact (https://www.bayesimpact.org).*
 
-**FR** — *Les agents IA de ce travail ont été développés sur la plateforme open-source
-Bayes Platform (AgentStudio), créée par l'association Bayes Impact
-(https://www.bayesimpact.org). Ce travail a été réalisé dans le cadre du programme
-Impulse de Bayes Impact.*
+**FR** — *Les agents IA de ce travail ont été développés sur la Bayes Platform
+open-source, créée par l'association Bayes Impact (https://www.bayesimpact.org).*
 
-(Drop the Impulse sentence if your work wasn't part of the program.)
+*Optional:* if your work was part of a Bayes program, add a clause naming it — e.g.
+EN *"…, as part of Bayes Impact's Impulse program."* / FR *"…, dans le cadre du
+programme Impulse de Bayes Impact."*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -599,8 +599,8 @@ If port 3000 is already in use:
 
 ## Citing & credit
 
-Publishing about agents you built on the platform (especially via the **Impulse**
-program)? Please **cite** it and add a one-line **acknowledgment** — see
+Publishing about agents you built on the **Bayes Platform**? Please **cite** it and
+add a one-line **acknowledgment** — see
 [`CITING.md`](CITING.md). Using the platform doesn't require co-authorship; `CITING.md`
 explains when co-authorship is (and isn't) appropriate. GitHub's "Cite this repository"
 button (from [`CITATION.cff`](CITATION.cff)) exports a ready BibTeX/APA citation.

--- a/README.md
+++ b/README.md
@@ -596,3 +596,11 @@ If port 3000 is already in use:
 - [TypeORM Documentation](https://typeorm.io)
 - [Turbo Documentation](https://turbo.build/repo/docs)
 - [Auth0 Documentation](https://auth0.com/docs)
+
+## Citing & credit
+
+Publishing about agents you built on the platform (especially via the **Impulse**
+program)? Please **cite** it and add a one-line **acknowledgment** — see
+[`CITING.md`](CITING.md). Using the platform doesn't require co-authorship; `CITING.md`
+explains when co-authorship is (and isn't) appropriate. GitHub's "Cite this repository"
+button (from [`CITATION.cff`](CITATION.cff)) exports a ready BibTeX/APA citation.


### PR DESCRIPTION
Makes the platform **citable** and documents how partners (especially via **Impulse**) should credit it — implementing the policy we discussed (cite + acknowledge by default; co-authorship only when genuinely earned).

### What's added
- **`CITATION.cff`** — GitHub now shows a **"Cite this repository"** button that exports BibTeX/APA. Uses software metadata for now; a `# TODO` marks where a **release DOI** (GitHub↔Zenodo) or a **[JOSS](https://joss.theoj.org/) paper** becomes the canonical citation.
- **`CITING.md`** — the one-pager:
  - **Cite** (Methods one-liner + BibTeX).
  - **Acknowledge** — ready-to-paste **FR/EN** sentence.
  - **Co-authorship** — *not* required for platform use ([ICMJE](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html): providing a tool = acknowledgment, not authorship); offered only when a Bayes contributor genuinely meets authorship criteria for that paper.
  - **Funder pass-through** (e.g. Google.org "with support from" wording).
  - **Why we ask** (impact tracking + sustaining the open-source project — the REDCap rationale).
- **README** — short "Citing & credit" pointer.

### Next (to make the citation canonical)
Mint a **Zenodo DOI** per release (fast) or publish a short **JOSS** paper (stronger), then fill the `# TODO`s in `CITATION.cff` / `CITING.md` so everything points at one peer-reviewed/DOI'd reference — the scikit-learn pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)