### PR TITLE
feat: improve form agent prompt and fillForm tool instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 - Conversation agent system prompts use the agent's configured prompt directly, without prepending a hardcoded identity header
 - Sub-agent Langfuse traces are grouped under the parent run's session, and the parent's tool-call event carries a direct link to the sub-agent trace
+- Form agent prompt instructs the agent to ask one question at a time, extract multiple field values from a single answer, and update fields when the user revises a previous answer
+- `fillForm` tool instructions explain that the agent can pass `getFormState: true` (including alongside partial field updates) to retrieve the current form state, and should only send fields that are new or have changed
 
 ### Fixed
 - Langfuse generations report cached prompt tokens (Vertex/Gemini `cachedContentTokenCount`), so context-cache hits and savings are visible instead of being dropped

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
@@ -18,7 +18,7 @@ export function buildConversationAgentPrompt({
 
 ${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
 
-${promptHelpers.tools(toolNames, toolDescriptions)}
+${promptHelpers.tools({ names: toolNames, descriptions: toolDescriptions, agent })}
 
 ${promptHelpers.language(agent.locale)}
 

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/form-agent.prompt.ts
@@ -15,18 +15,17 @@ export function buildFormAgentPrompt({
   // across runs. Putting the daily-changing date first would invalidate the
   // whole cached prefix on every date rollover.
   return `# Instructions:
+  
 ${agent.defaultPrompt}
 
-Here are the form fields to fill:
-${Object.entries(agent.outputJsonSchema?.properties ?? {})
-  .map(
-    ([key, value]) => `- ${key}: ${"description" in value ? value.description : "No description"}`,
-  )
-  .join("\n")}
+Your primary task is to help the user complete the form by asking questions.
+If a question order is provided, follow it.
+To avoid overwhelming the user, ask one question at a time. However, keep in mind that a single answer may contain values for multiple form fields — be sure to capture every details and save all of them in the form.
+From each user response, extract and fill as many fields as possible.
+Update any field whenever the user revises a previous answer.
+If a user response is unclear or doesn't map to any field, ask them to clarify or rephrase.
 
-${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
-
-${promptHelpers.tools(toolNames, toolDescriptions)}
+${promptHelpers.tools({ names: toolNames, descriptions: toolDescriptions, agent })}
 
 ${promptHelpers.language(agent.locale)}
 

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/helpers.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/helpers.ts
@@ -1,4 +1,5 @@
 import { ToolName } from "@caseai-connect/api-contracts"
+import type { Agent } from "@/domains/agents/agent.entity"
 import type { ResourceLibrary } from "@/domains/resource-libraries/resource-library.entity"
 import { buildResourceLink } from "@/domains/resource-libraries/resource-library-link.helper"
 
@@ -42,7 +43,15 @@ ${serializedLibraries}`
 Always answer in ${locale === "en" ? "English" : locale === "fr" ? "French" : "user's language"}.
       `.trim(),
 
-  tools: (names: string[], descriptions: Record<string, string> = {}) =>
+  tools: ({
+    agent,
+    names,
+    descriptions = {},
+  }: {
+    names: string[]
+    descriptions?: Record<string, string>
+    agent: Agent
+  }) =>
     names.length === 0
       ? ""
       : `## Tools:
@@ -56,7 +65,12 @@ ${names
         return `[${name}]: You MUST call the ${name} tool whenever you use information from the ${ToolName.RetrieveProjectDocumentChunks} tool to answer the user, regardless of whether the chunks come from uploaded documents (documentSourceType="project") or crawled web pages (documentSourceType="webCrawl"). Include EVERY document whose chunks you actually used — do not omit web-crawled pages. For each source, copy the documentId, documentTitle, and documentSourceType verbatim from the retrieved chunks. Do NOT cite sources inline in your text response; the ${name} tool is the only way to show sources to the user.`
 
       case ToolName.FillForm:
-        return `[${name}]: You can use the ${name} tool to fill out the form fields. Just fill out the information you have and ask the user for the missing information. You can also update previously filled information if the user changes their answer. Pass undefined for fields that are not filled yet.`
+        return `[${name}]: Use the ${name} tool to fill the form progressively. Call it with getFormState: true at any time — including alongside partial field updates — to retrieve the current form state and know which fields are already filled. Only pass fields that are new or have changed — never re-send fields already stored. Ask the user for any missing information until the form is complete. Form fields:
+${Object.entries(agent.outputJsonSchema?.properties ?? {})
+  .map(
+    ([key, value]) => `- ${key}: ${"description" in value ? value.description : "No description"}`,
+  )
+  .join("\n")}\n\n`
 
       case ToolName.RecalculateConversationSessionMetadata:
         return `[${name}]: Call this tool after answering the user so session metadata stays aligned. Return the full category set that should remain on the session (including categories still relevant from earlier turns), not only categories from the latest message.`

--- a/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.spec.ts
+++ b/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.spec.ts
@@ -31,20 +31,25 @@ describe("GemmaPromptHelper", () => {
     },
   })
   const testTools = { test: testTool } as ToolSet
-  it("appendToolsToPrompt", async () => {
+  it("appendToolsToPrompt - returns prompt unchanged when marker is absent", async () => {
     const initialPrompt = "initial prompt"
     const result = GemmaPromptHelper.appendToolsToPrompt({
       prompt: initialPrompt,
       tools: testTools,
     })
-    expect(result).toBeDefined()
-    expect(result).toContain(initialPrompt)
-    expect(result).toContain("##TOOLS")
-    expect(result).toContain("You have access to the following tools:")
-    expect(result).toContain("test: A test tool")
-    expect(result).toContain(
-      "Parameters: { stringVal: string | null; boolVal: boolean | null; intVal: number | null; numberVal: number | null }",
-    )
+    expect(result).toBe(initialPrompt)
+  })
+  it("appendToolsToPrompt - returns prompt unchanged when no tools", async () => {
+    const prompt = `some text\n## Response language:\nAlways answer in English.`
+    const result = GemmaPromptHelper.appendToolsToPrompt({ prompt, tools: {} as ToolSet })
+    expect(result).toBe(prompt)
+  })
+  it("appendToolsToPrompt - injects CRITICAL instruction before language marker", async () => {
+    const prompt = `some text\n## Response language:\nAlways answer in English.`
+    const result = GemmaPromptHelper.appendToolsToPrompt({ prompt, tools: testTools })
+    expect(result).toContain("(CRITICAL)")
+    expect(result).toContain("## Response language:\nAlways answer in")
+    expect(result.indexOf("(CRITICAL)")).toBeLessThan(result.indexOf("## Response language:"))
   })
   it("convertToolsToDocs", async () => {
     const results = GemmaPromptHelper.convertToolsToDocs(testTools)

--- a/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.ts
+++ b/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.ts
@@ -5,14 +5,16 @@ export class GemmaPromptHelper {
   static appendToolsToPrompt({ prompt, tools }: { prompt: string; tools: ToolSet }): string {
     const toolDocs = GemmaPromptHelper.convertToolsToDocs(tools)
     if (!toolDocs) return prompt
-    return `${prompt}
-
-##TOOLS
-You have access to the following tools:
-${toolDocs.join("\n")}
-
-(CRITICAL) If a parameters allows null, set the value to null when unknown. Set to null not to quoted "null"`
+    // FIXME: this is a hack to inject a critical instruction into the prompt. We should find a better way to do this.
+    const marker = "## Response language:\nAlways answer in"
+    const injection = `(CRITICAL) If a field value allows null, set the value to null when unknown. Set to null not to quoted "null"`
+    const injectedPrompt = prompt.includes(marker)
+      ? prompt.replace(marker, `${injection}\n${marker}`)
+      : prompt
+    return injectedPrompt
   }
+
+  // FIXME: not used anymore
   static convertToolsToDocs(tools: ToolSet) {
     if (!tools || Object.entries(tools).length === 0) return undefined
     return Object.entries(tools).map(


### PR DESCRIPTION
## Summary
- Form agent prompt instructs the agent to ask one question at a time, extract multiple field values from a single answer, and update fields when the user revises a previous answer
- `fillForm` tool instructions explain that `getFormState: true` can be passed (including alongside partial field updates) to retrieve the current form state, so the agent only sends fields that are new or have changed
- `GemmaPromptHelper` injects the null-field critical instruction before the language section instead of appending a tools block

🤖 Generated with [Claude Code](https://claude.com/claude-code)