### PR TITLE
feat: surface form sub-agent results in studio session view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Studio conversation session view surfaces the form results produced by delegated form sub-agents, opened in a side sheet from the relevant message
 
 ### Changed
 

--- a/apps/api/src/domains/agents/form-agent-sessions/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/e2e-tests/auth.spec.ts
@@ -178,6 +178,72 @@ describe("Agent Sessions - Auth", () => {
     })
   })
 
+  describe("FormAgentSessionsRoutes.listSubSessions", () => {
+    // Sub-sessions are listed for a parent conversation agent, the only agent
+    // type allowed to have sub-agents.
+    const createConversationContextForRole = async (role: ProjectMembershipRoleDto) => {
+      const { organization, project, agent, agentSession } =
+        await createOrganizationWithAgentSession({
+          repositories,
+          params: {
+            user: { auth0Id },
+            projectMembership: { role },
+          },
+          agentType: "conversation",
+        })
+      organizationId = organization.id
+      projectId = project.id
+      agentId = agent.id
+      agentSessionId = agentSession.id
+      accessToken = "token"
+    }
+
+    const subject = async (type: "playground" | "live") =>
+      request({
+        route: FormAgentSessionsRoutes.listSubSessions,
+        pathParams: removeNullish({ organizationId, projectId, agentId, agentSessionId }),
+        token: accessToken ?? undefined,
+        request: { payload: { type } },
+      })
+
+    describe.each([["live"], ["playground"]] as const)("listing %s sub-sessions", (type) => {
+      it("requires an authentication token", async () => {
+        accessToken = null
+        expectResponse(await subject(type), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+      })
+      it("requires a valid organization ID", async () => {
+        await createConversationContextForRole("owner")
+        organizationId = null
+        expectResponse(await subject(type), 400, AUTH_ERRORS.NO_ORGANIZATION_ID)
+      })
+      it("requires a valid agent ID", async () => {
+        await createConversationContextForRole("owner")
+        agentId = null
+        expectResponse(await subject(type), 404)
+      })
+      it("requires the user to be a member of the organization", async () => {
+        await createConversationContextForRole("owner")
+        auth0Id = mockForeignAuth0Id()
+        expectResponse(await subject(type), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+      })
+      if (type === "playground") {
+        it("doesn't allow a simple member to list playground sub-sessions", async () => {
+          await createConversationContextForRole("member")
+          expectResponse(await subject(type), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+        })
+      } else {
+        it("allows members to list live sub-sessions", async () => {
+          await createConversationContextForRole("member")
+          expectResponse(await subject(type), 201)
+        })
+      }
+      it("allows owner to list sub-sessions", async () => {
+        await createConversationContextForRole("owner")
+        expectResponse(await subject(type), 201)
+      })
+    })
+  })
+
   describe("FormAgentSessionsRoutes.deleteOne", () => {
     const subject = async (type: "playground" | "live") =>
       request({

--- a/apps/api/src/domains/agents/form-agent-sessions/e2e-tests/list-sub-sessions.spec.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/e2e-tests/list-sub-sessions.spec.ts
@@ -1,0 +1,133 @@
+import { FormAgentSessionsRoutes } from "@caseai-connect/api-contracts"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { setupUserGuardForTesting } from "../../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../../test/request"
+import { formAgentSessionFactory } from "../form-agent-session.factory"
+import { FormAgentSessionsModule } from "../form-agent-sessions.module"
+
+const PARENT_SESSION_ID = "11111111-1111-1111-1111-111111111111"
+
+describe("FormAgentSessionsRoutes.listSubSessions", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let organizationId: string
+  let projectId: string
+  let parentAgentId: string
+  let auth0Id = "auth0|123"
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [FormAgentSessionsModule],
+      applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    auth0Id = "auth0|123"
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await sdk.shutdown()
+    await app.close()
+  })
+
+  // The default agent created by createOrganizationWithAgent is a conversation
+  // agent, which is the only type allowed to have sub-agents.
+  const createContext = async () => {
+    const { user, organization, project, agent } = await createOrganizationWithAgent(repositories)
+    organizationId = organization.id
+    projectId = project.id
+    parentAgentId = agent.id
+    auth0Id = user.auth0Id
+
+    const formChildAgent = await repositories.agentRepository.save(
+      agentFactory.transient({ organization, project }).build({
+        name: "Intake Form",
+        type: "form",
+        outputJsonSchema: { type: "object", properties: { fullName: { type: "string" } } },
+      }),
+    )
+
+    await repositories.agentSubAgentRepository.save(
+      repositories.agentSubAgentRepository.create({
+        parentAgentId: agent.id,
+        childAgentId: formChildAgent.id,
+        toolName: "collect_intake",
+        description: "Collect intake details",
+        enabled: true,
+      }),
+    )
+
+    const subSession = await repositories.formAgentSessionRepository.save(
+      formAgentSessionFactory
+        .transient({ organization, project, user, agent: formChildAgent })
+        .playground()
+        .build({
+          parentSessionId: PARENT_SESSION_ID,
+          result: { fullName: "Helpful Assistant" },
+        }),
+    )
+
+    return { formChildAgent, subSession }
+  }
+
+  const subject = async (agentSessionId: string) =>
+    request({
+      route: FormAgentSessionsRoutes.listSubSessions,
+      pathParams: removeNullish({
+        organizationId,
+        projectId,
+        agentId: parentAgentId,
+        agentSessionId,
+      }),
+      token: "token",
+      request: { payload: { type: "playground" } },
+    })
+
+  it("returns the form sub-sessions delegated by the parent session", async () => {
+    const { formChildAgent, subSession } = await createContext()
+
+    const response = await subject(PARENT_SESSION_ID)
+
+    expectResponse(response, 201)
+    const subSessions = response.body.data
+    expect(subSessions).toHaveLength(1)
+    expect(subSessions[0]).toMatchObject({
+      toolName: "collect_intake",
+      agentId: formChildAgent.id,
+      agentName: "Intake Form",
+      outputJsonSchema: { type: "object", properties: { fullName: { type: "string" } } },
+    })
+    expect(subSessions[0]?.session.id).toBe(subSession.id)
+    expect(subSessions[0]?.session.result).toEqual({ fullName: "Helpful Assistant" })
+  })
+
+  it("returns an empty list when the parent session has no sub-sessions", async () => {
+    await createContext()
+
+    const response = await subject("22222222-2222-2222-2222-222222222222")
+
+    expectResponse(response, 201)
+    expect(response.body.data).toHaveLength(0)
+  })
+})

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.controller.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.controller.ts
@@ -1,5 +1,9 @@
-import { type FormAgentSessionDto, FormAgentSessionsRoutes } from "@caseai-connect/api-contracts"
-import { Body, Controller, Post, Req, UseGuards } from "@nestjs/common"
+import {
+  type FormAgentSessionDto,
+  FormAgentSessionsRoutes,
+  type FormSubSessionDto,
+} from "@caseai-connect/api-contracts"
+import { Body, Controller, Param, Post, Req, UseGuards } from "@nestjs/common"
 import type {
   EndpointRequestWithAgent,
   EndpointRequestWithAgentSession,
@@ -16,6 +20,8 @@ import { BaseAgentSessionGuard } from "../base-agent-sessions/base-agent-session
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { BaseAgentSessionsService } from "../base-agent-sessions/base-agent-sessions.service"
 import type { BaseAgentSessionType } from "../base-agent-sessions/base-agent-sessions.types"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { AgentSubAgentsService } from "../sub-agents/agent-sub-agents.service"
 import type { FormAgentSession } from "./form-agent-session.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { FormAgentSessionsService } from "./form-agent-sessions.service"
@@ -28,6 +34,8 @@ export class FormAgentSessionsController {
     private readonly formAgentSessionsService: FormAgentSessionsService,
 
     private readonly baseAgentSessionsService: BaseAgentSessionsService,
+
+    private readonly agentSubAgentsService: AgentSubAgentsService,
   ) {}
 
   @CheckPolicy((policy) => policy.canList())
@@ -73,6 +81,45 @@ export class FormAgentSessionsController {
       agentSession: request.agentSession,
     })
     return { data: { success: true } }
+  }
+
+  @CheckPolicy((policy) => policy.canList())
+  @Post(FormAgentSessionsRoutes.listSubSessions.path)
+  async listSubSessions(
+    @Req() request: EndpointRequestWithAgent,
+    @Param("agentSessionId") agentSessionId: string,
+    @Body() { payload }: typeof FormAgentSessionsRoutes.listSubSessions.request,
+  ): Promise<typeof FormAgentSessionsRoutes.listSubSessions.response> {
+    const connectScope = getRequiredConnectScope(request)
+
+    const [subAgents, sessions] = await Promise.all([
+      this.agentSubAgentsService.listSubAgents({ connectScope, parentAgent: request.agent }),
+      this.formAgentSessionsService.listSubSessions({
+        connectScope,
+        parentSessionId: agentSessionId,
+        userId: request.user.id,
+        type: payload.type,
+      }),
+    ])
+
+    const sessionByAgentId = new Map(sessions.map((session) => [session.agentId, session]))
+
+    const data = subAgents.flatMap((subAgent): FormSubSessionDto[] => {
+      if (subAgent.childAgent?.type !== "form") return []
+      const session = sessionByAgentId.get(subAgent.childAgentId)
+      if (!session) return []
+      return [
+        {
+          toolName: subAgent.toolName,
+          agentId: subAgent.childAgentId,
+          agentName: subAgent.childAgent.name,
+          outputJsonSchema: subAgent.childAgent.outputJsonSchema ?? undefined,
+          session: toDto(payload.type)(session),
+        },
+      ]
+    })
+
+    return { data }
   }
 }
 

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.spec.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.spec.ts
@@ -150,4 +150,56 @@ describe("FormAgentSessionsService", () => {
       expect(listed.map((session) => session.id)).toEqual([userSession.id])
     })
   })
+
+  describe("listSubSessions", () => {
+    it("returns only the sub-sessions for the given parent session, user and type", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      const subSession = await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+      // A sub-session under a different parent session must be excluded.
+      await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: "22222222-2222-2222-2222-222222222222",
+        type: "playground",
+      })
+
+      const listed = await service.listSubSessions({
+        connectScope,
+        parentSessionId: PARENT_SESSION_ID,
+        userId: user.id,
+        type: "playground",
+      })
+
+      expect(listed.map((session) => session.id)).toEqual([subSession.id])
+    })
+
+    it("does not return another user's sub-sessions", async () => {
+      const { connectScope, formAgent, user } = await createFormAgent()
+
+      await service.findOrCreateSubSession({
+        connectScope,
+        agentId: formAgent.id,
+        userId: user.id,
+        parentSessionId: PARENT_SESSION_ID,
+        type: "playground",
+      })
+
+      const listed = await service.listSubSessions({
+        connectScope,
+        parentSessionId: PARENT_SESSION_ID,
+        userId: "99999999-9999-9999-9999-999999999999",
+        type: "playground",
+      })
+
+      expect(listed).toHaveLength(0)
+    })
+  })
 })

--- a/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.ts
+++ b/apps/api/src/domains/agents/form-agent-sessions/form-agent-sessions.service.ts
@@ -147,6 +147,29 @@ export class FormAgentSessionsService {
     })
   }
 
+  /**
+   * Lists the form sub-sessions spawned by a given parent agent session. These
+   * are the persistent form sessions created when a parent agent delegates to a
+   * form sub-agent (see {@link findOrCreateSubSession}). Scoped to the requesting
+   * user to match {@link listSessions} visibility.
+   */
+  async listSubSessions({
+    connectScope,
+    parentSessionId,
+    userId,
+    type,
+  }: {
+    connectScope: RequiredConnectScope
+    parentSessionId: string
+    userId: string
+    type: BaseAgentSessionType
+  }): Promise<FormAgentSession[]> {
+    return this.sessionConnectRepository.find(connectScope, {
+      where: { parentSessionId, userId, type },
+      order: { createdAt: "ASC" },
+    })
+  }
+
   async updateSessionResult({
     connectScope,
     input,

--- a/apps/web/src/common/features/agents/agent-sessions/agent-session.factory.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/agent-session.factory.ts
@@ -3,7 +3,7 @@ import { Factory } from "fishery"
 import type { Agent } from "@/common/features/agents/agents.models"
 import type { ConversationAgentSession } from "./conversation/conversation-agent-sessions.models"
 import type { ExtractionAgentSessionSummary } from "./extraction/extraction-agent-sessions.models"
-import type { FormAgentSession } from "./form/form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "./form/form-agent-sessions.models"
 import type { AgentSessionMessage } from "./shared/agent-session-messages/agent-session-messages.models"
 
 type SessionTransientParams = {
@@ -54,6 +54,30 @@ export const formAgentSessionFactory = FormAgentSessionFactory.define(
   },
 )
 
+type FormSubSessionTransientParams = SessionTransientParams & {
+  session?: FormAgentSession
+}
+
+class FormSubSessionFactory extends Factory<FormSubSession, FormSubSessionTransientParams> {}
+
+export const formSubSessionFactory = FormSubSessionFactory.define(
+  ({ params, transientParams }): FormSubSession => {
+    const session =
+      transientParams.session ??
+      formAgentSessionFactory.transient(transientParams).build({ type: "playground" })
+    return {
+      toolName: params.toolName ?? faker.helpers.slugify(faker.word.verb()).replace(/-/g, "_"),
+      agentId: params.agentId ?? session.agentId,
+      agentName: params.agentName ?? faker.commerce.productName(),
+      outputJsonSchema: params.outputJsonSchema ?? {
+        type: "object",
+        properties: { title: { type: "string" }, summary: { type: "string" } },
+      },
+      session,
+    }
+  },
+)
+
 class ExtractionAgentSessionSummaryFactory extends Factory<
   ExtractionAgentSessionSummary,
   SessionTransientParams
@@ -83,4 +107,5 @@ export const agentSessionMessageFactory = AgentSessionMessageFactory.define(({ p
   role: params.role ?? "user",
   content: params.content ?? faker.lorem.sentence(),
   status: params.status ?? "completed",
+  toolCalls: params.toolCalls,
 }))

--- a/apps/web/src/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.middleware.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.middleware.ts
@@ -1,10 +1,17 @@
 import { createListenerMiddleware } from "@reduxjs/toolkit"
 import { getCurrentId } from "@/common/features/helpers"
 import type { AppDispatch, RootState } from "@/common/store"
+import { isStudioInterface } from "@/studio/routes/helpers"
+import { formAgentSessionsActions } from "../form/form-agent-sessions.slice"
+import { agentSessionMessagesActions } from "../shared/agent-session-messages/agent-session-messages.slice"
 import { listMessages } from "../shared/agent-session-messages/agent-session-messages.thunks"
 import { conversationAgentSessionsActions } from "./conversation-agent-sessions.slice"
 
 export const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
+
+// Streaming emits many chunks per second; debounce the sub-session refresh so
+// it fires once the stream settles instead of on every chunk.
+const SUB_SESSIONS_REFRESH_DEBOUNCE_MS = 500
 
 function registerListeners() {
   // Load conversation agent sessions when agent is loaded
@@ -24,6 +31,39 @@ function registerListeners() {
       const state = listenerApi.getState()
       const agentSessionId = getCurrentId({ state, name: "agentSessionId" })
       await listenerApi.dispatch(listMessages(agentSessionId))
+
+      // The Studio session view surfaces form sub-agent results delegated by
+      // this conversation session. Other interfaces don't render them, so skip
+      // the extra fetch there.
+      if (isStudioInterface()) {
+        const agentId = getCurrentId({ state, name: "agentId" })
+        await listenerApi.dispatch(
+          formAgentSessionsActions.listSubSessions({ agentId, agentSessionId }),
+        )
+      }
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: agentSessionMessagesActions.appendAssistantChunk,
+    effect: async (_, listenerApi) => {
+      if (!isStudioInterface()) return
+
+      // Collapse the burst of streaming chunks into a single refresh: cancel
+      // any pending run and wait for the stream to settle before fetching.
+      listenerApi.cancelActiveListeners()
+      await listenerApi.delay(SUB_SESSIONS_REFRESH_DEBOUNCE_MS)
+
+      const state = listenerApi.getState()
+      const agentSessionId = getCurrentId({ state, name: "agentSessionId" })
+
+      // The Studio session view surfaces form sub-agent results delegated by
+      // this conversation session. Other interfaces don't render them, so skip
+      // the extra fetch there.
+      const agentId = getCurrentId({ state, name: "agentId" })
+      await listenerApi.dispatch(
+        formAgentSessionsActions.listSubSessions({ agentId, agentSessionId }),
+      )
     },
   })
 }

--- a/apps/web/src/common/features/agents/agent-sessions/form/components/FormResult.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/form/components/FormResult.tsx
@@ -1,10 +1,9 @@
-import { Badge } from "@caseai-connect/ui/shad/badge"
 import { Item, ItemHeader, ItemTitle } from "@caseai-connect/ui/shad/item"
-import { Separator } from "@caseai-connect/ui/shad/separator"
 import { useTranslation } from "react-i18next"
 import type { FormAgentSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
 import type { Agent } from "@/common/features/agents/agents.models"
 import { assert } from "@/common/utils/assert"
+import { FormResultFields } from "./FormResultFields"
 
 export function FormResult({
   agent,
@@ -14,58 +13,17 @@ export function FormResult({
   agentSession: FormAgentSession
 }) {
   const { t } = useTranslation()
-  const form = buildForm({ agent, agentSession })
+  assert(agent.type === "form", `FormResult: Unsupported agent type: ${agent.type}`)
+  assert(agent.outputJsonSchema, "FormResult: Missing outputJsonSchema for form agent")
+
   return (
     <Item className="absolute inset-0 flex-col items-stretch flex-nowrap gap-0 p-0">
       <ItemHeader className="basis-auto shrink-0 px-4 pt-4 pb-2">
         <ItemTitle className="text-lg">{t("formAgentSession:props.result")}</ItemTitle>
       </ItemHeader>
       <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
-        <div className="flex flex-col gap-1">
-          {Object.entries(form).map(([key, value], index) => {
-            const hasValue = value !== ""
-            return (
-              <div key={key}>
-                {index > 0 && <Separator className="opacity-50" />}
-                <div className="flex gap-2 py-4 items-center">
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    {key}
-                  </span>
-                  {hasValue ? (
-                    <Badge variant="outline" className="w-fit text-muted-foreground font-mono">
-                      {value}
-                    </Badge>
-                  ) : (
-                    <Badge
-                      variant="outline"
-                      className="w-fit text-muted-foreground opacity-50 font-mono"
-                    >
-                      —
-                    </Badge>
-                  )}
-                </div>
-              </div>
-            )
-          })}
-        </div>
+        <FormResultFields outputJsonSchema={agent.outputJsonSchema} result={agentSession.result} />
       </div>
     </Item>
   )
-}
-
-function buildForm({ agent, agentSession }: { agent: Agent; agentSession: FormAgentSession }) {
-  assert(agent.type === "form", `BuildForm: Unsupported agent type: ${agent.type}`)
-  assert(agent.outputJsonSchema, "BuildForm: Missing outputJsonSchema for form agent")
-
-  const properties = Object.fromEntries(
-    Object.entries(agent.outputJsonSchema?.properties ?? {}).map(([key]) => [key, ""]),
-  )
-  if (agentSession.result) {
-    for (const key of Object.keys(properties)) {
-      if (key in agentSession.result) {
-        properties[key] = String(agentSession.result[key])
-      }
-    }
-  }
-  return properties
 }

--- a/apps/web/src/common/features/agents/agent-sessions/form/components/FormResultFields.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/form/components/FormResultFields.tsx
@@ -1,0 +1,68 @@
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import { Separator } from "@caseai-connect/ui/shad/separator"
+
+/**
+ * Renders the key/value list for a form agent's output: every property declared
+ * in the output schema, filled with the session result when available. Shared by
+ * the form session result panel and the sub-agent form result sheet.
+ */
+export function FormResultFields({
+  outputJsonSchema,
+  result,
+}: {
+  outputJsonSchema?: Record<string, unknown>
+  result?: Record<string, unknown>
+}) {
+  const fields = buildFields({ outputJsonSchema, result })
+
+  return (
+    <div className="flex flex-col gap-1">
+      {Object.entries(fields).map(([key, value], index) => {
+        const hasValue = value !== ""
+        return (
+          <div key={key}>
+            {index > 0 && <Separator className="opacity-50" />}
+            <div className="flex gap-2 py-4 items-center">
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                {key}
+              </span>
+              {hasValue ? (
+                <Badge variant="outline" className="w-fit text-muted-foreground font-mono">
+                  {value}
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="w-fit text-muted-foreground opacity-50 font-mono"
+                >
+                  —
+                </Badge>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function buildFields({
+  outputJsonSchema,
+  result,
+}: {
+  outputJsonSchema?: Record<string, unknown>
+  result?: Record<string, unknown>
+}): Record<string, string> {
+  const properties = (outputJsonSchema?.properties ?? {}) as Record<string, unknown>
+  const fields = Object.fromEntries(Object.keys(properties).map((key) => [key, ""]))
+
+  if (result) {
+    for (const key of Object.keys(fields)) {
+      if (key in result) {
+        fields[key] = String(result[key])
+      }
+    }
+  }
+
+  return fields
+}

--- a/apps/web/src/common/features/agents/agent-sessions/form/external/form-agent-sessions.api.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/external/form-agent-sessions.api.ts
@@ -1,6 +1,10 @@
-import { type FormAgentSessionDto, FormAgentSessionsRoutes } from "@caseai-connect/api-contracts"
+import {
+  type FormAgentSessionDto,
+  FormAgentSessionsRoutes,
+  type FormSubSessionDto,
+} from "@caseai-connect/api-contracts"
 import { getAxiosInstance } from "@/external/axios"
-import type { FormAgentSession } from "../form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "../form-agent-sessions.models"
 import type { IFormAgentSessionsSpi } from "../form-agent-sessions.spi"
 
 export default {
@@ -28,6 +32,14 @@ export default {
     )
     return response.data.data
   },
+  listSubSessions: async ({ type, ...params }) => {
+    const axios = getAxiosInstance()
+    const response = await axios.post<typeof FormAgentSessionsRoutes.listSubSessions.response>(
+      FormAgentSessionsRoutes.listSubSessions.getPath(params),
+      { payload: { type } } satisfies typeof FormAgentSessionsRoutes.listSubSessions.request,
+    )
+    return response.data.data.map(fromSubSessionDto)
+  },
 } satisfies IFormAgentSessionsSpi
 
 const fromDto = (dto: FormAgentSessionDto): FormAgentSession => ({
@@ -38,4 +50,12 @@ const fromDto = (dto: FormAgentSessionDto): FormAgentSession => ({
   traceUrl: dto.traceUrl,
   type: dto.type,
   updatedAt: dto.updatedAt,
+})
+
+const fromSubSessionDto = (dto: FormSubSessionDto): FormSubSession => ({
+  toolName: dto.toolName,
+  agentId: dto.agentId,
+  agentName: dto.agentName,
+  outputJsonSchema: dto.outputJsonSchema,
+  session: fromDto(dto.session),
 })

--- a/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.models.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.models.ts
@@ -1,4 +1,9 @@
-import type { AgentSessionMessageDto, FormAgentSessionDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMessageDto,
+  FormAgentSessionDto,
+  FormSubSessionDto,
+} from "@caseai-connect/api-contracts"
 
 export type FormAgentSession = FormAgentSessionDto
 export type FormAgentSessionMessage = AgentSessionMessageDto
+export type FormSubSession = FormSubSessionDto

--- a/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.selectors.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.selectors.ts
@@ -3,9 +3,10 @@ import type { RootState } from "@/common/store"
 import { ADS, type AsyncData } from "@/common/store/async-data-status"
 import { selectCurrentAgentData } from "../../agents.selectors"
 import { selectCurrentAgentSessionId } from "../current-agent-session-id/current-agent-session-id.selectors"
-import type { FormAgentSession } from "./form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "./form-agent-sessions.models"
 
 const selectFormAgentSessionsData = (state: RootState) => state.formAgentSessions.data
+const selectFormSubSessionsData = (state: RootState) => state.formAgentSessions.subSessions
 
 const missingAgentId = { status: ADS.Error, value: null, error: "No Agent selected" }
 const missingAgentSessions = {
@@ -33,6 +34,21 @@ export const selectCurrentFormAgentSessionsDataFromAgentId = (agentId?: string |
     if (!agentSessions) return missingAgentSessions
 
     return agentSessions
+  })
+
+const EMPTY_SUB_SESSIONS: FormSubSession[] = []
+
+/**
+ * Returns the form sub-sessions delegated by the given parent agent session.
+ * Resolves to an empty array until the fetch is fulfilled, so consumers can map
+ * over it unconditionally.
+ */
+export const selectFormSubSessionsBySessionId = (sessionId?: string | null) =>
+  createSelector([selectFormSubSessionsData], (subSessions): FormSubSession[] => {
+    if (!sessionId) return EMPTY_SUB_SESSIONS
+    const entry = subSessions?.[sessionId]
+    if (!entry || !ADS.isFulfilled(entry)) return EMPTY_SUB_SESSIONS
+    return entry.value
   })
 
 export const selectCurrentFormAgentSessionData = createSelector(

--- a/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.slice.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.slice.ts
@@ -3,16 +3,20 @@ import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data
 import type { Agent } from "../../agents.models"
 import { listAgents } from "../../agents.thunks"
 import { createAgentChatSession } from "../shared/base-agent-session/base-agent-sessions.thunks"
-import type { FormAgentSession } from "./form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "./form-agent-sessions.models"
 import { formAgentSessionsThunks } from "./form-agent-sessions.thunks"
 
 type DataType = Record<Agent["id"], AsyncData<FormAgentSession[]>> // keyed by agentId
+// Form sub-sessions delegated by a parent agent session, keyed by parent session id.
+type SubSessionsType = Record<string, AsyncData<FormSubSession[]>>
 type State = {
   data: DataType
+  subSessions: SubSessionsType
 }
 
 const initialState: State = {
   data: {},
+  subSessions: {},
 }
 
 const slice = createSlice({
@@ -67,6 +71,30 @@ const slice = createSlice({
           status: ADS.Error,
           value: null,
           error: action.error.message || "Failed to load form sessions",
+        }
+      })
+
+    builder
+      .addCase(formAgentSessionsThunks.listSubSessions.pending, (state, action) => {
+        const { agentSessionId } = action.meta.arg
+        const current = state.subSessions[agentSessionId]
+        if (current && ADS.isFulfilled(current)) return
+        state.subSessions[agentSessionId] = { status: ADS.Loading, value: null, error: null }
+      })
+      .addCase(formAgentSessionsThunks.listSubSessions.fulfilled, (state, action) => {
+        const { agentSessionId, subSessions } = action.payload
+        state.subSessions[agentSessionId] = {
+          status: ADS.Fulfilled,
+          value: subSessions,
+          error: null,
+        }
+      })
+      .addCase(formAgentSessionsThunks.listSubSessions.rejected, (state, action) => {
+        const { agentSessionId } = action.meta.arg
+        state.subSessions[agentSessionId] = {
+          status: ADS.Error,
+          value: null,
+          error: action.error.message || "Failed to load form sub-sessions",
         }
       })
   },

--- a/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.spi.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.spi.ts
@@ -1,5 +1,5 @@
 import type { BaseAgentSessionTypeDto, SuccessResponseDTO } from "@caseai-connect/api-contracts"
-import type { FormAgentSession } from "./form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "./form-agent-sessions.models"
 
 type BaseParams = {
   organizationId: string
@@ -11,4 +11,5 @@ export interface IFormAgentSessionsSpi {
   getAll: (params: BaseParams) => Promise<FormAgentSession[]>
   createOne: (params: BaseParams) => Promise<FormAgentSession>
   deleteOne: (params: BaseParams & { agentSessionId: string }) => Promise<SuccessResponseDTO>
+  listSubSessions: (params: BaseParams & { agentSessionId: string }) => Promise<FormSubSession[]>
 }

--- a/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.thunks.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/form/form-agent-sessions.thunks.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 import { getCurrentId } from "@/common/features/helpers"
 import type { RootState, ThunkExtraArg } from "@/common/store"
 import { buildType } from "../shared/base-agent-session/base-agent-sessions.thunks"
-import type { FormAgentSession } from "./form-agent-sessions.models"
+import type { FormAgentSession, FormSubSession } from "./form-agent-sessions.models"
 
 type ThunkConfig = { state: RootState; extra: ThunkExtraArg }
 
@@ -22,4 +22,26 @@ const getAll = createAsyncThunk<FormAgentSession[], { agentId: string }, ThunkCo
   },
 )
 
-export const formAgentSessionsThunks = { getAll }
+const listSubSessions = createAsyncThunk<
+  { agentSessionId: string; subSessions: FormSubSession[] },
+  { agentId: string; agentSessionId: string },
+  ThunkConfig
+>(
+  "formAgentSessions/listSubSessions",
+  async ({ agentId, agentSessionId }, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+
+    const subSessions = await services.formAgentSessions.listSubSessions({
+      organizationId,
+      projectId,
+      agentId,
+      agentSessionId,
+      type: buildType(),
+    })
+    return { agentSessionId, subSessions }
+  },
+)
+
+export const formAgentSessionsThunks = { getAll, listSubSessions }

--- a/apps/web/src/common/features/agents/agent-sessions/form/locales/form-agent-session.en.json
+++ b/apps/web/src/common/features/agents/agent-sessions/form/locales/form-agent-session.en.json
@@ -18,6 +18,11 @@
     "chat": {
       "title": "Playground",
       "placeholder": "Ask your question..."
+    },
+    "subAgentResults": {
+      "view": "Form result",
+      "title": "Sub-agent form results",
+      "description": "Results collected by the form sub-agents this agent delegated to."
     }
   }
 }

--- a/apps/web/src/common/features/agents/agent-sessions/form/locales/form-agent-session.fr.json
+++ b/apps/web/src/common/features/agents/agent-sessions/form/locales/form-agent-session.fr.json
@@ -18,6 +18,11 @@
     "chat": {
       "title": "Playground",
       "placeholder": "Posez votre question..."
+    },
+    "subAgentResults": {
+      "view": "Résultat du formulaire",
+      "title": "Résultats des sous-agents de formulaire",
+      "description": "Résultats collectés par les sous-agents de formulaire auxquels cet agent a délégué."
     }
   }
 }

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
@@ -10,11 +10,15 @@ import type { AgentSessionMessage as AgentSessionMessageType } from "@/common/fe
 import { useCopyToClipboard } from "@/common/hooks/use-copy-to-clipboard"
 import { Attachment } from "./Attachment"
 import { ChatBotMessage, ChatUserMessage } from "./Chat"
+import { useFormSubSessions } from "./form-sub-sessions-context"
 import { MarkdownWrapper } from "./MarkdownWrapper"
 import { SourcesTool } from "./SourcesTool"
+import { SubAgentFormResultSheet } from "./SubAgentFormResultSheet"
 import { SurfaceResourcesTool } from "./SurfaceResourcesTool"
 
 export function AgentSessionMessage({ message }: { message: AgentSessionMessageType }) {
+  const formSubSessions = useFormSubSessions()
+
   switch (message.role) {
     case "assistant": {
       const isStreaming = message.status === "streaming"
@@ -24,6 +28,15 @@ export function AgentSessionMessage({ message }: { message: AgentSessionMessageT
       const surfaceResourcesTool = message.toolCalls?.find(
         (call) => call.name === ToolName.SurfaceResources,
       )
+      // Tool names this message delegated to that resolved to a form sub-session,
+      // deduplicated so a sub-agent invoked twice shows a single affordance.
+      const delegatedToolNames = [
+        ...new Set(
+          (message.toolCalls ?? [])
+            .map((call) => call.name)
+            .filter((name) => formSubSessions.some((subSession) => subSession.toolName === name)),
+        ),
+      ]
       return (
         <div key={message.id} className="max-w-3/4 relative">
           <ChatBotMessage>
@@ -52,6 +65,14 @@ export function AgentSessionMessage({ message }: { message: AgentSessionMessageT
                 <RestrictedFeature feature="sources-tool">
                   {sourcesTool && <SourcesTool toolCall={sourcesTool} />}
                 </RestrictedFeature>
+
+                {delegatedToolNames.map((toolName) => (
+                  <SubAgentFormResultSheet
+                    key={toolName}
+                    subSessions={formSubSessions}
+                    defaultToolName={toolName}
+                  />
+                ))}
               </div>
             )}
           </ChatBotMessage>

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessages.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessages.tsx
@@ -9,7 +9,10 @@ import { ChevronDownIcon, FileCheckIcon, XIcon } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { ConversationAgentSession } from "@/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.models"
-import type { FormAgentSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
+import type {
+  FormAgentSession,
+  FormSubSession,
+} from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
 import type { AgentSessionMessage as AgentSessionMessageType } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models"
 import { AgentSessionMessage } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage"
 import {
@@ -21,6 +24,7 @@ import {
   ChatSubmit,
 } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/Chat"
 import { Dictaphone } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/Dictaphone"
+import { FormSubSessionsProvider } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/form-sub-sessions-context"
 import { useScrollToEnd } from "@/common/hooks/use-scroll-to-end"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import { AttachDocument } from "@/studio/features/documents/components/AttachDocument"
@@ -34,11 +38,13 @@ export function AgentSessionMessages({
   messages,
   rightSlot,
   onFillFormToolEvent,
+  formSubSessions = [],
 }: {
   rightSlot?: React.ReactNode
   session: AgentSession
   messages: AgentSessionMessageType[]
   onFillFormToolEvent?: () => void
+  formSubSessions?: FormSubSession[]
 }) {
   const isStreaming = useAppSelector(selectStreaming)
   const { t } = useTranslation()
@@ -71,7 +77,9 @@ export function AgentSessionMessages({
       )}
       <div className="flex flex-1 p-2 sm:p-4 min-h-0 md:min-h-full">
         <Chat className="border shadow-none">
-          <Messages messages={messages} isStreaming={isStreaming} />
+          <FormSubSessionsProvider value={formSubSessions}>
+            <Messages messages={messages} isStreaming={isStreaming} />
+          </FormSubSessionsProvider>
 
           <Footer
             session={session}

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/SubAgentFormResultSheet.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/SubAgentFormResultSheet.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@caseai-connect/ui/shad/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@caseai-connect/ui/shad/sheet"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@caseai-connect/ui/shad/tabs"
+import { ClipboardListIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { FormResultFields } from "@/common/features/agents/agent-sessions/form/components/FormResultFields"
+import type { FormSubSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
+
+/**
+ * Opens a sheet showing the form result of every form sub-agent the parent
+ * session delegated to, one tab per sub-agent. Triggered from a delegation tool
+ * call; the clicked sub-agent's tab is selected by default.
+ */
+export function SubAgentFormResultSheet({
+  subSessions,
+  defaultToolName,
+}: {
+  subSessions: FormSubSession[]
+  defaultToolName: string
+}) {
+  const { t } = useTranslation()
+
+  if (subSessions.length === 0) return null
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="sm" className="text-muted-foreground text-xs">
+          <ClipboardListIcon className="size-3.5" />
+          {t("formAgentSession:subAgentResults.view")}
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{t("formAgentSession:subAgentResults.title")}</SheetTitle>
+          <SheetDescription>{t("formAgentSession:subAgentResults.description")}</SheetDescription>
+        </SheetHeader>
+        <div className="px-4 pb-4">
+          <Tabs defaultValue={defaultToolName}>
+            <TabsList className="flex h-auto w-full flex-wrap justify-start">
+              {subSessions.map((subSession) => (
+                <TabsTrigger key={subSession.toolName} value={subSession.toolName}>
+                  {subSession.agentName}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {subSessions.map((subSession) => (
+              <TabsContent key={subSession.toolName} value={subSession.toolName}>
+                <FormResultFields
+                  outputJsonSchema={subSession.outputJsonSchema}
+                  result={subSession.session.result}
+                />
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/form-sub-sessions-context.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/form-sub-sessions-context.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react"
+import type { FormSubSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
+
+/**
+ * Carries the form sub-sessions delegated by the current parent agent session
+ * down to the individual tool-call renderers. Defaults to an empty list, so
+ * interfaces that don't load sub-sessions (everything outside the Studio) simply
+ * render no sub-agent result affordance.
+ */
+const FormSubSessionsContext = createContext<FormSubSession[]>([])
+
+export const FormSubSessionsProvider = FormSubSessionsContext.Provider
+
+export function useFormSubSessions() {
+  return useContext(FormSubSessionsContext)
+}

--- a/apps/web/src/stories/routes/studio/agent/AgentSessionRoute.stories.tsx
+++ b/apps/web/src/stories/routes/studio/agent/AgentSessionRoute.stories.tsx
@@ -5,6 +5,7 @@ import {
   agentSessionMessageFactory,
   conversationAgentSessionFactory,
   formAgentSessionFactory,
+  formSubSessionFactory,
 } from "@/common/features/agents/agent-sessions/agent-session.factory"
 import type { Agent } from "@/common/features/agents/agents.models"
 import { buildDecorator, render } from "@/stories/decorators"
@@ -23,6 +24,7 @@ type AgentType = Extract<Agent["type"], "conversation" | "form">
 type StoryArgs = StudioStoryArgs & {
   agentType: AgentType
   withMessages?: boolean
+  withSubAgentForms?: boolean
 }
 
 const meta = {
@@ -36,12 +38,14 @@ const meta = {
       options: ["conversation", "form"] satisfies AgentType[],
     },
     withMessages: { control: "boolean" },
+    withSubAgentForms: { control: "boolean" },
   },
   args: {
     ...studioStoryArgs,
     withAgents: true,
     agentType: "conversation",
     withMessages: true,
+    withSubAgentForms: false,
   },
   render: render({ routes: studioRoutes, path: StudioRoutes.agentSession.path }),
 } satisfies Meta<StoryArgs>
@@ -51,7 +55,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   decorators: [
-    buildDecorator<StoryArgs>(({ agentType, withMessages, ...args }) => {
+    buildDecorator<StoryArgs>(({ agentType, withMessages, withSubAgentForms, ...args }) => {
       const { baseSeeds, project, agents } = buildStudioData(args)
       const [firstAgent, ...restAgents] = agents
 
@@ -96,10 +100,58 @@ export const Default: Story = {
           : null
       const currentSessionId = (conversationSession ?? formSession)?.id ?? null
 
+      // Form sub-agents the parent conversation delegated to during this session.
+      const showSubAgentForms = withSubAgentForms && agentType === "conversation"
+      const subSessions = showSubAgentForms
+        ? [
+            formSubSessionFactory
+              .transient({
+                session: formAgentSessionFactory.build({
+                  type: "playground",
+                  result: { fullName: faker.person.fullName(), email: faker.internet.email() },
+                }),
+              })
+              .build({
+                toolName: "collect_contact",
+                agentName: "Contact Form",
+                outputJsonSchema: {
+                  type: "object",
+                  properties: { fullName: { type: "string" }, email: { type: "string" } },
+                },
+              }),
+            formSubSessionFactory
+              .transient({
+                session: formAgentSessionFactory.build({
+                  type: "playground",
+                  result: { company: faker.company.name(), industry: faker.commerce.department() },
+                }),
+              })
+              .build({
+                toolName: "collect_company",
+                agentName: "Company Form",
+                outputJsonSchema: {
+                  type: "object",
+                  properties: { company: { type: "string" }, industry: { type: "string" } },
+                },
+              }),
+          ]
+        : []
+
+      const assistantMessage = agentSessionMessageFactory.build({
+        role: "assistant",
+        toolCalls: showSubAgentForms
+          ? subSessions.map((subSession) => ({
+              id: faker.string.uuid(),
+              name: subSession.toolName,
+              arguments: {},
+            }))
+          : undefined,
+      })
+
       const messages = withMessages
         ? [
             agentSessionMessageFactory.build({ role: "user" }),
-            agentSessionMessageFactory.build({ role: "assistant" }),
+            assistantMessage,
             agentSessionMessageFactory.build({ role: "user" }),
             agentSessionMessageFactory.build({ role: "assistant" }),
           ]
@@ -115,6 +167,9 @@ export const Default: Story = {
           seed.formAgentSessions({
             [currentAgent.id]: formSession ? [formSession] : [],
           }),
+          currentSessionId && subSessions.length > 0
+            ? seed.formSubSessions({ [currentSessionId]: subSessions })
+            : {},
           seed.currentAgentSessionId(currentSessionId),
           seed.agentSessionMessages(messages),
         ),
@@ -125,5 +180,10 @@ export const Default: Story = {
 
 export const FormSession: Story = {
   args: { agentType: "form" },
+  decorators: Default.decorators,
+}
+
+export const WithSubAgentForms: Story = {
+  args: { agentType: "conversation", withMessages: true, withSubAgentForms: true },
   decorators: Default.decorators,
 }

--- a/apps/web/src/stories/seed.ts
+++ b/apps/web/src/stories/seed.ts
@@ -7,7 +7,10 @@ import type {
 } from "@/backoffice/features/backoffice/backoffice.models"
 import type { ConversationAgentSession } from "@/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.models"
 import type { ExtractionAgentSessions } from "@/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.models"
-import type { FormAgentSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
+import type {
+  FormAgentSession,
+  FormSubSession,
+} from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
 import type { AgentSessionMessage } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models"
 import type { Agent } from "@/common/features/agents/agents.models"
 import type { User } from "@/common/features/me/me.models"
@@ -198,6 +201,18 @@ export const seed = {
       ]),
     )
     return { formAgentSessions: { data } }
+  },
+
+  formSubSessions(
+    subSessionsByParentSessionId: Record<string, FormSubSession[]>,
+  ): StoryPreloadedState {
+    const subSessions = Object.fromEntries(
+      Object.entries(subSessionsByParentSessionId).map(([parentSessionId, subSessionList]) => [
+        parentSessionId,
+        ads.fulfilled(subSessionList),
+      ]),
+    )
+    return { formAgentSessions: { subSessions } }
   },
 
   extractionAgentSessions(

--- a/apps/web/src/studio/routes/StudioAgentSessionRoute.tsx
+++ b/apps/web/src/studio/routes/StudioAgentSessionRoute.tsx
@@ -1,15 +1,18 @@
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { GridHeader } from "@/common/components/grid/Grid"
 import type { ConversationAgentSession } from "@/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.models"
 import { FormResult } from "@/common/features/agents/agent-sessions/form/components/FormResult"
 import type { FormAgentSession } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.models"
+import { selectFormSubSessionsBySessionId } from "@/common/features/agents/agent-sessions/form/form-agent-sessions.selectors"
 import { selectCurrentMessagesData } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.selectors"
 import { AgentSessionMessages } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessages"
 import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
 import { getAgentIcon } from "@/common/features/agents/components/AgentIcon"
 import { useGetAgentRoute } from "@/common/hooks/use-get-path"
 import { useValue } from "@/common/hooks/use-value"
+import { useAppSelector } from "@/common/store/hooks"
 import { buildSince } from "@/common/utils/build-date"
 import { AgentSessionActions } from "../features/agents/components/AgentSessionActions"
 
@@ -17,6 +20,11 @@ type AgentSession = ConversationAgentSession | FormAgentSession
 export function StudioAgentSessionRoute({ agentSession }: { agentSession: AgentSession }) {
   const agent = useValue(selectCurrentAgentData)
   const messages = useValue(selectCurrentMessagesData)
+  const selectSubSessions = useMemo(
+    () => selectFormSubSessionsBySessionId(agentSession.id),
+    [agentSession.id],
+  )
+  const formSubSessions = useAppSelector(selectSubSessions)
 
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -47,6 +55,7 @@ export function StudioAgentSessionRoute({ agentSession }: { agentSession: AgentS
         <AgentSessionMessages
           session={agentSession}
           messages={messages}
+          formSubSessions={formSubSessions}
           rightSlot={
             agent.type === "form" ? (
               <FormResult agent={agent} agentSession={agentSession} />

--- a/packages/api-contracts/src/agents/form-agent-sessions/form-agent-sessions.dto.ts
+++ b/packages/api-contracts/src/agents/form-agent-sessions/form-agent-sessions.dto.ts
@@ -10,3 +10,17 @@ export type FormAgentSessionDto = {
   type: BaseAgentSessionTypeDto
   updatedAt: TimeType
 }
+
+/**
+ * A form sub-session spawned when a parent (conversation) agent delegates to a
+ * form sub-agent during a session. Carries the child form agent's identity and
+ * output schema alongside the accumulated session result so the parent session
+ * view can render the sub-agent's form result without extra lookups.
+ */
+export type FormSubSessionDto = {
+  toolName: string
+  agentId: string
+  agentName: string
+  outputJsonSchema?: Record<string, unknown>
+  session: FormAgentSessionDto
+}

--- a/packages/api-contracts/src/agents/form-agent-sessions/form-agent-sessions.routes.ts
+++ b/packages/api-contracts/src/agents/form-agent-sessions/form-agent-sessions.routes.ts
@@ -1,7 +1,7 @@
 import type { BaseAgentSessionTypeDto } from "../../agents/conversation-agent-sessions/conversation-agent-sessions.dto"
 import type { RequestPayload, ResponseData, SuccessResponseDTO } from "../../generic"
 import { defineRoute } from "../../helpers"
-import type { FormAgentSessionDto } from "./form-agent-sessions.dto"
+import type { FormAgentSessionDto, FormSubSessionDto } from "./form-agent-sessions.dto"
 
 type Request = RequestPayload<{ type: BaseAgentSessionTypeDto }>
 
@@ -17,5 +17,11 @@ export const FormAgentSessionsRoutes = {
   deleteOne: defineRoute<ResponseData<SuccessResponseDTO>, Request>({
     method: "post",
     path: "/organizations/:organizationId/projects/:projectId/agents/:agentId/form-agent-sessions/:agentSessionId/delete",
+  }),
+  // Lists the form sub-sessions spawned by a parent agent session. `:agentId` is
+  // the parent (conversation) agent and `:agentSessionId` is the parent session.
+  listSubSessions: defineRoute<ResponseData<FormSubSessionDto[]>, Request>({
+    method: "post",
+    path: "/organizations/:organizationId/projects/:projectId/agents/:agentId/agent-sessions/:agentSessionId/form-sub-sessions",
   }),
 }


### PR DESCRIPTION
## Summary
- Adds a `listSubSessions` endpoint that lists the form sub-sessions spawned by a parent (conversation) agent session
- Surfaces the form results produced by delegated form sub-agents in the Studio conversation session view, opened in a side sheet from the relevant message
- Debounces the streaming refresh of sub-sessions so it fires once the assistant stream settles rather than on every chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)