### PR TITLE
fix: list sub-agents returns empty for non-conversation parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Sub-agent Langfuse traces are grouped under the parent run's session, and the parent's tool-call event carries a direct link to the sub-agent trace
 
 ### Fixed
+- Listing sub-agents for a non-conversation parent agent returns an empty list instead of failing with an error
 
 ### Security
 

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.spec.ts
@@ -263,4 +263,20 @@ describe("AgentSubAgentsService", () => {
       }),
     ).rejects.toThrow("Only conversation agents can have sub-agents")
   })
+
+  it("returns an empty list for non-conversation parent agents instead of throwing", async () => {
+    const { organization, project, agent } = await createOrganizationWithAgent(repositories, {
+      agent: {
+        type: "form",
+        outputJsonSchema: { type: "object", properties: {} },
+      },
+    })
+
+    const listed = await service.listSubAgents({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      parentAgent: agent,
+    })
+
+    expect(listed).toEqual([])
+  })
 })

--- a/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
+++ b/apps/api/src/domains/agents/sub-agents/agent-sub-agents.service.ts
@@ -24,7 +24,13 @@ export class AgentSubAgentsService {
     connectScope: RequiredConnectScope
     parentAgent: Agent
   }): Promise<AgentSubAgent[]> {
-    this.validateParentAgent({ connectScope, parentAgent })
+    this.validateParentScope({ connectScope, parentAgent })
+
+    // Non-conversation agents can never have sub-agents; reading their (empty)
+    // list is a no-op rather than an error.
+    if (parentAgent.type !== "conversation") {
+      return []
+    }
 
     return this.agentSubAgentRepository.find({
       where: { parentAgentId: parentAgent.id },
@@ -47,7 +53,8 @@ export class AgentSubAgentsService {
     parentAgent: Agent
     subAgents: ReplaceAgentSubAgentDto[]
   }): Promise<AgentSubAgent[]> {
-    this.validateParentAgent({ connectScope, parentAgent })
+    this.validateParentScope({ connectScope, parentAgent })
+    this.validateParentIsConversation(parentAgent)
     this.validateReplacementInput({ parentAgent, subAgents })
 
     const childAgents = await this.resolveChildAgents({
@@ -82,7 +89,7 @@ export class AgentSubAgentsService {
     return savedRows
   }
 
-  private validateParentAgent({
+  private validateParentScope({
     connectScope,
     parentAgent,
   }: {
@@ -95,7 +102,9 @@ export class AgentSubAgentsService {
     ) {
       throw new UnprocessableEntityException("Parent agent must belong to the current project")
     }
+  }
 
+  private validateParentIsConversation(parentAgent: Agent) {
     if (parentAgent.type !== "conversation") {
       throw new UnprocessableEntityException("Only conversation agents can have sub-agents")
     }


### PR DESCRIPTION
## Summary

`listSubAgents` previously threw an `UnprocessableEntityException` ("Only conversation agents can have sub-agents") when called for a non-conversation parent agent. Since such agents can never have sub-agents, reading their (empty) list should be a no-op rather than an error.

This splits the parent validation:
- `validateParentScope` checks the parent belongs to the current project (shared by both read and write paths).
- `validateParentIsConversation` enforces the conversation-only rule, applied only on the write path (`replaceSubAgents`).

`listSubAgents` now validates scope and returns `[]` for non-conversation parents; `replaceSubAgents` still rejects them.

## Changes
- `agent-sub-agents.service.ts`: split validation, early-return empty list on read for non-conversation parents
- `agent-sub-agents.service.spec.ts`: add coverage for the empty-list behavior
- `CHANGELOG.md`: Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)