### PR TITLE
feat(extraction): show duration on successful run result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Successful extraction runs display their duration on the result page
 
 ### Changed
 

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.en.json
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.en.json
@@ -17,7 +17,8 @@
       },
       "download": {
         "button": "Download JSON"
-      }
+      },
+      "duration": "Duration: {{duration}}"
     },
     "document": {
       "props": {

--- a/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.fr.json
+++ b/apps/web/src/common/features/agents/agent-sessions/extraction/locales/extraction-agent-session.fr.json
@@ -17,7 +17,8 @@
       },
       "download": {
         "button": "Télécharger JSON"
-      }
+      },
+      "duration": "Durée : {{duration}}"
     },
     "document": {
       "props": {

--- a/apps/web/src/common/routes/agents/extraction/AgentExtractionRunRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentExtractionRunRoute.tsx
@@ -13,7 +13,7 @@ import { useGetAgentRoute } from "@/common/hooks/use-get-path"
 import { useMount } from "@/common/hooks/use-mount"
 import { useValue } from "@/common/hooks/use-value"
 import { useAppSelector } from "@/common/store/hooks"
-import { buildSince } from "@/common/utils/build-date"
+import { buildDuration, buildSince } from "@/common/utils/build-date"
 import { TraceUrlOpener } from "@/studio/components/TraceUrlOpener"
 import { AsyncRoute } from "../../AsyncRoute"
 import { LoadingRoute } from "../../LoadingRoute"
@@ -59,6 +59,13 @@ function WithData() {
               <Badge variant={isSuccess ? "success" : isPending ? "outline" : "destructive"}>
                 {t(`status:${run.status}`)}
               </Badge>
+              {isSuccess && (
+                <Badge variant="secondary">
+                  {t("extractionAgentSession:result.duration", {
+                    duration: buildDuration(run.createdAt, run.updatedAt),
+                  })}
+                </Badge>
+              )}
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary
- Display the run duration as a badge on the extraction run result page for successful runs
- Compute it from `createdAt`/`updatedAt` via `buildDuration`
- Add the `result.duration` i18n key in EN/FR

🤖 Generated with [Claude Code](https://claude.com/claude-code)