### PR TITLE
fix: stabilize agent prompt prefix for vertex implicit caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Agent system prompts place the current date at the end instead of the start, so the stable instructions form a byte-identical prefix that Vertex implicit context caching can reuse across runs (including sub-agent runs invoked via a parent agent)
 
 ### Security
 

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-processor.service.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-processor.service.ts
@@ -335,7 +335,7 @@ export class AgentCsvExtractionRunProcessorService extends ServiceWithLLM {
       content: [{ type: "text", text: inputText }],
     }
 
-    const systemPrompt = `Today's date: ${new Date().toLocaleDateString()}\n\n${agent.defaultPrompt}`
+    const systemPrompt = `${agent.defaultPrompt}\n\nToday's date: ${new Date().toLocaleDateString()}`
 
     const llmConfig = this.buildLLMConfig({
       systemPrompt,

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
@@ -10,9 +10,11 @@ export function buildConversationAgentPrompt({
   toolDescriptions?: Record<string, string>
   toolNames: string[]
 }): string {
-  return `${promptHelpers.now()}
-
-## Identity
+  // Keep the volatile timestamp at the very END so the stable content above
+  // forms a byte-stable prefix that Vertex/Gemini implicit caching can reuse
+  // across runs. Putting the daily-changing date first would invalidate the
+  // whole cached prefix on every date rollover.
+  return `## Identity
 You are **${agent.name}**, a conversational AI assistant.
 
 ${agent.defaultPrompt}
@@ -21,5 +23,7 @@ ${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
 
 ${promptHelpers.tools(toolNames, toolDescriptions)}
 
-${promptHelpers.language(agent.locale)}`
+${promptHelpers.language(agent.locale)}
+
+${promptHelpers.now()}`
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
@@ -10,9 +10,11 @@ export function buildFormAgentPrompt({
   toolDescriptions?: Record<string, string>
   toolNames: string[]
 }): string {
-  return `${promptHelpers.now()}
-
-# Instructions:
+  // Keep the volatile timestamp at the very END so the stable content above
+  // forms a byte-stable prefix that Vertex/Gemini implicit caching can reuse
+  // across runs. Putting the daily-changing date first would invalidate the
+  // whole cached prefix on every date rollover.
+  return `# Instructions:
 ${agent.defaultPrompt}
 
 Here are the form fields to fill:
@@ -26,5 +28,7 @@ ${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
 
 ${promptHelpers.tools(toolNames, toolDescriptions)}
 
-${promptHelpers.language(agent.locale)}`
+${promptHelpers.language(agent.locale)}
+
+${promptHelpers.now()}`
 }

--- a/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-run-processor.service.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-run-processor.service.ts
@@ -395,7 +395,7 @@ export class EvaluationExtractionRunProcessorService extends ServiceWithLLM {
       content: [{ type: "text", text: inputText }],
     }
 
-    const systemPrompt = `Today's date: ${new Date().toLocaleDateString()}\n\n${agent.defaultPrompt}`
+    const systemPrompt = `${agent.defaultPrompt}\n\nToday's date: ${new Date().toLocaleDateString()}`
 
     const llmConfig = this.buildLLMConfig({
       systemPrompt,

--- a/apps/api/src/domains/evaluations/reports/evaluation-reports.service.ts
+++ b/apps/api/src/domains/evaluations/reports/evaluation-reports.service.ts
@@ -219,15 +219,13 @@ return only the rating value (0 to 100), no sentence`,
   }
 
   private generateMasterPrompt(agent: Agent): string {
-    return `
-Today's date: ${new Date().toLocaleDateString()}
-
-${agent.defaultPrompt}
+    return `${agent.defaultPrompt}
 
 # Attachment:
 If there is a file (image or pdf) attached to the user's chat message, answer the user's question or instruction reading the content of the file.
 
 Always answer in ${agent.locale}.
-  `.trim()
+
+Today's date: ${new Date().toLocaleDateString()}`
   }
 }


### PR DESCRIPTION
## Problem

`cachedContentTokenCount` was missing from Vertex `usageMetadata` for sub-agent runs invoked via a parent agent, while direct calls reported it.

Vertex/Gemini implicit context caching keys on the **longest common prefix** of recent requests. The system prompt is that prefix (it's sent first). Both master-prompt builders placed the daily-changing `Today's date: …` line at **byte 0**, so every date rollover invalidated the entire cached prefix — and it's the worst possible position for prefix matching. The date was the only per-run volatile element in an otherwise stable prompt.

## Fix

Move the current-date line to the **end** of the system prompt. The large, stable block (identity → instructions → tools → language) becomes the byte-identical cacheable prefix shared across runs; the daily date now only changes a tiny suffix that was never part of the cached prefix.

Applied consistently to:
- conversation + form master prompts (`master-promts/`)
- evaluation report, evaluation extraction, and CSV extraction prompt builders

Also cleaned up accidental per-line indentation introduced in the evaluation-reports prompt template.

## Caveats

- Implicit caching only triggers above the provider token floor (~1024 Flash / ~2048 Pro); short sub-agent prompts won't cache regardless.
- Capturing the cached count in telemetry/Langfuse (currently dropped in `parseUsageDetails`) is a separate follow-up.