### PR TITLE
feat: link sub-agent langfuse traces to parent session and tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Studio conversation session view surfaces the form results produced by delegated form sub-agents, opened in a side sheet from the relevant message
 
 ### Changed
+- Sub-agent Langfuse traces are grouped under the parent run's session, and the parent's tool-call event carries a direct link to the sub-agent trace
 
 ### Fixed
 

--- a/apps/api/src/common/interfaces/llm-provider.interface.ts
+++ b/apps/api/src/common/interfaces/llm-provider.interface.ts
@@ -48,6 +48,12 @@ export type LLMMetadata = (
   agentId: string
   projectId: string
   tags: string[]
+  /**
+   * Overrides the langfuse session id (which otherwise derives from
+   * `agentSessionId`). Sub-agents set this to the parent session id so their
+   * dedicated traces group under the same langfuse session as the parent run.
+   */
+  langfuseSessionId?: string
 }
 
 export interface LLMProvider {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.spec.ts
@@ -140,7 +140,9 @@ describe("buildSubAgentTools", () => {
     }
     const findOrCreateSubSession = jest.fn().mockResolvedValue(subSession)
     let capturedMessages: { role: string; content: string }[] = []
-    let capturedMetadata: { traceId: string; agentSessionId: string; tags: string[] } | undefined
+    let capturedMetadata:
+      | { traceId: string; agentSessionId: string; langfuseSessionId?: string; tags: string[] }
+      | undefined
 
     const { tools } = await buildSubAgentTools({
       agentSessionScope: {
@@ -205,9 +207,11 @@ describe("buildSubAgentTools", () => {
     expect(capturedMessages[0]?.content).toContain("fillForm")
     expect(result.answer).toBe("form answer")
     // The form sub-agent gets its own dedicated trace (the sub-session's), linked
-    // back to the parent trace via a tag.
+    // back to the parent trace via a tag, but is grouped under the parent's
+    // langfuse session so they share one session timeline.
     expect(capturedMetadata?.traceId).toBe("sub-trace-id")
     expect(capturedMetadata?.agentSessionId).toBe("sub-session-id")
+    expect(capturedMetadata?.langfuseSessionId).toBe("parent-session-id")
     expect(capturedMetadata?.tags).toContain("parent-trace:parent-trace-id")
     expect(capturedMetadata?.tags).toContain("sub-agent")
   })
@@ -240,7 +244,9 @@ describe("buildSubAgentTools", () => {
     }
     const findOrCreateSubSession = jest.fn().mockResolvedValue(subSession)
     let capturedMessages: { role: string; content: string }[] = []
-    let capturedMetadata: { traceId: string; agentSessionId: string; tags: string[] } | undefined
+    let capturedMetadata:
+      | { traceId: string; agentSessionId: string; langfuseSessionId?: string; tags: string[] }
+      | undefined
 
     const { tools } = await buildSubAgentTools({
       agentSessionScope: {
@@ -302,9 +308,11 @@ describe("buildSubAgentTools", () => {
     expect(capturedMessages[0]?.content).toContain("How much is the pro plan?")
     expect(result.answer).toBe("pricing answer")
     // The conversation sub-agent gets its own dedicated trace (the sub-session's),
-    // linked back to the parent trace via a tag.
+    // linked back to the parent trace via a tag, but is grouped under the parent's
+    // langfuse session so they share one session timeline.
     expect(capturedMetadata?.traceId).toBe("sub-trace-id")
     expect(capturedMetadata?.agentSessionId).toBe("sub-session-id")
+    expect(capturedMetadata?.langfuseSessionId).toBe("parent-session-id")
     expect(capturedMetadata?.tags).toContain("parent-trace:parent-trace-id")
     expect(capturedMetadata?.tags).toContain("sub-agent")
   })

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/sub-agent-tools.ts
@@ -182,6 +182,15 @@ async function runSubAgentTool({
   // trace); any other sub-agent gets a fresh trace id per invocation.
   const subAgentTraceId = childSession.traceId
 
+  // Surface a direct link to the sub-agent's own langfuse trace on the parent's
+  // tool-call event. The AI SDK runs this tool inside an `ai.toolCall` span (the
+  // span the langfuse exporter turns into the `ai.toolCall …` event); any
+  // `ai.telemetry.metadata.*` attribute set on it is copied into that event's
+  // metadata, giving a copyable pointer from the parent trace to the child's.
+  trace
+    .getActiveSpan()
+    ?.setAttribute("ai.telemetry.metadata.subAgentTraceUrl", getTraceUrl(subAgentTraceId))
+
   const { tools, mcpClose, toolDescriptions } = await buildTools({
     agentSessionScope: childScope,
     includeSessionMetadataTools: false,
@@ -358,10 +367,13 @@ function buildSubAgentMetadata({
   // The sub-agent runs inside a fresh OTEL root span (see runSubAgentTool), so its
   // spans get their own OTEL trace id and the exporter writes them under this
   // dedicated langfuse trace id rather than collapsing into the parent's trace.
-  // A `parent-trace:` tag links back to the parent run for navigation.
+  // It is grouped under the parent's langfuse session (`langfuseSessionId`) so the
+  // parent and all its sub-agent traces share one session timeline, and a
+  // `parent-trace:` tag links back to the parent run for navigation.
   return {
     traceId: subAgentTraceId,
     agentSessionId: childSession.id,
+    langfuseSessionId: session.id,
     agentId: childAgent.id,
     projectId: childAgent.projectId,
     organizationId: session?.organizationId ?? connectScope.organizationId,

--- a/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
+++ b/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
@@ -531,7 +531,7 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
   }): Record<string, string | number | string[]> {
     return removeNullish({
       langfuseTraceId: metadata.traceId,
-      sessionId: `as:${metadata.agentSessionId}`,
+      sessionId: `as:${metadata.langfuseSessionId ?? metadata.agentSessionId}`,
       userId: `o:${metadata.organizationId} / p:${metadata.projectId}`,
       tags: [...this.getTags(config), ...(metadata?.tags || [])],
       currentTurn: metadata.currentTurn,


### PR DESCRIPTION
## Summary

Makes sub-agent Langfuse traces discoverable from the parent agent's trace.

- **Shared session** — each sub-agent's dedicated trace is now grouped under the parent run's Langfuse session. Added an optional `langfuseSessionId` override to `LLMMetadata` (defaults to `agentSessionId`); `buildMetadata` prefers it, and `buildSubAgentMetadata` sets it to the parent session id. Parent + all sub-agent traces share one session timeline.
- **Direct link** — `runSubAgentTool` sets `ai.telemetry.metadata.subAgentTraceUrl` on the active `ai.toolCall` span. The Langfuse exporter already copies `ai.telemetry.metadata.*` attributes into the tool-call event's metadata, so the parent's tool-call event now carries a copyable pointer to the sub-agent trace. No exporter change needed.

The existing `parent-trace:` tag on the sub-agent trace is unchanged.

## Notes

On the v2 OSS Langfuse UI the `subAgentTraceUrl` renders in the event metadata JSON (copy-pasteable rather than a one-click hyperlink). The shared session also lets you hop between parent and sub-agent traces from the Session view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)