### PR TITLE
fix: report cached prompt tokens to Langfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Langfuse generations report cached prompt tokens (Vertex/Gemini `cachedContentTokenCount`), so context-cache hits and savings are visible instead of being dropped
 
 ### Security
 

--- a/apps/api/src/external/langfuse/langfuse-integration-exporter.ts
+++ b/apps/api/src/external/langfuse/langfuse-integration-exporter.ts
@@ -339,6 +339,17 @@ export class LangfuseIntegrationExporter implements SpanExporter {
         "ai.usage.tokens" in attributes
           ? parseInt(attributes["ai.usage.tokens"]?.toString() ?? "0", 10)
           : undefined,
+      // Cached prompt tokens (Vertex/Gemini `cachedContentTokenCount`, mapped by
+      // the AI SDK to `usage.cachedInputTokens`). These are already counted in
+      // `input`; surfacing them separately lets Langfuse show cache hits/savings.
+      ...("ai.usage.cachedInputTokens" in attributes
+        ? {
+            cache_read_input_tokens: parseInt(
+              attributes["ai.usage.cachedInputTokens"]?.toString() ?? "0",
+              10,
+            ),
+          }
+        : {}),
     }
   }
 


### PR DESCRIPTION
## Problem

Even when Vertex/Gemini returns `cachedContentTokenCount` (a context-cache hit), the value never reached Langfuse. The exporter's `parseUsageDetails` read only `input` / `output` / `total` token attributes and silently dropped the cached count, so cache hits and the resulting cost savings were invisible in dashboards.

## Fix

The AI SDK maps `cachedContentTokenCount` → `usage.cachedInputTokens` and emits it on the telemetry span as `ai.usage.cachedInputTokens` (confirmed in `@ai-sdk/google`, which Vertex reuses). The exporter now reads that attribute and surfaces it as a `cache_read_input_tokens` usage detail.

These tokens are already included in `input`; the new field is additive/informational and lets Langfuse display cache hits and savings.

## Notes

- Complements #484 (stable prompt prefix), which makes the cache actually *hit*; this PR makes those hits *visible*.
- No-op for providers/calls that don't report cached tokens (the field is only added when the attribute is present).