### PR TITLE
fix: drop hardcoded identity header from conversation agent prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Studio conversation session view surfaces the form results produced by delegated form sub-agents, opened in a side sheet from the relevant message
 
 ### Changed
+- Conversation agent system prompts use the agent's configured prompt directly, without prepending a hardcoded identity header
 - Sub-agent Langfuse traces are grouped under the parent run's session, and the parent's tool-call event carries a direct link to the sub-agent trace
 
 ### Fixed

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
@@ -14,10 +14,7 @@ export function buildConversationAgentPrompt({
   // forms a byte-stable prefix that Vertex/Gemini implicit caching can reuse
   // across runs. Putting the daily-changing date first would invalidate the
   // whole cached prefix on every date rollover.
-  return `## Identity
-You are **${agent.name}**, a conversational AI assistant.
-
-${agent.defaultPrompt}
+  return `${agent.defaultPrompt}
 
 ${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
 


### PR DESCRIPTION
## Summary
The conversation agent system prompt previously prepended a hardcoded `## Identity\nYou are **${agent.name}**, a conversational AI assistant.` block before the agent's configured prompt. This change removes that header so the agent's `defaultPrompt` is used directly as the system prompt.

This keeps the prompt fully controlled by the agent's own configuration and avoids injecting a fixed identity that may conflict with the configured persona.

## Changes
- Remove the hardcoded identity header from `buildConversationAgentPrompt`
- Changelog entry under Unreleased / Changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)