### PR TITLE
feat: allow agents to delegate to form and conversation sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Agents can delegate to a form agent as a sub-agent: the parent passes the user's latest answer, and the form sub-agent fills the form and replies with the current form state and the next question to ask
+- Agents can delegate to a conversation agent as a sub-agent: the parent passes the user's latest answer, and the conversation sub-agent answers using its own tools and replies to the parent agent
+- Sub-agent runs are recorded as their own Langfuse trace, linked back to the parent agent's trace
 
 ### Changed
 

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/build-tools.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/build-tools.spec.ts
@@ -5,12 +5,19 @@ import { agentSessionControllerTestSetup } from "./test-setup"
 
 const getTestContext = agentSessionControllerTestSetup()
 
+type AgentSessionScope = Parameters<StreamingService["streamAgentResponse"]>[0]["agentSessionScope"]
+
 type BuildToolsArgs = {
-  agent: Parameters<StreamingService["streamAgentResponse"]>[0]["agent"]
-  sessionId: string
-  connectScope: RequiredConnectScope
+  agentSessionScope: AgentSessionScope
   onExecute: () => void
 }
+
+const buildSessionStub = (sessionId: string): AgentSessionScope["session"] =>
+  ({
+    id: sessionId,
+    traceId: sessionId,
+    organizationId: "organization-id",
+  }) as AgentSessionScope["session"]
 
 type BuildToolsAccessor = {
   buildTools: (args: BuildToolsArgs) => Promise<{
@@ -21,16 +28,18 @@ type BuildToolsAccessor = {
 
 describe("buildTools", () => {
   it("should omit document retrieval when documentsRagMode is none", async () => {
-    const { streamingService, testAgent, testOrganization, testProject } = getTestContext()
+    const { toolsService, testAgent, testOrganization, testProject } = getTestContext()
     const connectScope: RequiredConnectScope = {
       organizationId: testOrganization.id,
       projectId: testProject.id,
     }
 
-    const { tools } = await (streamingService as unknown as BuildToolsAccessor).buildTools({
-      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
-      sessionId: "session-id",
-      connectScope,
+    const { tools } = await (toolsService as unknown as BuildToolsAccessor).buildTools({
+      agentSessionScope: {
+        agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
+        session: buildSessionStub("session-id"),
+        connectScope,
+      },
       onExecute: () => undefined,
     })
 
@@ -39,16 +48,18 @@ describe("buildTools", () => {
   })
 
   it("should expose document retrieval when documentsRagMode is all", async () => {
-    const { streamingService, testAgent, testOrganization, testProject } = getTestContext()
+    const { toolsService, testAgent, testOrganization, testProject } = getTestContext()
     const connectScope: RequiredConnectScope = {
       organizationId: testOrganization.id,
       projectId: testProject.id,
     }
 
-    const { tools } = await (streamingService as unknown as BuildToolsAccessor).buildTools({
-      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.All },
-      sessionId: "session-id",
-      connectScope,
+    const { tools } = await (toolsService as unknown as BuildToolsAccessor).buildTools({
+      agentSessionScope: {
+        agent: { ...testAgent, documentsRagMode: DocumentsRagMode.All },
+        session: buildSessionStub("session-id"),
+        connectScope,
+      },
       onExecute: () => undefined,
     })
 
@@ -57,16 +68,18 @@ describe("buildTools", () => {
   })
 
   it("should expose document retrieval when documentsRagMode is tags", async () => {
-    const { streamingService, testAgent, testOrganization, testProject } = getTestContext()
+    const { toolsService, testAgent, testOrganization, testProject } = getTestContext()
     const connectScope: RequiredConnectScope = {
       organizationId: testOrganization.id,
       projectId: testProject.id,
     }
 
-    const { tools } = await (streamingService as unknown as BuildToolsAccessor).buildTools({
-      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.Tags },
-      sessionId: "session-id",
-      connectScope,
+    const { tools } = await (toolsService as unknown as BuildToolsAccessor).buildTools({
+      agentSessionScope: {
+        agent: { ...testAgent, documentsRagMode: DocumentsRagMode.Tags },
+        session: buildSessionStub("session-id"),
+        connectScope,
+      },
       onExecute: () => undefined,
     })
 
@@ -76,7 +89,7 @@ describe("buildTools", () => {
 
   it("should expose metadata recalculation tool when agent has categories", async () => {
     const {
-      streamingService,
+      toolsService,
       service,
       testAgent,
       testOrganization,
@@ -102,14 +115,16 @@ describe("buildTools", () => {
       type: "playground",
     })
 
-    const { tools } = await (streamingService as unknown as BuildToolsAccessor).buildTools({
-      agent: {
-        ...testAgent,
-        sessionCategories: [savedCategory],
-        documentsRagMode: DocumentsRagMode.None,
+    const { tools } = await (toolsService as unknown as BuildToolsAccessor).buildTools({
+      agentSessionScope: {
+        agent: {
+          ...testAgent,
+          sessionCategories: [savedCategory],
+          documentsRagMode: DocumentsRagMode.None,
+        },
+        session,
+        connectScope,
       },
-      sessionId: session.id,
-      connectScope,
       onExecute: () => undefined,
     })
 
@@ -120,7 +135,7 @@ describe("buildTools", () => {
     const {
       agentRepository,
       agentSubAgentRepository,
-      streamingService,
+      toolsService,
       testAgent,
       testOrganization,
       testProject,
@@ -153,11 +168,13 @@ describe("buildTools", () => {
     )
 
     const { tools, toolDescriptions } = await (
-      streamingService as unknown as BuildToolsAccessor
+      toolsService as unknown as BuildToolsAccessor
     ).buildTools({
-      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
-      sessionId: "session-id",
-      connectScope,
+      agentSessionScope: {
+        agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
+        session: buildSessionStub("session-id"),
+        connectScope,
+      },
       onExecute: () => undefined,
     })
 
@@ -170,7 +187,7 @@ describe("buildTools", () => {
       agentRepository,
       agentSubAgentRepository,
       featureFlagRepository,
-      streamingService,
+      toolsService,
       testAgent,
       testOrganization,
       testProject,
@@ -210,11 +227,13 @@ describe("buildTools", () => {
     )
 
     const { tools, toolDescriptions } = await (
-      streamingService as unknown as BuildToolsAccessor
+      toolsService as unknown as BuildToolsAccessor
     ).buildTools({
-      agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
-      sessionId: "session-id",
-      connectScope,
+      agentSessionScope: {
+        agent: { ...testAgent, documentsRagMode: DocumentsRagMode.None },
+        session: buildSessionStub("session-id"),
+        connectScope,
+      },
       onExecute: () => undefined,
     })
 

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/finalize-streaming.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/finalize-streaming.spec.ts
@@ -25,8 +25,7 @@ describe("finalizeStreaming", () => {
     })
 
     const { assistantMessageId } = await streamingService.prepareForStreaming({
-      connectScope,
-      sessionId: session.id,
+      agentSessionScope: { agent: testAgent, session, connectScope },
       userContent: "Hello",
       agentType: testAgent.type,
     })

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/find-or-create-sub-session.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/find-or-create-sub-session.spec.ts
@@ -1,0 +1,94 @@
+import { afterAll } from "@jest/globals"
+import { conversationAgentSessionFactory } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { agentSessionControllerTestSetup } from "./test-setup"
+
+const getTestContext = agentSessionControllerTestSetup()
+
+const PARENT_SESSION_ID = "11111111-1111-1111-1111-111111111111"
+
+describe("findOrCreateSubSession", () => {
+  afterAll(async () => {
+    await sdk.shutdown()
+  })
+
+  it("creates a conversation sub-session marked as a sub-session and linked to the parent", async () => {
+    const { service, testAgent, testOrganization, testProject, testUser } = getTestContext()
+
+    const session = await service.findOrCreateSubSession({
+      connectScope: { organizationId: testOrganization.id, projectId: testProject.id },
+      agentId: testAgent.id,
+      userId: testUser.id,
+      parentSessionId: PARENT_SESSION_ID,
+      type: "playground",
+    })
+
+    expect(session.isSubSession).toBe(true)
+    expect(session.parentSessionId).toBe(PARENT_SESSION_ID)
+    expect(session.agentId).toBe(testAgent.id)
+    expect(session.userId).toBe(testUser.id)
+    expect(session.type).toBe("playground")
+  })
+
+  it("reuses the existing sub-session for the same parent session and conversation agent", async () => {
+    const { service, testAgent, testOrganization, testProject, testUser } = getTestContext()
+    const connectScope = { organizationId: testOrganization.id, projectId: testProject.id }
+
+    const first = await service.findOrCreateSubSession({
+      connectScope,
+      agentId: testAgent.id,
+      userId: testUser.id,
+      parentSessionId: PARENT_SESSION_ID,
+      type: "playground",
+    })
+    const second = await service.findOrCreateSubSession({
+      connectScope,
+      agentId: testAgent.id,
+      userId: testUser.id,
+      parentSessionId: PARENT_SESSION_ID,
+      type: "playground",
+    })
+
+    expect(second.id).toBe(first.id)
+  })
+
+  it("excludes sub-sessions from the user-facing session list", async () => {
+    const {
+      service,
+      testAgent,
+      testOrganization,
+      testProject,
+      testUser,
+      conversationAgentSessionRepository,
+    } = getTestContext()
+    const connectScope = { organizationId: testOrganization.id, projectId: testProject.id }
+
+    const userSession = conversationAgentSessionFactory
+      .transient({
+        organization: testOrganization,
+        project: testProject,
+        agent: testAgent,
+        user: testUser,
+      })
+      .playground()
+      .build()
+    await conversationAgentSessionRepository.save(userSession)
+
+    await service.findOrCreateSubSession({
+      connectScope,
+      agentId: testAgent.id,
+      userId: testUser.id,
+      parentSessionId: PARENT_SESSION_ID,
+      type: "playground",
+    })
+
+    const listed = await service.getAllSessionsForAgent({
+      connectScope,
+      agentId: testAgent.id,
+      userId: testUser.id,
+      type: "playground",
+    })
+
+    expect(listed.map((session) => session.id)).toEqual([userSession.id])
+  })
+})

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/mark-streaming-error.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/mark-streaming-error.spec.ts
@@ -24,8 +24,7 @@ describe("markStreamingError", () => {
     })
 
     const { assistantMessageId } = await streamingService.prepareForStreaming({
-      connectScope,
-      sessionId: session.id,
+      agentSessionScope: { agent: testAgent, session, connectScope },
       userContent: "Hello",
       agentType: testAgent.type,
     })

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/prepare-for-streaming.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/prepare-for-streaming.spec.ts
@@ -27,8 +27,7 @@ describe("prepareForStreaming", () => {
 
     const { session: updatedSession, assistantMessageId } =
       await streamingService.prepareForStreaming({
-        connectScope,
-        sessionId: session.id,
+        agentSessionScope: { agent: testAgent, session, connectScope },
         userContent: "Hello, how are you?",
         agentType: testAgent.type,
       })
@@ -56,10 +55,15 @@ describe("prepareForStreaming", () => {
 
     // Use a valid UUID format for non-existent session
     const nonExistentId = "00000000-0000-0000-0000-000000000000"
+    const session = {
+      id: nonExistentId,
+      traceId: nonExistentId,
+      organizationId: testOrganization.id,
+      messages: [],
+    }
     await expect(
       streamingService.prepareForStreaming({
-        connectScope,
-        sessionId: nonExistentId,
+        agentSessionScope: { agent: testAgent, session: session as never, connectScope },
         userContent: "Hello",
         agentType: testAgent.type,
       }),

--- a/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/agent-sessions-service-tests/test-setup.ts
@@ -20,6 +20,7 @@ import { userFactory } from "@/domains/users/user.factory"
 import { sdk } from "@/external/llm/open-telemetry-init"
 import { AgentMessage } from "../../shared/agent-session-messages/agent-message.entity"
 import { StreamingService } from "../../shared/agent-session-messages/streaming/streaming.service"
+import { ToolsService } from "../../shared/agent-session-messages/streaming/tools.service"
 import { ConversationAgentSession } from "../conversation-agent-session.entity"
 import { ConversationAgentSessionCategory } from "../conversation-agent-session-category.entity"
 import { ConversationAgentSessionsModule } from "../conversation-agent-sessions.module"
@@ -28,6 +29,7 @@ import { ConversationAgentSessionsService } from "../conversation-agent-sessions
 export function agentSessionControllerTestSetup() {
   let service: ConversationAgentSessionsService
   let streamingService: StreamingService
+  let toolsService: ToolsService
   let conversationAgentSessionRepository: Repository<ConversationAgentSession>
   let conversationAgentSessionCategoryRepository: Repository<ConversationAgentSessionCategory>
   let agentRepository: Repository<Agent>
@@ -62,6 +64,7 @@ export function agentSessionControllerTestSetup() {
     await clearTestDatabase(setup.dataSource)
     service = setup.module.get<ConversationAgentSessionsService>(ConversationAgentSessionsService)
     streamingService = setup.module.get<StreamingService>(StreamingService)
+    toolsService = setup.module.get<ToolsService>(ToolsService)
     conversationAgentSessionRepository = setup.getRepository(ConversationAgentSession)
     conversationAgentSessionCategoryRepository = setup.getRepository(
       ConversationAgentSessionCategory,
@@ -129,6 +132,7 @@ export function agentSessionControllerTestSetup() {
       testUser,
       userRepository,
       streamingService,
+      toolsService,
     }
   }
 }

--- a/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-session.entity.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-session.entity.ts
@@ -25,6 +25,20 @@ export class ConversationAgentSession extends ConnectEntityBase {
   @Column({ type: "varchar", nullable: true })
   title!: string | null
 
+  // The parent agent session that spawned this sub-session, if any. Used to
+  // find-or-create a single conversation sub-session per parent conversation so
+  // the sub-agent's turns land in one persistent trace. Its presence is what
+  // marks a session as a sub-session (see {@link isSubSession}).
+  @Column({ type: "uuid", name: "parent_session_id", nullable: true })
+  parentSessionId!: string | null
+
+  // True when this conversation session was created on behalf of a parent agent
+  // that delegates to this conversation agent as a sub-agent. Derived from
+  // parentSessionId so there is no separate column to keep in sync.
+  get isSubSession(): boolean {
+    return this.parentSessionId != null
+  }
+
   @Column({ type: "timestamp", nullable: true, name: "expires_at" }) // FIXME: to be removed
   expiresAt!: Date | null
 

--- a/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-session.factory.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-session.factory.ts
@@ -58,6 +58,8 @@ export const conversationAgentSessionFactory = ConversationAgentSessionFactory.d
       projectId: transientParams.project.id,
       type: params.type || "playground",
       title: params.title ?? null,
+      parentSessionId: params.parentSessionId ?? null,
+      isSubSession: (params.parentSessionId ?? null) !== null,
       expiresAt: params.expiresAt ?? defaultExpiresAt,
       createdAt: params.createdAt || now,
       updatedAt: params.updatedAt || now,

--- a/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
-import type { Repository } from "typeorm"
+import { IsNull, type Repository } from "typeorm"
 import { v4 } from "uuid"
 
 import { ConnectRepository } from "@/common/entities/connect-repository"
@@ -82,8 +82,46 @@ export class ConversationAgentSessionsService {
     type: BaseAgentSessionType
   }): Promise<ConversationAgentSession[]> {
     return await this.conversationAgentSessionConnectRepository.find(connectScope, {
-      where: { agentId, userId, type },
+      // Exclude sub-sessions (those with a parent session): these are internal
+      // artifacts created when a parent agent delegates to this conversation
+      // agent, not user-facing sessions.
+      where: { agentId, userId, type, parentSessionId: IsNull() },
       order: { createdAt: "DESC" },
+    })
+  }
+
+  /**
+   * Finds the conversation sub-session spawned by a parent agent session for a
+   * given conversation sub-agent, or creates it if it does not exist yet. A
+   * single sub-session is reused across parent turns so the sub-agent's runs all
+   * land in one persistent trace.
+   */
+  async findOrCreateSubSession({
+    connectScope,
+    agentId,
+    userId,
+    parentSessionId,
+    type,
+  }: {
+    connectScope: RequiredConnectScope
+    agentId: string
+    userId: string
+    parentSessionId: string
+    type: BaseAgentSessionType
+  }): Promise<ConversationAgentSession> {
+    const existing = await this.conversationAgentSessionConnectRepository.find(connectScope, {
+      where: { agentId, parentSessionId, type },
+      take: 1,
+    })
+    if (existing[0]) return existing[0]
+
+    return this.conversationAgentSessionConnectRepository.createAndSave(connectScope, {
+      agentId,
+      userId,
+      type,
+      parentSessionId,
+      expiresAt: null,
+      traceId: v4(),
     })
   }
 

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-session.entity.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-session.entity.ts
@@ -21,6 +21,20 @@ export class FormAgentSession extends ConnectEntityBase {
   @Column({ type: "jsonb", nullable: true })
   result!: Record<string, unknown> | null
 
+  // The parent agent session that spawned this sub-session, if any. Used to
+  // find-or-create a single sub form session per parent conversation so the
+  // form state accumulates across turns. Its presence is what marks a session as
+  // a sub-session (see {@link isSubSession}).
+  @Column({ type: "uuid", name: "parent_session_id", nullable: true })
+  parentSessionId!: string | null
+
+  // True when this form session was created on behalf of a parent agent that
+  // delegates to this form agent as a sub-agent. Derived from parentSessionId so
+  // there is no separate column to keep in sync.
+  get isSubSession(): boolean {
+    return this.parentSessionId != null
+  }
+
   @OneToMany(
     () => AgentMessage,
     (message) => message.formAgentSession,

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-session.factory.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-session.factory.ts
@@ -39,6 +39,8 @@ export const formAgentSessionFactory = FormAgentSessionFactory.define(
       messages: params.messages || [],
       traceId: v4(),
       result: params.result || null,
+      parentSessionId: params.parentSessionId ?? null,
+      isSubSession: (params.parentSessionId ?? null) !== null,
       campaignId: params.campaignId ?? null,
       reviewCampaign: null,
     } satisfies FormAgentSession

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.spec.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.spec.ts
@@ -1,0 +1,153 @@
+import { afterAll } from "@jest/globals"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { AgentsModule } from "../agents.module"
+import { FormAgentSessionsService } from "./form-agent-sessions.service"
+
+const PARENT_SESSION_ID = "11111111-1111-1111-1111-111111111111"
+
+describe("FormAgentSessionsService", () => {
+  let service: FormAgentSessionsService
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [AgentsModule],
+    })
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await sdk.shutdown()
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    service = setup.module.get<FormAgentSessionsService>(FormAgentSessionsService)
+    repositories = setup.getAllRepositories()
+  })
+
+  const createFormAgent = async () => {
+    const { organization, project, user } = await createOrganizationWithAgent(repositories)
+    const formAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        name: "Intake Form",
+        type: "form",
+        outputJsonSchema: { type: "object", properties: {} },
+      }),
+    )
+    return {
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      formAgent,
+      user,
+    }
+  }
+
+  describe("findOrCreateSubSession", () => {
+    it("creates a form sub-session marked as a sub-session and linked to the parent", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      const session = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+
+      expect(session.isSubSession).toBe(true)
+      expect(session.parentSessionId).toBe(PARENT_SESSION_ID)
+      expect(session.agentId).toBe(formAgent.id)
+      expect(session.userId).toBe(user.id)
+      expect(session.type).toBe("playground")
+    })
+
+    it("reuses the existing sub-session for the same parent session and form agent", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      const first = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+      const second = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+
+      expect(second.id).toBe(first.id)
+      const sessions = await repositories.formAgentSessionRepository.find({
+        where: { parentSessionId: PARENT_SESSION_ID },
+      })
+      expect(sessions).toHaveLength(1)
+    })
+
+    it("keeps the accumulated form state when reusing the sub-session", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      const created = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+      await service.updateSessionResult({
+        connectScope,
+        sessionId: created.id,
+        input: { name: "Alex" },
+      })
+
+      const reused = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+
+      expect(reused.id).toBe(created.id)
+      expect(reused.result).toEqual({ name: "Alex" })
+    })
+
+    it("excludes sub-sessions from the user-facing session list", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      const userSession = await service.createSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        type: "playground",
+      })
+      await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+
+      const listed = await service.listSessions({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        type: "playground",
+      })
+
+      expect(listed.map((session) => session.id)).toEqual([userSession.id])
+    })
+  })
+})

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
-import type { Repository } from "typeorm"
+import { IsNull, type Repository } from "typeorm"
 import { v4 } from "uuid"
 import { ConnectRepository } from "@/common/entities/connect-repository"
 import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
@@ -48,7 +48,10 @@ export class FormAgentSessionsService {
     type: BaseAgentSessionType
   }): Promise<FormAgentSession[]> {
     return this.sessionConnectRepository.find(connectScope, {
-      where: { agentId, type, userId },
+      // Exclude sub-sessions (those with a parent session): these are internal
+      // artifacts created when a parent agent delegates to this form agent, not
+      // user-facing sessions.
+      where: { agentId, type, userId, parentSessionId: IsNull() },
       order: { createdAt: "DESC" },
     })
   }
@@ -108,6 +111,40 @@ export class FormAgentSessionsService {
     const session = sessions[0]
     if (!session) return null
     return session
+  }
+
+  /**
+   * Finds the form sub-session spawned by a parent agent session for a given
+   * form sub-agent, or creates it if it does not exist yet. A single sub-session
+   * is reused across parent turns so the form state accumulates.
+   */
+  async findOrCreateSubSession({
+    connectScope,
+    agentId,
+    userId,
+    parentSessionId,
+    type,
+  }: {
+    connectScope: RequiredConnectScope
+    agentId: string
+    userId: string
+    parentSessionId: string
+    type: BaseAgentSessionType
+  }): Promise<FormAgentSession> {
+    const existing = await this.sessionConnectRepository.find(connectScope, {
+      where: { agentId, parentSessionId, type },
+      take: 1,
+    })
+    if (existing[0]) return existing[0]
+
+    return this.sessionConnectRepository.createAndSave(connectScope, {
+      agentId,
+      userId,
+      type,
+      parentSessionId,
+      result: null,
+      traceId: v4(),
+    })
   }
 
   async updateSessionResult({

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/generate-master-prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/generate-master-prompt.ts
@@ -1,0 +1,19 @@
+import type { Agent } from "@/domains/agents/agent.entity"
+import { buildConversationAgentPrompt } from "./conversation-agent.prompt"
+import { buildFormAgentPrompt } from "./form-agent.prompt"
+
+export function generateMasterPrompt(params: {
+  agent: Agent
+  toolDescriptions?: Record<string, string>
+  toolNames: string[]
+}): string {
+  const agentType = params.agent.type
+  switch (agentType) {
+    case "form":
+      return buildFormAgentPrompt(params)
+    case "conversation":
+      return buildConversationAgentPrompt(params)
+    default:
+      throw new Error(`Unsupported agent type: ${agentType}`)
+  }
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
@@ -1,6 +1,9 @@
+import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
+import type { Agent } from "@/domains/agents/agent.entity"
 import type { ConversationAgentSession } from "../../../conversation-agent-sessions/conversation-agent-session.entity"
 import type { FormAgentSession } from "../../../form-agent-sessions/form-agent-session.entity"
 import type { AgentMessage } from "../agent-message.entity"
+import type { ToolExecutionLog } from "./tools/tool-execution-log"
 
 /**
  * Minimal session context for public/anonymous sessions that have no
@@ -17,3 +20,11 @@ export type StreamingSession =
   | ConversationAgentSession
   | FormAgentSession
   | PublicStreamingSessionProxy
+
+export type AgentSessionScope = {
+  agent: Agent
+  session: StreamingSession
+  connectScope: RequiredConnectScope
+}
+
+export type OnExecute = (toolExecution: ToolExecutionLog) => void

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.controller.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.controller.ts
@@ -12,6 +12,7 @@ import { JwtAuthGuard } from "@/domains/auth/jwt-auth.guard"
 import { UserGuard } from "@/domains/users/user.guard"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { StreamingService } from "./streaming.service"
+import type { AgentSessionScope } from "./streaming-session.types"
 
 @UseGuards(JwtAuthGuard, UserGuard, ResourceContextGuard)
 @RequireContext("organization", "project", "agent", "agentSession")
@@ -32,7 +33,12 @@ export class StreamingController {
       const organizationId = request.organizationId
       const projectId = request.project.id
       const agent = request.agent
-      const sessionId = request.agentSession.id
+
+      const agentSessionScope: AgentSessionScope = {
+        connectScope: { organizationId, projectId },
+        agent,
+        session: request.agentSession,
+      }
 
       if (!userContent) {
         throw new ForbiddenException("Missing user content")
@@ -46,9 +52,7 @@ export class StreamingController {
         void (async () => {
           try {
             const events = this.chatStreamingService.streamAgentResponse({
-              connectScope: { organizationId, projectId },
-              agent,
-              sessionId,
+              agentSessionScope,
               userContent,
               attachmentDocumentId,
               notifyClient: (event) => {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.module.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.module.ts
@@ -14,6 +14,7 @@ import { McpModule } from "@/external/mcp"
 import { AgentMessageAttachmentDocumentsService } from "../agent-message-attachment-documents.service"
 import { StreamingController } from "./streaming.controller"
 import { StreamingService } from "./streaming.service"
+import { ToolsService } from "./tools.service"
 
 @Module({
   imports: [
@@ -24,7 +25,12 @@ import { StreamingService } from "./streaming.service"
     McpServersModule,
     forwardRef(() => ConversationAgentSessionsModule),
   ],
-  providers: [...moduleProviders, AgentMessageAttachmentDocumentsService, StreamingService],
+  providers: [
+    ...moduleProviders,
+    AgentMessageAttachmentDocumentsService,
+    StreamingService,
+    ToolsService,
+  ],
   controllers: [StreamingController],
   exports: [StreamingService],
 })

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
@@ -1,13 +1,8 @@
 import { URL } from "node:url"
-import {
-  DocumentsRagMode,
-  type StreamEvent,
-  type StreamEventPayload,
-  ToolName,
-} from "@caseai-connect/api-contracts"
+import type { StreamEvent, StreamEventPayload } from "@caseai-connect/api-contracts"
 import { Inject, Injectable, Logger, NotFoundException } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
-import type { FilePart, ImagePart, ToolSet } from "ai"
+import type { FilePart, ImagePart } from "ai"
 import type { Repository } from "typeorm/repository/Repository"
 import { v4 } from "uuid"
 import { ConnectRepository } from "@/common/entities/connect-repository"
@@ -19,35 +14,25 @@ import type {
 } from "@/common/interfaces/llm-provider.interface"
 import type { Agent } from "@/domains/agents/agent.entity"
 import { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
-import { ConversationAgentSessionsService } from "@/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service"
 import { FormAgentSession } from "@/domains/agents/form-agent-sessions/form-agent-session.entity"
-import { FormAgentSessionsService } from "@/domains/agents/form-agent-sessions/form-agent-sessions.service"
-import { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
-// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
-import { DocumentChunkRetrievalService } from "@/domains/documents/embeddings/document-chunk-retrieval.service"
 import {
   FILE_STORAGE_SERVICE,
   type IFileStorage,
 } from "@/domains/documents/storage/file-storage.interface"
-// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
-import { McpServersService } from "@/domains/mcp-servers/mcp-servers.service"
-import { ProjectsService } from "@/domains/projects/projects.service"
+import { getTraceUrl } from "@/external/langfuse/langfuse-helper"
 import { ServiceWithLLM } from "@/external/llm"
-// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
-import { McpClientService } from "@/external/mcp"
 import { AgentMessage } from "../agent-message.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { AgentMessageAttachmentDocumentsService } from "../agent-message-attachment-documents.service"
-import { buildConversationAgentPrompt } from "./master-promts/conversation-agent.prompt"
-import { buildFormAgentPrompt } from "./master-promts/form-agent.prompt"
-import type { PublicStreamingSessionProxy, StreamingSession } from "./streaming-session.types"
-import { type BuiltTools, buildSubAgentTools } from "./sub-agent-tools"
-import { fillFormTool } from "./tools/fill-form.tool"
-import { recalculateConversationSessionMetadataTool } from "./tools/recalculate-conversation-session-metadata.tool"
-import { retrieveProjectDocumentChunksTool } from "./tools/retrieve-project-document-chunks.tool"
-import { sourcesTool } from "./tools/sources.tool"
-import { surfaceResourcesTool } from "./tools/surface-resources.tool"
+import { generateMasterPrompt } from "./master-promts/generate-master-prompt"
+import type {
+  AgentSessionScope,
+  PublicStreamingSessionProxy,
+  StreamingSession,
+} from "./streaming-session.types"
 import type { ToolExecutionLog } from "./tools/tool-execution-log"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { ToolsService } from "./tools.service"
 
 type NotifyClient = (event: Extract<StreamEvent, { type: "notify_client" }>) => void
 
@@ -65,18 +50,7 @@ export class StreamingService extends ServiceWithLLM {
     private readonly fileStorageService: IFileStorage,
     private readonly agentMessageAttachmentDocumentsService: AgentMessageAttachmentDocumentsService,
 
-    @Inject(FormAgentSessionsService)
-    private readonly formAgentSessionsService: FormAgentSessionsService,
-    @Inject(ConversationAgentSessionsService)
-    private readonly conversationAgentSessionsService: ConversationAgentSessionsService,
-    @Inject(AgentSubAgentsService)
-    private readonly agentSubAgentsService: AgentSubAgentsService,
-    @Inject(ProjectsService)
-    private readonly projectsService: ProjectsService,
-
-    private readonly documentChunkRetrievalService: DocumentChunkRetrievalService,
-    private readonly mcpClientService: McpClientService,
-    private readonly mcpServersService: McpServersService,
+    private readonly toolsService: ToolsService,
 
     @InjectRepository(ConversationAgentSession)
     conversationAgentSessionRepository: Repository<ConversationAgentSession>,
@@ -113,27 +87,27 @@ export class StreamingService extends ServiceWithLLM {
    * Handles the full flow: persist before, stream, persist after.
    */
   async *streamAgentResponse({
-    connectScope,
-    sessionId,
-    agent,
+    agentSessionScope,
     userContent,
     attachmentDocumentId,
     notifyClient,
   }: {
-    connectScope: RequiredConnectScope
-    sessionId: string
-    agent: Agent
+    agentSessionScope: AgentSessionScope
     userContent: string
     attachmentDocumentId?: string
     notifyClient: NotifyClient
   }): AsyncGenerator<StreamEvent, void, unknown> {
+    const { agent } = agentSessionScope
+
     const { session: updatedSession, assistantMessageId } = await this.prepareForStreaming({
-      connectScope,
-      sessionId,
+      agentSessionScope,
       userContent,
       attachmentDocumentId,
       agentType: agent.type,
     })
+
+    // Update the session in the agentSessionScope to reflect the latest state after preparing for streaming
+    agentSessionScope.session = updatedSession
 
     yield this.sseEvent({ type: "start", messageId: assistantMessageId })
 
@@ -142,12 +116,9 @@ export class StreamingService extends ServiceWithLLM {
 
     try {
       const llmRequest = await this.buildLLMRequest({
-        agent,
-        sessionId,
+        agentSessionScope,
         notifyClient,
-        session: updatedSession,
         attachmentDocumentId,
-        connectScope,
         assistantMessageId,
       })
       mcpClose = llmRequest.mcpClose
@@ -248,11 +219,8 @@ export class StreamingService extends ServiceWithLLM {
 
     try {
       const llmRequest = await this.buildLLMRequest({
-        agent,
-        sessionId: publicSessionId,
+        agentSessionScope: { session: sessionProxy, agent, connectScope },
         notifyClient,
-        session: sessionProxy,
-        connectScope,
         assistantMessageId,
       })
       mcpClose = llmRequest.mcpClose
@@ -303,56 +271,44 @@ export class StreamingService extends ServiceWithLLM {
   }
 
   private async buildLLMRequest({
-    agent,
-    sessionId,
+    agentSessionScope,
     notifyClient,
-    session,
     attachmentDocumentId,
-    connectScope,
     assistantMessageId,
   }: {
+    agentSessionScope: AgentSessionScope
     assistantMessageId: string
-    agent: Agent
-    sessionId: string
     notifyClient: NotifyClient
-    session: StreamingSession
     attachmentDocumentId?: string
-    connectScope: RequiredConnectScope
   }) {
-    const { tools, mcpClose, toolDescriptions } = await this.buildTools({
-      agent,
-      sessionId,
-      session,
-      connectScope,
-      onExecute: async (toolExecution) =>
-        await this.persistToolExecutionAndNotifyClient({
-          connectScope,
-          assistantMessageId,
-          sessionId,
-          notifyClient,
-          toolExecution,
-        }),
-    })
+    const { session, agent, connectScope } = agentSessionScope
+
+    const { tools, mcpClose, toolDescriptions, hasSubAgentTools } =
+      await this.toolsService.buildTools({
+        agentSessionScope,
+        onExecute: async (toolExecution) => {
+          await this.persistToolExecutionAndNotifyClient({
+            agentSessionScope,
+            assistantMessageId,
+            notifyClient,
+            toolExecution,
+          })
+        },
+      })
 
     const toolNames = tools ? Object.keys(tools) : []
     const config = this.buildLLMConfig({
-      systemPrompt: this.generateMasterPrompt({ agent, toolNames, toolDescriptions }),
+      systemPrompt: generateMasterPrompt({ agent, toolNames, toolDescriptions }),
       model: agent.model,
       temperature: agent.temperature,
       tools,
     })
 
-    const metadata: LLMMetadata = {
-      traceId: session.traceId,
-      agentSessionId: session.id,
-      agentId: agent.id,
-      projectId: agent.projectId,
-      organizationId: session.organizationId,
-      currentTurn: session.messages.filter((message) => message.role === "user").length,
-      tags: [agent.name],
-    }
+    const metadata: LLMMetadata = this.buildLLMData({ session, agent, hasSubAgentTools })
 
     const messages = await this.convertToLLMFormat(session.messages)
+
+    // If there's an attachment document, we need to handle it and add it to the LLM messages
     if (attachmentDocumentId)
       await this.handleAttachmentDocumentInLLMMessage({
         llmMessages: messages,
@@ -361,6 +317,30 @@ export class StreamingService extends ServiceWithLLM {
       })
 
     return { config, metadata, messages, mcpClose }
+  }
+
+  private buildLLMData({
+    session,
+    agent,
+    hasSubAgentTools,
+  }: {
+    session: StreamingSession
+    agent: Agent
+    hasSubAgentTools: boolean
+  }): LLMMetadata {
+    this.logger.log(
+      `Agent "${agent.name}" (${agent.id}) trace: ${getTraceUrl(session.traceId)} (session ${session.id})`,
+    )
+    const tags = [agent.name]
+    return {
+      traceId: session.traceId,
+      agentSessionId: session.id,
+      agentId: agent.id,
+      projectId: agent.projectId,
+      organizationId: session.organizationId,
+      currentTurn: session.messages.filter((message) => message.role === "user").length,
+      tags: hasSubAgentTools ? [...tags, "parent-agent"] : tags,
+    }
   }
 
   private async handleAttachmentDocumentInLLMMessage({
@@ -469,22 +449,6 @@ export class StreamingService extends ServiceWithLLM {
     return llmMessages
   }
 
-  private generateMasterPrompt(params: {
-    agent: Agent
-    toolDescriptions?: Record<string, string>
-    toolNames: string[]
-  }): string {
-    const agentType = params.agent.type
-    switch (agentType) {
-      case "form":
-        return buildFormAgentPrompt(params)
-      case "conversation":
-        return buildConversationAgentPrompt(params)
-      default:
-        throw new Error(`Unsupported agent type: ${agentType}`)
-    }
-  }
-
   /**
    * Finds a session by ID and recovers aborted streams
    */
@@ -528,26 +492,21 @@ export class StreamingService extends ServiceWithLLM {
    * Persists user message + empty assistant message with status "streaming"
    */
   async prepareForStreaming({
+    agentSessionScope,
     agentType,
-    connectScope,
     attachmentDocumentId,
-    sessionId,
     userContent,
   }: {
     agentType: Agent["type"]
-    connectScope: RequiredConnectScope
+    agentSessionScope: AgentSessionScope
     attachmentDocumentId?: string
-    sessionId: string
     userContent: string
   }): Promise<{
     session: ConversationAgentSession | FormAgentSession
     assistantMessageId: string
   }> {
-    const session = await this.findSessionById({ sessionId, agentType })
-
-    if (!session) {
-      throw new NotFoundException(`AgentSession with id ${sessionId} not found`)
-    }
+    const { session, connectScope } = agentSessionScope
+    const sessionId = session.id
 
     // Create user message
     await this.agentMessageConnectRepository.createAndSave(connectScope, {
@@ -698,270 +657,18 @@ export class StreamingService extends ServiceWithLLM {
     return elapsed > this.STREAM_TIMEOUT_MS
   }
 
-  private buildConversationTools({
-    agent,
-    sessionId,
-    connectScope,
-    currentCategoryNames,
-    hasSourcesTool,
-    includeSessionMetadataTools,
-    mcpTools,
-    onExecute,
-    subAgentTools,
-  }: {
-    agent: Agent
-    sessionId: string
-    connectScope: RequiredConnectScope
-    currentCategoryNames: string[]
-    hasSourcesTool: boolean
-    includeSessionMetadataTools: boolean
-    mcpTools: ToolSet
-    onExecute: (toolExecution: ToolExecutionLog) => void
-    subAgentTools: ToolSet
-  }): ToolSet {
-    const hasRecalculateConversationSessionMetadataTool =
-      includeSessionMetadataTools && (agent.sessionCategories?.length ?? 0) > 0
-
-    const tools: ToolSet = {
-      ...(agent.documentsRagMode === DocumentsRagMode.None
-        ? {}
-        : {
-            [ToolName.RetrieveProjectDocumentChunks]: retrieveProjectDocumentChunksTool({
-              connectScope,
-              documentTagIds:
-                agent.documentsRagMode === DocumentsRagMode.Tags
-                  ? (agent.documentTags?.map((documentTag) => documentTag.id) ?? [])
-                  : [],
-              retrievalService: this.documentChunkRetrievalService,
-              onExecute,
-            }),
-          }),
-      ...(hasSourcesTool ? { [ToolName.Sources]: sourcesTool({ onExecute }) } : {}),
-      ...((agent.resourceLibraries?.length ?? 0) > 0
-        ? { [ToolName.SurfaceResources]: surfaceResourcesTool({ onExecute }) }
-        : {}),
-      ...(hasRecalculateConversationSessionMetadataTool
-        ? {
-            [ToolName.RecalculateConversationSessionMetadata]:
-              recalculateConversationSessionMetadataTool({
-                connectScope,
-                sessionId,
-                availableCategoryNames: (agent.sessionCategories ?? [])
-                  .map((agentSessionCategory) => agentSessionCategory.name)
-                  .sort((leftCategoryName, rightCategoryName) =>
-                    leftCategoryName.localeCompare(rightCategoryName),
-                  ),
-                currentCategoryNames,
-                conversationAgentSessionsService: this.conversationAgentSessionsService,
-                onExecute,
-              }),
-          }
-        : {}),
-    }
-
-    this.addToolsWithoutCollisions({ target: tools, source: mcpTools, sourceLabel: "MCP" })
-    this.addToolsWithoutCollisions({
-      target: tools,
-      source: subAgentTools,
-      sourceLabel: "sub-agent",
-    })
-    return tools
-  }
-
-  private async buildTools({
-    agent,
-    sessionId,
-    session,
-    connectScope,
-    includeSessionMetadataTools = true,
-    includeSubAgentTools = true,
-    onExecute,
-  }: {
-    agent: Agent
-    sessionId: string
-    session?: StreamingSession
-    connectScope: RequiredConnectScope
-    includeSessionMetadataTools?: boolean
-    includeSubAgentTools?: boolean
-    onExecute: (toolExecution: ToolExecutionLog) => void
-  }): Promise<BuiltTools> {
-    const hasSourcesTool = await this.projectsService.hasFeature({
-      connectScope,
-      feature: "sources-tool",
-    })
-    const mcpCloseFns: (() => Promise<void>)[] = []
-    const mcpTools: ToolSet = {}
-    const mcpToolDescriptions: Record<string, string> = {}
-
-    const serverConfigs = await this.mcpServersService.getEnabledServersForAgent(agent.id)
-    for (const serverConfig of serverConfigs) {
-      const mcpSession = await this.mcpClientService.connect(serverConfig)
-      mcpCloseFns.push(mcpSession.close)
-      for (const [toolName, toolDef] of Object.entries(mcpSession.tools)) {
-        const originalExecute = toolDef.execute
-        if (!originalExecute) continue
-        const description = this.getToolDescription(toolDef)
-        if (description) mcpToolDescriptions[toolName] = description
-        mcpTools[toolName] = {
-          ...toolDef,
-          execute: (async (...executeArgs: Parameters<typeof originalExecute>) => {
-            this.logger.log(
-              `[MCP] Calling tool "${toolName}" with args: ${JSON.stringify(executeArgs[0])}`,
-            )
-            onExecute({
-              toolName,
-              arguments: (executeArgs[0] ?? {}) as Record<string, unknown>,
-            })
-            try {
-              const result = await originalExecute(...executeArgs)
-              this.logger.log(`[MCP] Tool "${toolName}" returned: ${JSON.stringify(result)}`)
-              return result
-            } catch (error) {
-              this.logger.error(`[MCP] Tool "${toolName}" failed: ${error}`)
-              throw error
-            }
-          }) as typeof originalExecute,
-        }
-      }
-    }
-
-    const mcpClose =
-      mcpCloseFns.length > 0
-        ? async () => {
-            for (const closeFn of mcpCloseFns) await closeFn()
-          }
-        : undefined
-
-    switch (agent.type) {
-      case "conversation": {
-        const currentCategoryNames =
-          includeSessionMetadataTools && (agent.sessionCategories?.length ?? 0) > 0
-            ? await this.conversationAgentSessionsService.getCurrentCategoryNamesForSession({
-                connectScope,
-                sessionId,
-              })
-            : []
-        const { tools: subAgentTools, toolDescriptions: subAgentToolDescriptions } =
-          includeSubAgentTools
-            ? await buildSubAgentTools({
-                agent,
-                agentSubAgentsService: this.agentSubAgentsService,
-                buildLLMConfig: (params) => this.buildLLMConfig(params),
-                buildTools: (params) => this.buildTools(params),
-                connectScope,
-                generateMasterPrompt: (params) => this.generateMasterPrompt(params),
-                getProviderForModel: (model) => this.getProviderForModel(model),
-                onExecute,
-                projectsService: this.projectsService,
-                session,
-                sessionId,
-              })
-            : { tools: {}, toolDescriptions: {} }
-        const tools = this.buildConversationTools({
-          agent,
-          sessionId,
-          connectScope,
-          currentCategoryNames,
-          hasSourcesTool,
-          includeSessionMetadataTools,
-          mcpTools,
-          onExecute,
-          subAgentTools,
-        })
-
-        return {
-          mcpClose,
-          tools,
-          toolDescriptions: this.filterToolDescriptions({
-            descriptions: { ...mcpToolDescriptions, ...subAgentToolDescriptions },
-            tools,
-          }),
-        }
-      }
-
-      case "form":
-        return {
-          mcpClose,
-          toolDescriptions: {},
-          tools: {
-            [ToolName.FillForm]: fillFormTool({
-              connectScope,
-              agent,
-              sessionId,
-              formAgentSessionsService: this.formAgentSessionsService,
-              onExecute,
-            }),
-            ...((agent.resourceLibraries?.length ?? 0) > 0
-              ? { [ToolName.SurfaceResources]: surfaceResourcesTool({ onExecute }) }
-              : {}),
-          } as ToolSet,
-        }
-
-      default:
-        return { mcpClose, toolDescriptions: {}, tools: undefined }
-    }
-  }
-
-  private addToolsWithoutCollisions({
-    source,
-    sourceLabel,
-    target,
-  }: {
-    source: ToolSet
-    sourceLabel: string
-    target: ToolSet
-  }) {
-    for (const [toolName, toolDef] of Object.entries(source)) {
-      if (target[toolName]) {
-        this.logger.warn(
-          `Skipping ${sourceLabel} tool "${toolName}" because another tool with the same name is already registered.`,
-        )
-        continue
-      }
-      target[toolName] = toolDef
-    }
-  }
-
-  private filterToolDescriptions({
-    descriptions,
-    tools,
-  }: {
-    descriptions: Record<string, string>
-    tools: ToolSet | undefined
-  }): Record<string, string> {
-    if (!tools) return {}
-
-    return Object.fromEntries(
-      Object.keys(tools)
-        .map((toolName) => [toolName, descriptions[toolName]] as const)
-        .filter((entry): entry is readonly [string, string] => entry[1] !== undefined),
-    )
-  }
-
-  private getToolDescription(toolDef: unknown): string | undefined {
-    if (!toolDef || typeof toolDef !== "object" || !("description" in toolDef)) {
-      return undefined
-    }
-
-    const description = (toolDef as { description?: unknown }).description
-    return typeof description === "string" && description.trim().length > 0
-      ? description
-      : undefined
-  }
-
   private async persistToolExecutionAndNotifyClient({
-    connectScope,
-    sessionId,
+    agentSessionScope,
     notifyClient,
     toolExecution,
     assistantMessageId,
   }: {
+    agentSessionScope: AgentSessionScope
     assistantMessageId: string
-    connectScope: RequiredConnectScope
-    sessionId: string
     notifyClient: NotifyClient
     toolExecution: ToolExecutionLog
   }): Promise<void> {
+    const { session, connectScope } = agentSessionScope
     const toolCall = {
       id: v4(),
       name: toolExecution.toolName,
@@ -971,7 +678,7 @@ export class StreamingService extends ServiceWithLLM {
     // Create a tool message in the database for each tool call, so that the session history is complete and reflects what actually happened during the agent execution (including tool calls)
     await this.agentMessageConnectRepository.createAndSave(connectScope, {
       id: v4(),
-      sessionId,
+      sessionId: session.id,
       role: "tool",
       content: `${toolExecution.toolName} called`,
       status: "completed",

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.spec.ts
@@ -26,7 +26,11 @@ describe("buildSubAgentTools", () => {
     }
 
     const { tools } = await buildSubAgentTools({
-      agent: parentAgent as never,
+      agentSessionScope: {
+        agent: parentAgent,
+        session: { id: "session-id", traceId: "trace-id", organizationId: "organization-id" },
+        connectScope: { organizationId: "organization-id", projectId: "project-id" },
+      } as never,
       agentSubAgentsService: {
         listSubAgents: jest.fn().mockResolvedValue([
           {
@@ -41,8 +45,19 @@ describe("buildSubAgentTools", () => {
         ]),
       } as never,
       buildLLMConfig: (params) => params as never,
-      buildTools: async ({ onExecute }) => ({
+      conversationAgentSessionsService: {
+        findOrCreateSubSession: jest.fn(),
+      } as never,
+      formAgentSessionsService: {
+        findOrCreateSubSession: jest.fn(),
+      } as never,
+      buildTools: async ({
+        onExecute,
+      }: {
+        onExecute: (toolExecution: ToolExecutionLog) => void
+      }) => ({
         toolDescriptions: {},
+        hasSubAgentTools: false,
         tools: {
           child_lookup: tool({
             description: "Look up child context.",
@@ -54,7 +69,6 @@ describe("buildSubAgentTools", () => {
           }),
         },
       }),
-      connectScope: { organizationId: "organization-id", projectId: "project-id" },
       generateMasterPrompt: () => "system prompt",
       getProviderForModel: () =>
         ({
@@ -74,7 +88,6 @@ describe("buildSubAgentTools", () => {
       projectsService: {
         hasFeature: jest.fn().mockResolvedValue(true),
       } as never,
-      sessionId: "session-id",
     })
 
     expect(tools.ask_helpful_assistant).toBeDefined()
@@ -94,5 +107,205 @@ describe("buildSubAgentTools", () => {
         arguments: { query: "pricing" },
       },
     ])
+  })
+
+  it("runs a form sub-agent against a dedicated form sub-session and prompts it to fill the form", async () => {
+    const childAgent = {
+      id: "form-agent-id",
+      projectId: "project-id",
+      organizationId: "organization-id",
+      name: "Intake Form",
+      defaultPrompt: "Collect the user details.",
+      model: "mock-model",
+      temperature: 0,
+      locale: "en",
+      type: "form",
+      documentsRagMode: DocumentsRagMode.None,
+      outputJsonSchema: { type: "object", properties: {} },
+    }
+    const parentAgent = {
+      ...childAgent,
+      id: "parent-agent-id",
+      name: "Orchestrator",
+      type: "conversation",
+    }
+
+    const subSession = {
+      id: "sub-session-id",
+      traceId: "sub-trace-id",
+      organizationId: "organization-id",
+      type: "playground",
+      result: null,
+      messages: [],
+    }
+    const findOrCreateSubSession = jest.fn().mockResolvedValue(subSession)
+    let capturedMessages: { role: string; content: string }[] = []
+    let capturedMetadata: { traceId: string; agentSessionId: string; tags: string[] } | undefined
+
+    const { tools } = await buildSubAgentTools({
+      agentSessionScope: {
+        agent: parentAgent,
+        session: {
+          id: "parent-session-id",
+          traceId: "parent-trace-id",
+          organizationId: "organization-id",
+          userId: "user-id",
+          type: "playground",
+          messages: [],
+        },
+        connectScope: { organizationId: "organization-id", projectId: "project-id" },
+      } as never,
+      agentSubAgentsService: {
+        listSubAgents: jest.fn().mockResolvedValue([
+          {
+            id: "sub-agent-id",
+            parentAgentId: parentAgent.id,
+            childAgentId: childAgent.id,
+            toolName: "ask_intake_form",
+            description: "Ask the intake form agent.",
+            enabled: true,
+            childAgent,
+          },
+        ]),
+      } as never,
+      buildLLMConfig: (params) => params as never,
+      conversationAgentSessionsService: {
+        findOrCreateSubSession: jest.fn(),
+      } as never,
+      formAgentSessionsService: { findOrCreateSubSession } as never,
+      buildTools: async () => ({ toolDescriptions: {}, tools: {}, hasSubAgentTools: false }),
+      generateMasterPrompt: () => "system prompt",
+      getProviderForModel: () =>
+        ({
+          streamChatResponse: async function* ({ messages, metadata }) {
+            capturedMessages = messages
+            capturedMetadata = metadata
+            yield "form answer"
+          },
+        }) as never,
+      onExecute: () => {},
+      projectsService: { hasFeature: jest.fn().mockResolvedValue(true) } as never,
+    })
+
+    const subAgentTool = tools.ask_intake_form as never as {
+      execute: (input: { task: string; context: string }) => Promise<{ answer: string }>
+    }
+    const result = await subAgentTool.execute({ task: "My name is Alex.", context: "" })
+
+    expect(findOrCreateSubSession).toHaveBeenCalledWith({
+      connectScope: { organizationId: "organization-id", projectId: "project-id" },
+      agentId: "form-agent-id",
+      userId: "user-id",
+      parentSessionId: "parent-session-id",
+      type: "playground",
+    })
+    expect(capturedMessages).toHaveLength(1)
+    expect(capturedMessages[0]?.role).toBe("user")
+    expect(capturedMessages[0]?.content).toContain("My name is Alex.")
+    expect(capturedMessages[0]?.content).toContain("fillForm")
+    expect(result.answer).toBe("form answer")
+    // The form sub-agent gets its own dedicated trace (the sub-session's), linked
+    // back to the parent trace via a tag.
+    expect(capturedMetadata?.traceId).toBe("sub-trace-id")
+    expect(capturedMetadata?.agentSessionId).toBe("sub-session-id")
+    expect(capturedMetadata?.tags).toContain("parent-trace:parent-trace-id")
+    expect(capturedMetadata?.tags).toContain("sub-agent")
+  })
+
+  it("runs a conversation sub-agent against a dedicated conversation sub-session", async () => {
+    const childAgent = {
+      id: "conversation-agent-id",
+      projectId: "project-id",
+      organizationId: "organization-id",
+      name: "Pricing Expert",
+      defaultPrompt: "Answer pricing questions.",
+      model: "mock-model",
+      temperature: 0,
+      locale: "en",
+      type: "conversation",
+      documentsRagMode: DocumentsRagMode.None,
+    }
+    const parentAgent = {
+      ...childAgent,
+      id: "parent-agent-id",
+      name: "Orchestrator",
+    }
+
+    const subSession = {
+      id: "sub-session-id",
+      traceId: "sub-trace-id",
+      organizationId: "organization-id",
+      type: "playground",
+      messages: [],
+    }
+    const findOrCreateSubSession = jest.fn().mockResolvedValue(subSession)
+    let capturedMessages: { role: string; content: string }[] = []
+    let capturedMetadata: { traceId: string; agentSessionId: string; tags: string[] } | undefined
+
+    const { tools } = await buildSubAgentTools({
+      agentSessionScope: {
+        agent: parentAgent,
+        session: {
+          id: "parent-session-id",
+          traceId: "parent-trace-id",
+          organizationId: "organization-id",
+          userId: "user-id",
+          type: "playground",
+          messages: [],
+        },
+        connectScope: { organizationId: "organization-id", projectId: "project-id" },
+      } as never,
+      agentSubAgentsService: {
+        listSubAgents: jest.fn().mockResolvedValue([
+          {
+            id: "sub-agent-id",
+            parentAgentId: parentAgent.id,
+            childAgentId: childAgent.id,
+            toolName: "ask_pricing_expert",
+            description: "Ask the pricing expert.",
+            enabled: true,
+            childAgent,
+          },
+        ]),
+      } as never,
+      buildLLMConfig: (params) => params as never,
+      conversationAgentSessionsService: { findOrCreateSubSession } as never,
+      formAgentSessionsService: { findOrCreateSubSession: jest.fn() } as never,
+      buildTools: async () => ({ toolDescriptions: {}, tools: {}, hasSubAgentTools: false }),
+      generateMasterPrompt: () => "system prompt",
+      getProviderForModel: () =>
+        ({
+          streamChatResponse: async function* ({ messages, metadata }) {
+            capturedMessages = messages
+            capturedMetadata = metadata
+            yield "pricing answer"
+          },
+        }) as never,
+      onExecute: () => {},
+      projectsService: { hasFeature: jest.fn().mockResolvedValue(true) } as never,
+    })
+
+    const subAgentTool = tools.ask_pricing_expert as never as {
+      execute: (input: { task: string; context: string }) => Promise<{ answer: string }>
+    }
+    const result = await subAgentTool.execute({ task: "How much is the pro plan?", context: "" })
+
+    expect(findOrCreateSubSession).toHaveBeenCalledWith({
+      connectScope: { organizationId: "organization-id", projectId: "project-id" },
+      agentId: "conversation-agent-id",
+      userId: "user-id",
+      parentSessionId: "parent-session-id",
+      type: "playground",
+    })
+    expect(capturedMessages).toHaveLength(1)
+    expect(capturedMessages[0]?.role).toBe("user")
+    expect(capturedMessages[0]?.content).toContain("How much is the pro plan?")
+    expect(result.answer).toBe("pricing answer")
+    // The conversation sub-agent gets its own dedicated trace (the sub-session's),
+    // linked back to the parent trace via a tag.
+    expect(capturedMetadata?.traceId).toBe("sub-trace-id")
+    expect(capturedMetadata?.agentSessionId).toBe("sub-session-id")
+    expect(capturedMetadata?.tags).toContain("parent-trace:parent-trace-id")
+    expect(capturedMetadata?.tags).toContain("sub-agent")
   })
 })

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
@@ -1,22 +1,29 @@
+import { Logger } from "@nestjs/common"
+import { trace } from "@opentelemetry/api"
 import type { ToolSet } from "ai"
-import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
 import type {
   LLMConfig,
   LLMMetadata,
   LLMProvider,
 } from "@/common/interfaces/llm-provider.interface"
 import type { Agent } from "@/domains/agents/agent.entity"
+import type { ConversationAgentSessionsService } from "@/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service"
+import type { FormAgentSessionsService } from "@/domains/agents/form-agent-sessions/form-agent-sessions.service"
 import type { AgentSubAgent } from "@/domains/agents/sub-agents/agent-sub-agent.entity"
 import type { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
 import type { ProjectsService } from "@/domains/projects/projects.service"
-import type { StreamingSession } from "./streaming-session.types"
+import { getTraceUrl } from "@/external/langfuse/langfuse-helper"
+import type { AgentSessionScope, OnExecute, StreamingSession } from "./streaming-session.types"
 import { type SubAgentToolInput, subAgentTool } from "./tools/sub-agent.tool"
-import type { ToolExecutionLog } from "./tools/tool-execution-log"
+
+const logger = new Logger("SubAgentTools")
+const tracer = trace.getTracer("caseai-sub-agent")
 
 export type BuiltTools = {
   tools: ToolSet | undefined
   mcpClose?: () => Promise<void>
   toolDescriptions: Record<string, string>
+  hasSubAgentTools: boolean
 }
 
 type BuildLLMConfig = (params: {
@@ -33,46 +40,46 @@ type GenerateMasterPrompt = (params: {
 }) => string
 
 type BuildTools = (params: {
-  agent: Agent
-  connectScope: RequiredConnectScope
+  agentSessionScope: AgentSessionScope
   includeSessionMetadataTools?: boolean
   includeSubAgentTools?: boolean
-  onExecute: (toolExecution: ToolExecutionLog) => void
-  session?: StreamingSession
-  sessionId: string
+  onExecute: OnExecute
 }) => Promise<BuiltTools>
 
 export async function buildSubAgentTools({
-  agent,
   agentSubAgentsService,
   buildLLMConfig,
   buildTools,
-  connectScope,
+  conversationAgentSessionsService,
+  formAgentSessionsService,
   generateMasterPrompt,
   getProviderForModel,
   onExecute,
   projectsService,
-  session,
-  sessionId,
+  agentSessionScope,
 }: {
-  agent: Agent
+  agentSessionScope: AgentSessionScope
   agentSubAgentsService: AgentSubAgentsService
   buildLLMConfig: BuildLLMConfig
   buildTools: BuildTools
-  connectScope: RequiredConnectScope
+  conversationAgentSessionsService: ConversationAgentSessionsService
+  formAgentSessionsService: FormAgentSessionsService
   generateMasterPrompt: GenerateMasterPrompt
   getProviderForModel: (model: string) => LLMProvider
-  onExecute: (toolExecution: ToolExecutionLog) => void
+  onExecute: OnExecute
   projectsService: ProjectsService
-  session?: StreamingSession
-  sessionId: string
-}): Promise<{ tools: ToolSet; toolDescriptions: Record<string, string> }> {
+}): Promise<{
+  tools: ToolSet
+  toolDescriptions: Record<string, string>
+  hasSubAgentTools: boolean
+}> {
+  const { agent, connectScope } = agentSessionScope
   const hasAgentOrchestration = await projectsService.hasFeature({
     connectScope,
     feature: "agent-orchestration",
   })
   if (!hasAgentOrchestration) {
-    return { tools: {}, toolDescriptions: {} }
+    return { tools: {}, toolDescriptions: {}, hasSubAgentTools: false }
   }
 
   const subAgents = await agentSubAgentsService.listSubAgents({
@@ -84,64 +91,99 @@ export async function buildSubAgentTools({
 
   for (const subAgent of subAgents) {
     if (!subAgent.enabled) continue
+    if (subAgent.childAgent.type === "extraction") continue
 
-    const description = buildSubAgentToolDescription(subAgent)
+    const description = subAgent.description
     tools[subAgent.toolName] = subAgentTool({
       description,
       toolName: subAgent.toolName,
       onExecute,
       execute: (input) =>
         runSubAgentTool({
+          agentSessionScope,
           buildLLMConfig,
           buildTools,
-          connectScope,
+          conversationAgentSessionsService,
+          formAgentSessionsService,
           generateMasterPrompt,
           getProviderForModel,
           input,
           onExecute,
-          parentAgent: agent,
-          session,
-          sessionId,
           subAgent,
         }),
     })
     toolDescriptions[subAgent.toolName] = description
   }
 
-  return { tools, toolDescriptions }
+  return { tools, toolDescriptions, hasSubAgentTools: Object.keys(tools).length > 0 }
 }
 
 async function runSubAgentTool({
+  agentSessionScope,
   buildLLMConfig,
   buildTools,
-  connectScope,
+  conversationAgentSessionsService,
+  formAgentSessionsService,
   generateMasterPrompt,
   getProviderForModel,
   input,
   onExecute,
-  parentAgent,
-  session,
-  sessionId,
   subAgent,
 }: {
+  agentSessionScope: AgentSessionScope
   buildLLMConfig: BuildLLMConfig
   buildTools: BuildTools
-  connectScope: RequiredConnectScope
+  conversationAgentSessionsService: ConversationAgentSessionsService
+  formAgentSessionsService: FormAgentSessionsService
   generateMasterPrompt: GenerateMasterPrompt
   getProviderForModel: (model: string) => LLMProvider
   input: SubAgentToolInput
-  onExecute: (toolExecution: ToolExecutionLog) => void
-  parentAgent: Agent
-  session?: StreamingSession
-  sessionId: string
+  onExecute: OnExecute
   subAgent: AgentSubAgent
-}): Promise<string> {
+}): Promise<Record<string, unknown>> {
   const childAgent = subAgent.childAgent
-  const { tools, mcpClose, toolDescriptions } = await buildTools({
+  if (childAgent.type === "extraction") {
+    throw new Error(
+      `Sub-agent "${childAgent.name}" (${childAgent.id}) is an extraction agent, which is not supported as a sub-agent.`,
+    )
+  }
+
+  // Form and conversation sub-agents each get their own persistent sub-session,
+  // keyed to the parent session. A form sub-agent needs it so the fillForm tool
+  // can accumulate form state across parent turns; a conversation sub-agent uses
+  // it for trace continuity. Other sub-agents reuse the parent session scope.
+  let childSession: StreamingSession
+
+  switch (childAgent.type) {
+    case "form":
+      childSession = await resolveFormSubSession({
+        agentSessionScope,
+        childAgent,
+        formAgentSessionsService,
+      })
+      break
+    case "conversation":
+      childSession = await resolveConversationSubSession({
+        agentSessionScope,
+        childAgent,
+        conversationAgentSessionsService,
+      })
+      break
+  }
+
+  const childScope: AgentSessionScope = {
+    ...agentSessionScope,
     agent: childAgent,
-    sessionId,
-    session,
-    connectScope,
+    session: childSession,
+  }
+
+  // Dedicated trace id for the sub-agent run. A form or conversation sub-agent
+  // reuses its persistent sub-session trace id (so all of its turns land in one
+  // trace); any other sub-agent gets a fresh trace id per invocation.
+  const subAgentTraceId = childSession.traceId
+
+  const { tools, mcpClose, toolDescriptions } = await buildTools({
+    agentSessionScope: childScope,
     includeSessionMetadataTools: false,
     includeSubAgentTools: false,
     onExecute: (toolExecution) =>
@@ -153,76 +195,177 @@ async function runSubAgentTool({
 
   try {
     const toolNames = tools ? Object.keys(tools) : []
+    const systemPrompt = generateMasterPrompt({
+      agent: childAgent,
+      toolNames,
+      toolDescriptions,
+    })
+
     const config = buildLLMConfig({
-      systemPrompt: generateMasterPrompt({
-        agent: childAgent,
-        toolNames,
-        toolDescriptions,
-      }),
+      systemPrompt,
       model: childAgent.model,
       temperature: childAgent.temperature,
       tools,
     })
+
     const metadata = buildSubAgentMetadata({
       childAgent,
-      connectScope,
-      parentAgent,
-      session,
-      sessionId,
-    })
-    const chunks = getProviderForModel(config.model).streamChatResponse({
-      messages: [{ role: "user", content: buildSubAgentPrompt(input) }],
-      config,
-      metadata,
+      agentSessionScope,
+      childSession,
+      subAgentTraceId,
     })
 
-    let answer = ""
-    for await (const chunk of chunks) answer += chunk
-    return answer
+    logger.log(
+      `Sub-agent "${childAgent.name}" (${childAgent.id}) trace: ${getTraceUrl(subAgentTraceId)} ` +
+        `(parent "${agentSessionScope.agent.name}" trace: ${getTraceUrl(agentSessionScope.session.traceId)})`,
+    )
+
+    // Run the sub-agent's LLM call inside a fresh OTEL root span so its spans get
+    // their own OTEL trace id. The langfuse exporter groups by OTEL trace id and
+    // writes each group under a single langfuse trace id — detaching here lets the
+    // sub-agent's advertised trace id (subAgentTraceId) become its own trace
+    // instead of collapsing into the parent's.
+    return await tracer.startActiveSpan(
+      `sub-agent ${childAgent.name}`,
+      { root: true },
+      async (rootSpan) => {
+        try {
+          const chunks = getProviderForModel(config.model).streamChatResponse({
+            messages: [{ role: "user", content: buildSubAgentPrompt(input, childAgent) }],
+            config,
+            metadata,
+          })
+
+          let answer = ""
+          for await (const chunk of chunks) answer += chunk
+          return { answer }
+        } finally {
+          rootSpan.end()
+        }
+      },
+    )
   } finally {
     await mcpClose?.()
   }
 }
 
-function buildSubAgentPrompt(input: SubAgentToolInput): string {
+/**
+ * Finds or creates the form session used when a parent agent delegates to a form
+ * sub-agent. The session is keyed to the parent session so its state survives
+ * across turns. Falls back to the parent session when the parent has no user
+ * context (e.g. public sessions), where a user-scoped sub-session can't be made.
+ */
+async function resolveFormSubSession({
+  agentSessionScope,
+  childAgent,
+  formAgentSessionsService,
+}: {
+  agentSessionScope: AgentSessionScope
+  childAgent: Agent
+  formAgentSessionsService: FormAgentSessionsService
+}): Promise<StreamingSession> {
+  const { connectScope, session: parentSession } = agentSessionScope
+  if (!("userId" in parentSession) || !("type" in parentSession)) {
+    return parentSession
+  }
+
+  return formAgentSessionsService.findOrCreateSubSession({
+    connectScope,
+    agentId: childAgent.id,
+    userId: parentSession.userId,
+    parentSessionId: parentSession.id,
+    type: parentSession.type,
+  })
+}
+
+/**
+ * Finds or creates the conversation session used when a parent agent delegates
+ * to a conversation sub-agent. The session is keyed to the parent session so the
+ * sub-agent's runs land in one persistent trace across parent turns. Falls back
+ * to the parent session when the parent has no user context (e.g. public
+ * sessions), where a user-scoped sub-session can't be made.
+ */
+async function resolveConversationSubSession({
+  agentSessionScope,
+  childAgent,
+  conversationAgentSessionsService,
+}: {
+  agentSessionScope: AgentSessionScope
+  childAgent: Agent
+  conversationAgentSessionsService: ConversationAgentSessionsService
+}): Promise<StreamingSession> {
+  const { connectScope, session: parentSession } = agentSessionScope
+  if (!("userId" in parentSession) || !("type" in parentSession)) {
+    return parentSession
+  }
+
+  return conversationAgentSessionsService.findOrCreateSubSession({
+    connectScope,
+    agentId: childAgent.id,
+    userId: parentSession.userId,
+    parentSessionId: parentSession.id,
+    type: parentSession.type,
+  })
+}
+
+/**
+ * Builds the user-facing message handed to the sub-agent. The child agent's
+ * master prompt is already supplied as the system prompt via the LLM config, so
+ * this carries only the delegated task and any context the parent passed.
+ */
+function buildSubAgentPrompt(input: SubAgentToolInput, childAgent: Agent): string {
   const context = input.context.trim()
-  return [
-    "You are being invoked as a sub-agent by another assistant.",
+  const parts: (string | undefined)[] = [
     context ? `Conversation context:\n${context}` : undefined,
     `Delegated task:\n${input.task}`,
-    "Return a direct answer that the parent assistant can use for the user.",
   ]
-    .filter((part): part is string => part !== undefined)
-    .join("\n\n")
+
+  switch (childAgent.type) {
+    case "form":
+      parts.push(
+        [
+          "The delegated task contains the user's latest answer(s).",
+          "Use the fillForm tool to record any field values you can extract from that answer, then read the resulting form state.",
+          "Reply to the parent assistant with:",
+          "1. The current form state (the fields filled so far and their values).",
+          "2. If the form is not complete, the single next question to ask the user for a still-missing field. If the form is complete, say so explicitly.",
+        ].join("\n"),
+      )
+      break
+    case "conversation":
+      parts.push(
+        "The delegated task is to respond to the user on behalf of the parent assistant. The sub-agent should reply with a direct answer that the parent assistant can use for the user. The sub-agent has access to its own tools and context.",
+      )
+      break
+  }
+
+  return parts.filter((part): part is string => part !== undefined).join("\n\n")
 }
 
 function buildSubAgentMetadata({
   childAgent,
-  connectScope,
-  parentAgent,
-  session,
-  sessionId,
+  agentSessionScope,
+  childSession,
+  subAgentTraceId,
 }: {
+  agentSessionScope: AgentSessionScope
   childAgent: Agent
-  connectScope: RequiredConnectScope
-  parentAgent: Agent
-  session?: StreamingSession
-  sessionId: string
+  childSession: StreamingSession
+  subAgentTraceId: string
 }): LLMMetadata {
+  const { connectScope, agent: parentAgent, session } = agentSessionScope
+
+  // The sub-agent runs inside a fresh OTEL root span (see runSubAgentTool), so its
+  // spans get their own OTEL trace id and the exporter writes them under this
+  // dedicated langfuse trace id rather than collapsing into the parent's trace.
+  // A `parent-trace:` tag links back to the parent run for navigation.
   return {
-    traceId: session?.traceId ?? sessionId,
-    agentSessionId: session?.id ?? sessionId,
+    traceId: subAgentTraceId,
+    agentSessionId: childSession.id,
     agentId: childAgent.id,
     projectId: childAgent.projectId,
     organizationId: session?.organizationId ?? connectScope.organizationId,
-    currentTurn: session?.messages.filter((message) => message.role === "user").length ?? 0,
-    tags: [parentAgent.name, childAgent.name, "sub-agent"],
+    currentTurn: session?.messages?.filter((message) => message.role === "user").length ?? 0,
+    tags: [parentAgent.name, childAgent.name, "sub-agent", `parent-trace:${session.traceId}`],
   }
-}
-
-function buildSubAgentToolDescription(subAgent: AgentSubAgent): string {
-  const configuredDescription = subAgent.description.trim()
-  if (configuredDescription.length > 0) return configuredDescription
-
-  return `Delegate to ${subAgent.childAgent.name}, a conversation agent, when that agent is better suited to the user's request.`
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
@@ -1,0 +1,353 @@
+import { DocumentsRagMode, ToolName } from "@caseai-connect/api-contracts"
+import { Inject, Injectable, Logger } from "@nestjs/common"
+import type { ToolSet } from "ai"
+import type { LLMProvider } from "@/common/interfaces/llm-provider.interface"
+import type { Agent } from "@/domains/agents/agent.entity"
+import { ConversationAgentSessionsService } from "@/domains/agents/conversation-agent-sessions/conversation-agent-sessions.service"
+import { FormAgentSessionsService } from "@/domains/agents/form-agent-sessions/form-agent-sessions.service"
+import { AgentSubAgentsService } from "@/domains/agents/sub-agents/agent-sub-agents.service"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { DocumentChunkRetrievalService } from "@/domains/documents/embeddings/document-chunk-retrieval.service"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { McpServersService } from "@/domains/mcp-servers/mcp-servers.service"
+import { ProjectsService } from "@/domains/projects/projects.service"
+import { ServiceWithLLM } from "@/external/llm"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { McpClientService } from "@/external/mcp"
+import { generateMasterPrompt } from "./master-promts/generate-master-prompt"
+import type { AgentSessionScope, OnExecute } from "./streaming-session.types"
+import { type BuiltTools, buildSubAgentTools } from "./sub-agent-tools"
+import { fillFormTool } from "./tools/fill-form.tool"
+import { recalculateConversationSessionMetadataTool } from "./tools/recalculate-conversation-session-metadata.tool"
+import { retrieveProjectDocumentChunksTool } from "./tools/retrieve-project-document-chunks.tool"
+import { sourcesTool } from "./tools/sources.tool"
+import { surfaceResourcesTool } from "./tools/surface-resources.tool"
+
+/**
+ * The tools exposed by an agent's enabled MCP servers
+ */
+type McpToolset = {
+  // A function that tears down every open MCP session. If no MCP sessions were opened, this will be undefined.
+  disconnect: (() => Promise<void>) | undefined
+  // The tools exposed by the agent's enabled MCP servers.
+  tools: ToolSet
+  // Descriptions for the tools exposed by the agent's enabled MCP servers.
+  toolDescriptions: Record<string, string>
+}
+
+/**
+ * Builds the tool sets exposed to the LLM for a given agent.
+ *
+ * Owns everything related to tools: MCP tool wiring, conversation/form agent
+ * tools, sub-agent tools, and the helpers that merge and filter them. Extracted
+ * from StreamingService so that service can focus on the streaming lifecycle.
+ */
+@Injectable()
+export class ToolsService extends ServiceWithLLM {
+  private readonly logger = new Logger(ToolsService.name)
+
+  constructor(
+    @Inject(FormAgentSessionsService)
+    private readonly formAgentSessionsService: FormAgentSessionsService,
+    @Inject(ConversationAgentSessionsService)
+    private readonly conversationAgentSessionsService: ConversationAgentSessionsService,
+    @Inject(AgentSubAgentsService)
+    private readonly agentSubAgentsService: AgentSubAgentsService,
+    @Inject(ProjectsService)
+    private readonly projectsService: ProjectsService,
+
+    private readonly documentChunkRetrievalService: DocumentChunkRetrievalService,
+    private readonly mcpClientService: McpClientService,
+    private readonly mcpServersService: McpServersService,
+
+    @Inject("_MockLLMProvider")
+    mockLlmProvider: LLMProvider,
+    @Inject("VertexLLMProvider")
+    vertexLlmProvider: LLMProvider,
+    @Inject("MedGemmaLLMProvider")
+    medGemmaLlmProvider: LLMProvider,
+    @Inject("GemmaLLMProvider")
+    gemmaLlmProvider: LLMProvider,
+  ) {
+    super({ mockLlmProvider, vertexLlmProvider, medGemmaLlmProvider, gemmaLlmProvider })
+  }
+
+  async buildTools({
+    agentSessionScope,
+    onExecute,
+    includeSessionMetadataTools = true,
+    includeSubAgentTools = true,
+  }: {
+    agentSessionScope: AgentSessionScope
+    onExecute: OnExecute
+    includeSessionMetadataTools?: boolean
+    includeSubAgentTools?: boolean
+  }): Promise<BuiltTools> {
+    const { agent } = agentSessionScope
+    const mcp = await this.buildMcpTools({ agent, onExecute })
+
+    switch (agent.type) {
+      case "conversation":
+        return this.buildConversationAgentTools({
+          agentSessionScope,
+          includeSessionMetadataTools,
+          includeSubAgentTools,
+          mcp,
+          onExecute,
+        })
+
+      case "form":
+        return this.buildFormAgentTools({ agentSessionScope, mcp, onExecute })
+
+      default:
+        return {
+          mcpClose: mcp.disconnect,
+          toolDescriptions: {},
+          tools: undefined,
+          hasSubAgentTools: false,
+        }
+    }
+  }
+
+  private async buildMcpTools({
+    agent,
+    onExecute,
+  }: {
+    agent: Agent
+    onExecute: OnExecute
+  }): Promise<McpToolset> {
+    const mcpCloseFns: (() => Promise<void>)[] = []
+    const mcpTools: ToolSet = {}
+    const mcpToolDescriptions: Record<string, string> = {}
+
+    const serverConfigs = await this.mcpServersService.getEnabledServersForAgent(agent.id)
+    for (const serverConfig of serverConfigs) {
+      const mcpSession = await this.mcpClientService.connect(serverConfig)
+      mcpCloseFns.push(mcpSession.close)
+      for (const [toolName, toolDef] of Object.entries(mcpSession.tools)) {
+        const originalExecute = toolDef.execute
+        if (!originalExecute) continue
+        const description = this.getToolDescription(toolDef)
+        if (description) mcpToolDescriptions[toolName] = description
+        mcpTools[toolName] = {
+          ...toolDef,
+          execute: (async (...executeArgs: Parameters<typeof originalExecute>) => {
+            this.logger.log(
+              `[MCP] Calling tool "${toolName}" with args: ${JSON.stringify(executeArgs[0])}`,
+            )
+            onExecute({
+              toolName,
+              arguments: (executeArgs[0] ?? {}) as Record<string, unknown>,
+            })
+            try {
+              const result = await originalExecute(...executeArgs)
+              this.logger.log(`[MCP] Tool "${toolName}" returned: ${JSON.stringify(result)}`)
+              return result
+            } catch (error) {
+              this.logger.error(`[MCP] Tool "${toolName}" failed: ${error}`)
+              throw error
+            }
+          }) as typeof originalExecute,
+        }
+      }
+    }
+
+    const disconnect =
+      mcpCloseFns.length > 0
+        ? async () => {
+            for (const closeFn of mcpCloseFns) await closeFn()
+          }
+        : undefined
+
+    return { disconnect, tools: mcpTools, toolDescriptions: mcpToolDescriptions }
+  }
+
+  private async buildConversationAgentTools({
+    agentSessionScope,
+    includeSessionMetadataTools,
+    includeSubAgentTools,
+    mcp,
+    onExecute,
+  }: {
+    agentSessionScope: AgentSessionScope
+    includeSessionMetadataTools: boolean
+    includeSubAgentTools: boolean
+    mcp: McpToolset
+    onExecute: OnExecute
+  }): Promise<BuiltTools> {
+    const { agent, connectScope, session } = agentSessionScope
+    const [
+      hasSourcesTool,
+      currentCategoryNames,
+      { tools: subAgentTools, toolDescriptions: subAgentToolDescriptions },
+    ] = await Promise.all([
+      // Check if the agent has the sources tool enabled
+      this.projectsService.hasFeature({ connectScope, feature: "sources-tool" }),
+
+      // Get the current category names for the session if requested and if the agent has session categories
+      includeSessionMetadataTools && (agent.sessionCategories?.length ?? 0) > 0
+        ? this.conversationAgentSessionsService.getCurrentCategoryNamesForSession({
+            connectScope,
+            sessionId: session.id,
+          })
+        : Promise.resolve([]),
+
+      // Build sub-agent tools if requested
+      includeSubAgentTools
+        ? buildSubAgentTools({
+            agentSessionScope,
+            agentSubAgentsService: this.agentSubAgentsService,
+            buildLLMConfig: (params) => this.buildLLMConfig(params),
+            buildTools: (params) => this.buildTools(params),
+            conversationAgentSessionsService: this.conversationAgentSessionsService,
+            formAgentSessionsService: this.formAgentSessionsService,
+            generateMasterPrompt,
+            getProviderForModel: (model) => this.getProviderForModel(model),
+            onExecute,
+            projectsService: this.projectsService,
+          })
+        : Promise.resolve({ tools: {}, toolDescriptions: {} }),
+    ])
+
+    const hasRecalculateConversationSessionMetadataTool =
+      includeSessionMetadataTools && (agent.sessionCategories?.length ?? 0) > 0
+
+    const tools: ToolSet = {
+      // Add the document retrieval tool if the agent has a RAG mode enabled
+      ...(agent.documentsRagMode === DocumentsRagMode.None
+        ? {}
+        : {
+            [ToolName.RetrieveProjectDocumentChunks]: retrieveProjectDocumentChunksTool({
+              connectScope,
+              documentTagIds:
+                agent.documentsRagMode === DocumentsRagMode.Tags
+                  ? (agent.documentTags?.map((documentTag) => documentTag.id) ?? [])
+                  : [],
+              retrievalService: this.documentChunkRetrievalService,
+              onExecute,
+            }),
+          }),
+
+      // Add the sources tool if the agent has the sources tool feature enabled
+      ...(hasSourcesTool ? { [ToolName.Sources]: sourcesTool({ onExecute }) } : {}),
+
+      // Add the surface resources tool if the agent has any resource libraries
+      ...((agent.resourceLibraries?.length ?? 0) > 0
+        ? { [ToolName.SurfaceResources]: surfaceResourcesTool({ onExecute }) }
+        : {}),
+
+      // Add the recalculate conversation session metadata tool if the agent has session categories and the feature is enabled
+      ...(hasRecalculateConversationSessionMetadataTool
+        ? {
+            [ToolName.RecalculateConversationSessionMetadata]:
+              recalculateConversationSessionMetadataTool({
+                connectScope,
+                sessionId: agentSessionScope.session.id,
+                availableCategoryNames: (agent.sessionCategories ?? [])
+                  .map((agentSessionCategory) => agentSessionCategory.name)
+                  .sort((leftCategoryName, rightCategoryName) =>
+                    leftCategoryName.localeCompare(rightCategoryName),
+                  ),
+                currentCategoryNames,
+                conversationAgentSessionsService: this.conversationAgentSessionsService,
+                onExecute,
+              }),
+          }
+        : {}),
+    }
+
+    // Merge the MCP tools into the final tool set
+    this.addToolsWithoutCollisions({ target: tools, source: mcp.tools, sourceLabel: "MCP" })
+
+    // Merge the sub-agent tools into the final tool set
+    this.addToolsWithoutCollisions({
+      target: tools,
+      source: subAgentTools,
+      sourceLabel: "sub-agent",
+    })
+
+    return {
+      mcpClose: mcp.disconnect,
+      tools,
+      toolDescriptions: this.filterToolDescriptions({
+        descriptions: { ...mcp.toolDescriptions, ...subAgentToolDescriptions },
+        tools,
+      }),
+      hasSubAgentTools: Object.keys(subAgentTools).length > 0,
+    }
+  }
+
+  private buildFormAgentTools({
+    agentSessionScope,
+    mcp,
+    onExecute,
+  }: {
+    agentSessionScope: AgentSessionScope
+    mcp: McpToolset
+    onExecute: OnExecute
+  }): BuiltTools {
+    const { agent } = agentSessionScope
+    return {
+      mcpClose: mcp.disconnect,
+      toolDescriptions: {},
+      tools: {
+        [ToolName.FillForm]: fillFormTool({
+          agentSessionScope,
+          formAgentSessionsService: this.formAgentSessionsService,
+          onExecute,
+        }),
+        ...((agent.resourceLibraries?.length ?? 0) > 0
+          ? { [ToolName.SurfaceResources]: surfaceResourcesTool({ onExecute }) }
+          : {}),
+      } as ToolSet,
+      hasSubAgentTools: false,
+    }
+  }
+
+  private addToolsWithoutCollisions({
+    source,
+    sourceLabel,
+    target,
+  }: {
+    source: ToolSet
+    sourceLabel: string
+    target: ToolSet
+  }) {
+    for (const [toolName, toolDef] of Object.entries(source)) {
+      if (target[toolName]) {
+        this.logger.warn(
+          `Skipping ${sourceLabel} tool "${toolName}" because another tool with the same name is already registered.`,
+        )
+        continue
+      }
+      target[toolName] = toolDef
+    }
+  }
+
+  private filterToolDescriptions({
+    descriptions,
+    tools,
+  }: {
+    descriptions: Record<string, string>
+    tools: ToolSet | undefined
+  }): Record<string, string> {
+    if (!tools) return {}
+
+    return Object.fromEntries(
+      Object.keys(tools)
+        .map((toolName) => [toolName, descriptions[toolName]] as const)
+        .filter((entry): entry is readonly [string, string] => entry[1] !== undefined),
+    )
+  }
+
+  private getToolDescription(toolDef: unknown): string | undefined {
+    if (!toolDef || typeof toolDef !== "object" || !("description" in toolDef)) {
+      return undefined
+    }
+
+    const description = (toolDef as { description?: unknown }).description
+    return typeof description === "string" && description.trim().length > 0
+      ? description
+      : undefined
+  }
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/fill-form.tool.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/fill-form.tool.ts
@@ -1,72 +1,71 @@
 import { outputJsonSchemaSchema, ToolName } from "@caseai-connect/api-contracts"
 import { tool } from "ai"
 import { z } from "zod"
-import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
-import { castToolInputParameters, zNullableType } from "@/common/zod-helper"
-import type { Agent } from "@/domains/agents/agent.entity"
+import { castToolInputParameters } from "@/common/zod-helper"
+import type { FormAgentSession } from "@/domains/agents/form-agent-sessions/form-agent-session.entity"
 import type { FormAgentSessionsService } from "@/domains/agents/form-agent-sessions/form-agent-sessions.service"
+import type { AgentSessionScope } from "../streaming-session.types"
+import { buildFormFieldsZodSchema } from "./form-schema.helper"
 import type { ToolExecutionLog } from "./tool-execution-log"
 
 export function fillFormTool({
-  connectScope,
-  agent,
-  sessionId,
+  agentSessionScope,
   formAgentSessionsService,
   onExecute,
 }: {
-  connectScope: RequiredConnectScope
-  agent: Agent
-  sessionId: string
+  agentSessionScope: AgentSessionScope
   formAgentSessionsService: FormAgentSessionsService
   onExecute: (toolExecution: ToolExecutionLog) => void
 }) {
+  const { agent, connectScope, session } = agentSessionScope
   const schema = outputJsonSchemaSchema.parse(agent.outputJsonSchema) // validate the schema from the agent definition
 
-  const inputSchema = buildInputSchemaForFormTool(schema.properties)
+  const inputSchema = buildFormFieldsZodSchema(schema.properties)
 
   return tool({
     description: "Fill out a form. Get the values from user's answers.",
-    inputSchema,
+    inputSchema: z.object({
+      formFields: inputSchema
+        .describe(
+          "The form fields to be filled, with values provided by the user at this point, meaning can be a partial set of fields.",
+        )
+        .optional(),
+      getFormState: z.boolean().optional().describe("Whether to return the current form state."),
+    }),
     outputSchema: z.object({
       formState: inputSchema.describe(
         "The current state of the form, with values filled by the user",
       ),
     }),
     execute: async (input, _options) => {
-      const typedInput = castToolInputParameters(input)
-      const { result: formState } = await formAgentSessionsService.updateSessionResult({
-        connectScope,
-        sessionId,
-        input: typedInput,
-      })
+      if (input.formFields) {
+        const typedInput = castToolInputParameters(input.formFields)
+        const { result: formState } = await formAgentSessionsService.updateSessionResult({
+          connectScope,
+          sessionId: session.id,
+          input: typedInput,
+        })
+        onExecute({ toolName: ToolName.FillForm, arguments: typedInput })
+        return { formState }
+      }
 
-      onExecute({ toolName: ToolName.FillForm, arguments: typedInput })
-
-      return { formState }
+      onExecute({ toolName: ToolName.FillForm, arguments: {} })
+      assertFormAgentSessionResult(agentSessionScope)
+      return { formState: agentSessionScope.session.result || {} }
     },
   })
 }
 
-// TODO: write a test for this method
-function buildInputSchemaForFormTool(
-  properties: z.infer<typeof outputJsonSchemaSchema>["properties"],
-): z.ZodObject<Record<string, z.ZodTypeAny>> {
-  const shape: Record<string, z.ZodTypeAny> = {}
-  for (const [key, value] of Object.entries(properties)) {
-    const description = value.description || ""
-    switch (value.type) {
-      case "string":
-        shape[key] = zNullableType(z.string(), description)
-        break
-      case "number":
-        shape[key] = zNullableType(z.number(), description)
-        break
-      case "boolean":
-        shape[key] = zNullableType(z.boolean(), description)
-        break
-      default:
-        throw new Error(`Unsupported property type: ${value.type}`)
-    }
+function assertFormAgentSessionResult(
+  agentSessionScope: AgentSessionScope,
+): asserts agentSessionScope is AgentSessionScope & {
+  session: NonNullable<FormAgentSession>
+} {
+  const { session } = agentSessionScope
+  if (!("type" in session)) {
+    throw new Error("Agent session type is not initialized")
   }
-  return z.object(shape).strict()
+  if (!("result" in session)) {
+    throw new Error("Agent session result is not initialized")
+  }
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/form-schema.helper.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/form-schema.helper.ts
@@ -1,0 +1,26 @@
+import type { outputJsonSchemaSchema } from "@caseai-connect/api-contracts"
+import { z } from "zod"
+import { zNullableType } from "@/common/zod-helper"
+
+export function buildFormFieldsZodSchema(
+  properties: z.infer<typeof outputJsonSchemaSchema>["properties"],
+): z.ZodObject<Record<string, z.ZodTypeAny>> {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const [key, value] of Object.entries(properties)) {
+    const description = value.description ?? ""
+    switch (value.type) {
+      case "string":
+        shape[key] = zNullableType(z.string(), description)
+        break
+      case "number":
+        shape[key] = zNullableType(z.number(), description)
+        break
+      case "boolean":
+        shape[key] = zNullableType(z.boolean(), description)
+        break
+      default:
+        throw new Error(`Unsupported form field type: ${value.type}`)
+    }
+  }
+  return z.object(shape).strict()
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/sub-agent.tool.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/sub-agent.tool.ts
@@ -2,15 +2,18 @@ import { tool } from "ai"
 import { z } from "zod"
 import type { ToolExecutionLog } from "./tool-execution-log"
 
-const subAgentInputSchema = z.object({
+const inputSchema = z.object({
   task: z.string().min(1).describe("The precise task or question to delegate to the sub-agent."),
   context: z
     .string()
     .default("")
     .describe("Relevant conversation context the sub-agent needs to answer accurately."),
 })
+const outputSchema = z.object({
+  answer: z.string().describe("The sub-agent response."),
+})
 
-export type SubAgentToolInput = z.infer<typeof subAgentInputSchema>
+export type SubAgentToolInput = z.infer<typeof inputSchema>
 
 export function subAgentTool({
   description,
@@ -19,20 +22,17 @@ export function subAgentTool({
   toolName,
 }: {
   description: string
-  execute: (input: SubAgentToolInput) => Promise<string>
+  execute: (input: SubAgentToolInput) => Promise<Record<string, unknown>>
   onExecute: (toolExecution: ToolExecutionLog) => void
   toolName: string
 }) {
   return tool({
     description,
-    inputSchema: subAgentInputSchema,
-    outputSchema: z.object({
-      answer: z.string().describe("The sub-agent response."),
-    }),
+    inputSchema,
+    outputSchema,
     execute: async (input) => {
       onExecute({ toolName, arguments: input })
-      const answer = await execute(input)
-      return { answer }
+      return execute(input as SubAgentToolInput)
     },
   })
 }

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
@@ -184,19 +184,13 @@ describe("AgentSubAgentsService", () => {
     ).rejects.toThrow("Duplicate sub-agent tool names are not allowed")
   })
 
-  it("rejects sub-agents outside the project or with a non-conversation type", async () => {
+  it("rejects sub-agents outside the project", async () => {
     const { organization, project, agent } = await createOrganizationWithAgent(repositories)
     const otherProject = await repositories.projectRepository.save(
       projectFactory.transient({ organization }).build(),
     )
     const otherProjectAgent = await repositories.agentRepository.save(
       agentFactory.transient({ organization, project: otherProject }).build(),
-    )
-    const extractionAgent = await repositories.agentRepository.save(
-      agentFactory.transient({ organization, project }).build({
-        type: "extraction",
-        outputJsonSchema: { type: "object", properties: {} },
-      }),
     )
     const connectScope = { organizationId: organization.id, projectId: project.id }
 
@@ -214,21 +208,33 @@ describe("AgentSubAgentsService", () => {
         ],
       }),
     ).rejects.toThrow("One or more sub-agents do not exist in this project")
+  })
 
-    await expect(
-      service.replaceSubAgents({
-        connectScope,
-        parentAgent: agent,
-        subAgents: [
-          {
-            childAgentId: extractionAgent.id,
-            toolName: "ask_extraction",
-            description: "",
-            enabled: true,
-          },
-        ],
+  it("accepts non-conversation agents as sub-agents", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+    const extractionAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        type: "extraction",
+        outputJsonSchema: { type: "object", properties: {} },
       }),
-    ).rejects.toThrow("Sub-agents must be conversation agents")
+    )
+    const connectScope = { organizationId: organization.id, projectId: project.id }
+
+    const result = await service.replaceSubAgents({
+      connectScope,
+      parentAgent: agent,
+      subAgents: [
+        {
+          childAgentId: extractionAgent.id,
+          toolName: "ask_extraction",
+          description: "",
+          enabled: true,
+        },
+      ],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.childAgentId).toBe(extractionAgent.id)
   })
 
   it("rejects non-conversation parent agents", async () => {

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
@@ -146,11 +146,6 @@ export class AgentSubAgentsService {
       throw new UnprocessableEntityException("One or more sub-agents do not exist in this project")
     }
 
-    const invalidChildAgent = childAgents.find((agent) => agent.type !== "conversation")
-    if (invalidChildAgent) {
-      throw new UnprocessableEntityException("Sub-agents must be conversation agents")
-    }
-
     return childAgents
   }
 }

--- a/apps/api/src/migrations/1782314857774-form-sub-session.ts
+++ b/apps/api/src/migrations/1782314857774-form-sub-session.ts
@@ -1,0 +1,13 @@
+import type { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FormSubSession1782314857774 implements MigrationInterface {
+  name = "FormSubSession1782314857774"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "form_agent_session" ADD "parent_session_id" uuid`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "form_agent_session" DROP COLUMN "parent_session_id"`)
+  }
+}

--- a/apps/api/src/migrations/1782389701803-conversation-sub-session.ts
+++ b/apps/api/src/migrations/1782389701803-conversation-sub-session.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ConversationSubSession1782389701803 implements MigrationInterface {
+  name = "ConversationSubSession1782389701803"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "conversation_agent_session" ADD "parent_session_id" uuid`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "conversation_agent_session" DROP COLUMN "parent_session_id"`,
+    )
+  }
+}

--- a/apps/web/src/studio/features/agents/components/AgentSubAgentItem.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSubAgentItem.tsx
@@ -1,0 +1,107 @@
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import { Button } from "@caseai-connect/ui/shad/button"
+import { Field, FieldLabel } from "@caseai-connect/ui/shad/field"
+import { Input } from "@caseai-connect/ui/shad/input"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@caseai-connect/ui/shad/item"
+import { Switch } from "@caseai-connect/ui/shad/switch"
+import { Textarea } from "@caseai-connect/ui/shad/textarea"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@caseai-connect/ui/shad/tooltip"
+import { Trash2Icon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { getAgentIcon } from "@/common/features/agents/components/AgentIcon"
+import type { AgentSubAgentFormValue } from "./AgentSubAgentsTab"
+
+export function AgentSubAgentItem({
+  subAgent,
+  agent,
+  onUpdate,
+  onRemove,
+}: {
+  subAgent: AgentSubAgentFormValue
+  agent: Agent | undefined
+  onUpdate: (fields: Partial<Omit<AgentSubAgentFormValue, "id" | "agentId">>) => void
+  onRemove: () => void
+}) {
+  const { t } = useTranslation()
+
+  if (!agent) return null
+
+  const title = agent.name
+  const Icon = getAgentIcon(agent.type)
+
+  return (
+    <div className="rounded-md border">
+      <Item>
+        <ItemMedia variant="icon">
+          <Icon />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>
+            {title}
+            <Badge variant={subAgent.enabled ? "default" : "secondary"}>
+              {subAgent.enabled
+                ? t("agent:orchestration.enabled")
+                : t("agent:orchestration.disabled")}
+            </Badge>
+          </ItemTitle>
+          <ItemDescription>{subAgent.toolName}</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Switch
+            checked={subAgent.enabled}
+            onCheckedChange={(enabled) => onUpdate({ enabled })}
+            aria-label={t("agent:orchestration.enabled")}
+          />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8 text-muted-foreground hover:text-destructive"
+                aria-label={t("agent:orchestration.remove")}
+                onClick={onRemove}
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("agent:orchestration.remove")}</TooltipContent>
+          </Tooltip>
+        </ItemActions>
+      </Item>
+      <div className="grid gap-4 border-t p-4 md:grid-cols-[minmax(12rem,18rem)_1fr]">
+        <Field>
+          <FieldLabel htmlFor={`sub-agent-tool-name-${subAgent.id}`}>
+            {t("agent:orchestration.toolName")}
+          </FieldLabel>
+          <Input
+            id={`sub-agent-tool-name-${subAgent.id}`}
+            value={subAgent.toolName}
+            placeholder={t("agent:orchestration.toolNamePlaceholder")}
+            onChange={(event) => onUpdate({ toolName: event.target.value })}
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor={`sub-agent-description-${subAgent.id}`}>
+            {t("agent:orchestration.description")}
+          </FieldLabel>
+          <Textarea
+            id={`sub-agent-description-${subAgent.id}`}
+            value={subAgent.description}
+            rows={2}
+            className="min-h-20"
+            onChange={(event) => onUpdate({ description: event.target.value })}
+          />
+        </Field>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
@@ -47,12 +47,7 @@ export function AgentSubAgentsTab({
   const { t } = useTranslation()
   const selectedAgentIds = new Set(value.map((subAgent) => subAgent.agentId))
   const availableAgents = agents
-    .filter(
-      (agent) =>
-        agent.type === "conversation" &&
-        agent.id !== parentAgentId &&
-        !selectedAgentIds.has(agent.id),
-    )
+    .filter((agent) => agent.id !== parentAgentId && !selectedAgentIds.has(agent.id))
     .sort((leftAgent, rightAgent) => leftAgent.name.localeCompare(rightAgent.name))
 
   const updateSubAgent = (

--- a/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSubAgentsTab.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@caseai-connect/ui/shad/badge"
 import { Button } from "@caseai-connect/ui/shad/button"
 import {
   Empty,
@@ -8,7 +7,6 @@ import {
   EmptyTitle,
 } from "@caseai-connect/ui/shad/empty"
 import { Field, FieldGroup, FieldLabel } from "@caseai-connect/ui/shad/field"
-import { Input } from "@caseai-connect/ui/shad/input"
 import {
   Item,
   ItemActions,
@@ -18,12 +16,11 @@ import {
   ItemMedia,
   ItemTitle,
 } from "@caseai-connect/ui/shad/item"
-import { Switch } from "@caseai-connect/ui/shad/switch"
-import { Textarea } from "@caseai-connect/ui/shad/textarea"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@caseai-connect/ui/shad/tooltip"
-import { BotIcon, PlusIcon, Trash2Icon } from "lucide-react"
+import { BotIcon, PlusIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import type { Agent } from "@/common/features/agents/agents.models"
+import { getAgentIcon } from "@/common/features/agents/components/AgentIcon"
+import { AgentSubAgentItem } from "./AgentSubAgentItem"
 
 export type AgentSubAgentFormValue = {
   id: string
@@ -47,7 +44,12 @@ export function AgentSubAgentsTab({
   const { t } = useTranslation()
   const selectedAgentIds = new Set(value.map((subAgent) => subAgent.agentId))
   const availableAgents = agents
-    .filter((agent) => agent.id !== parentAgentId && !selectedAgentIds.has(agent.id))
+    .filter(
+      (agent) =>
+        (agent.type === "conversation" || agent.type === "form") &&
+        agent.id !== parentAgentId &&
+        !selectedAgentIds.has(agent.id),
+    )
     .sort((leftAgent, rightAgent) => leftAgent.name.localeCompare(rightAgent.name))
 
   const updateSubAgent = (
@@ -92,81 +94,15 @@ export function AgentSubAgentsTab({
           </Empty>
         ) : (
           <ItemGroup className="gap-3">
-            {value.map((subAgent) => {
-              const agent = agents.find((candidate) => candidate.id === subAgent.agentId)
-              const title = agent?.name ?? t("agent:orchestration.missingAgent")
-              return (
-                <div key={subAgent.id} className="rounded-md border">
-                  <Item>
-                    <ItemMedia variant="icon">
-                      <BotIcon />
-                    </ItemMedia>
-                    <ItemContent>
-                      <ItemTitle>
-                        {title}
-                        <Badge variant={subAgent.enabled ? "default" : "secondary"}>
-                          {subAgent.enabled
-                            ? t("agent:orchestration.enabled")
-                            : t("agent:orchestration.disabled")}
-                        </Badge>
-                      </ItemTitle>
-                      <ItemDescription>{subAgent.toolName}</ItemDescription>
-                    </ItemContent>
-                    <ItemActions>
-                      <Switch
-                        checked={subAgent.enabled}
-                        onCheckedChange={(enabled) => updateSubAgent(subAgent.id, { enabled })}
-                        aria-label={t("agent:orchestration.enabled")}
-                      />
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="size-8 text-muted-foreground hover:text-destructive"
-                            aria-label={t("agent:orchestration.remove")}
-                            onClick={() => removeSubAgent(subAgent.id)}
-                          >
-                            <Trash2Icon className="size-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>{t("agent:orchestration.remove")}</TooltipContent>
-                      </Tooltip>
-                    </ItemActions>
-                  </Item>
-                  <div className="grid gap-4 border-t p-4 md:grid-cols-[minmax(12rem,18rem)_1fr]">
-                    <Field>
-                      <FieldLabel htmlFor={`sub-agent-tool-name-${subAgent.id}`}>
-                        {t("agent:orchestration.toolName")}
-                      </FieldLabel>
-                      <Input
-                        id={`sub-agent-tool-name-${subAgent.id}`}
-                        value={subAgent.toolName}
-                        placeholder={t("agent:orchestration.toolNamePlaceholder")}
-                        onChange={(event) =>
-                          updateSubAgent(subAgent.id, { toolName: event.target.value })
-                        }
-                      />
-                    </Field>
-                    <Field>
-                      <FieldLabel htmlFor={`sub-agent-description-${subAgent.id}`}>
-                        {t("agent:orchestration.description")}
-                      </FieldLabel>
-                      <Textarea
-                        id={`sub-agent-description-${subAgent.id}`}
-                        value={subAgent.description}
-                        rows={2}
-                        className="min-h-20"
-                        onChange={(event) =>
-                          updateSubAgent(subAgent.id, { description: event.target.value })
-                        }
-                      />
-                    </Field>
-                  </div>
-                </div>
-              )
-            })}
+            {value.map((subAgent) => (
+              <AgentSubAgentItem
+                key={subAgent.id}
+                subAgent={subAgent}
+                agent={agents.find((candidate) => candidate.id === subAgent.agentId)}
+                onUpdate={(fields) => updateSubAgent(subAgent.id, fields)}
+                onRemove={() => removeSubAgent(subAgent.id)}
+              />
+            ))}
           </ItemGroup>
         )}
       </Field>
@@ -179,28 +115,31 @@ export function AgentSubAgentsTab({
           </p>
         ) : (
           <div className="grid gap-3 md:grid-cols-2">
-            {availableAgents.map((agent) => (
-              <Item key={agent.id} variant="outline">
-                <ItemMedia variant="icon">
-                  <BotIcon />
-                </ItemMedia>
-                <ItemContent>
-                  <ItemTitle>{agent.name}</ItemTitle>
-                  <ItemDescription>{agent.defaultPrompt}</ItemDescription>
-                </ItemContent>
-                <ItemActions>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => addSubAgent(agent)}
-                  >
-                    <PlusIcon />
-                    {t("agent:orchestration.add")}
-                  </Button>
-                </ItemActions>
-              </Item>
-            ))}
+            {availableAgents.map((agent) => {
+              const Icon = getAgentIcon(agent.type)
+              return (
+                <Item key={agent.id} variant="outline">
+                  <ItemMedia variant="icon">
+                    <Icon />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>{agent.name}</ItemTitle>
+                    <ItemDescription>{agent.defaultPrompt}</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => addSubAgent(agent)}
+                    >
+                      <PlusIcon />
+                      {t("agent:orchestration.add")}
+                    </Button>
+                  </ItemActions>
+                </Item>
+              )
+            })}
           </div>
         )}
       </Field>


### PR DESCRIPTION
## Summary

Adds sub-agent delegation so a parent agent can hand off the user's latest answer to a specialized sub-agent:

- **Form sub-agent** — fills the form and replies with the current form state and the next question to ask.
- **Conversation sub-agent** — answers using its own tools and replies to the parent agent.
- Sub-agent runs are recorded as their own Langfuse trace, linked back to the parent agent's trace.

## Changes

- New form/conversation sub-session entities, factories, services, and migrations.
- `generate-master-prompt`, `tools.service`, `form-schema.helper`, and updated `fill-form` / `sub-agent` tools in the streaming pipeline.
- Web: `AgentSubAgentItem` component and updated `AgentSubAgentsTab`.
- Tests for sub-session creation, form/conversation session services, and sub-agent tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)