### PR TITLE
feat(backoffice): redesign feature flags editor as a searchable dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 -  (beta) Gemini 3.1 Flash Lite & Gemini 3.5 Flash available for all Agents
 
 ### Changed
+- Backoffice feature flags are now managed through a searchable dialog with side-by-side Available/Enabled columns, reachable from both the projects list and the project detail page
 
 ### Fixed
 

--- a/apps/web/src/backoffice/features/backoffice/components/BackofficeTable.tsx
+++ b/apps/web/src/backoffice/features/backoffice/components/BackofficeTable.tsx
@@ -1,16 +1,32 @@
 import { type FeatureFlagKey, FeatureFlags } from "@caseai-connect/api-contracts"
-import { Badge } from "@caseai-connect/ui/shad/badge"
 import { Button } from "@caseai-connect/ui/shad/button"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@caseai-connect/ui/shad/dropdown-menu"
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@caseai-connect/ui/shad/command"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@caseai-connect/ui/shad/dialog"
 import { Input } from "@caseai-connect/ui/shad/input"
 import type { Column } from "@tanstack/react-table"
-import { ArrowUpDownIcon, PlusIcon, SearchIcon, XIcon } from "lucide-react"
-import { useMemo } from "react"
+import {
+  ArrowUpDownIcon,
+  ChevronsUpDownIcon,
+  FlagIcon,
+  MinusCircleIcon,
+  PlusCircleIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react"
+import { type ReactNode, useState } from "react"
 
 export function SearchField({
   value,
@@ -36,53 +52,162 @@ export function SearchField({
 }
 
 export function FeatureFlagCell({
+  projectName,
   enabledFlags,
   onAdd,
   onRemove,
 }: {
+  projectName: string
   enabledFlags: FeatureFlagKey[]
   onAdd: (featureFlagKey: FeatureFlagKey) => void
   onRemove: (featureFlagKey: FeatureFlagKey) => void
 }) {
-  const availableFlags = useMemo(
-    () => FeatureFlags.filter((flag) => !enabledFlags.includes(flag.key)),
-    [enabledFlags],
-  )
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+  const enabledCount = enabledFlags.length
+
+  const normalizedSearch = search.trim().toLowerCase()
+  const visibleFlags = [...FeatureFlags]
+    .filter(
+      (flag) =>
+        flag.key.toLowerCase().includes(normalizedSearch) ||
+        flag.description.toLowerCase().includes(normalizedSearch),
+    )
+    .sort((flagA, flagB) => flagA.key.localeCompare(flagB.key))
+  const availableFlags = visibleFlags.filter((flag) => !enabledFlags.includes(flag.key))
+  const selectedFlags = visibleFlags.filter((flag) => enabledFlags.includes(flag.key))
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) setSearch("")
+  }
+
+  const handleAdd = (flagKey: FeatureFlagKey) => {
+    onAdd(flagKey)
+    setSearch("")
+  }
+
+  const handleRemove = (flagKey: FeatureFlagKey) => {
+    onRemove(flagKey)
+    setSearch("")
+  }
+
   return (
-    <div className="flex flex-wrap items-center gap-2" data-no-navigate>
-      {enabledFlags.map((flagKey) => (
-        <Badge key={flagKey} variant="secondary" className="gap-1 pr-1">
-          {flagKey}
-          <button
+    <div data-no-navigate>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogTrigger asChild>
+          <Button
             type="button"
-            onClick={() => onRemove(flagKey)}
-            className="rounded-full p-0.5 hover:bg-muted-foreground/20"
-            aria-label={`Remove ${flagKey}`}
+            variant="outline"
+            size="sm"
+            className="h-8 justify-between gap-2 font-normal"
           >
-            <XIcon className="h-3 w-3" />
-          </button>
-        </Badge>
-      ))}
-      {availableFlags.length > 0 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="h-7 px-2 text-xs">
-              <PlusIcon className="mr-1 h-3 w-3" />
-              Add flag
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent onClick={(event) => event.stopPropagation()}>
-            {availableFlags.map((flag) => (
-              <DropdownMenuItem key={flag.key} onSelect={() => onAdd(flag.key)}>
+            <span className="flex items-center gap-1.5">
+              <FlagIcon className="size-3.5 text-muted-foreground" />
+              {enabledCount === 0 ? (
+                <span className="text-muted-foreground">No flags</span>
+              ) : (
+                <span>
+                  {enabledCount} {enabledCount === 1 ? "flag" : "flags"}
+                </span>
+              )}
+            </span>
+            <ChevronsUpDownIcon className="size-3.5 text-muted-foreground" />
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          className="gap-0 p-0 sm:max-w-3xl"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <DialogHeader className="p-4 pb-2">
+            <DialogTitle>
+              <span className="font-normal text-muted-foreground">{projectName} / </span>
+              Feature flags
+            </DialogTitle>
+            <DialogDescription>Enable or disable feature flags for this project.</DialogDescription>
+          </DialogHeader>
+          <Command shouldFilter={false}>
+            <div className="relative border-t">
+              <CommandInput
+                placeholder="Search flags…"
+                value={search}
+                onValueChange={setSearch}
+                className="pr-8"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  aria-label="Clear search"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+                >
+                  <XIcon className="size-4" />
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 divide-x">
+              <FlagColumn
+                heading={`Available · ${availableFlags.length}`}
+                icon={<PlusCircleIcon className="size-4 shrink-0 text-green-500 mt-1 mx-1" />}
+                flags={availableFlags}
+                emptyLabel={normalizedSearch ? "No matches" : "All flags enabled"}
+                onSelect={handleAdd}
+              />
+              <FlagColumn
+                heading={`Enabled · ${selectedFlags.length}`}
+                icon={<MinusCircleIcon className="size-4 shrink-0 text-red-500 mt-1 mx-1" />}
+                flags={selectedFlags}
+                emptyLabel={normalizedSearch ? "No matches" : "No flags enabled"}
+                onSelect={handleRemove}
+              />
+            </div>
+          </Command>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+type FeatureFlag = (typeof FeatureFlags)[number]
+
+function FlagColumn({
+  heading,
+  icon,
+  flags,
+  emptyLabel,
+  onSelect,
+}: {
+  heading: string
+  icon: ReactNode
+  flags: FeatureFlag[]
+  emptyLabel: string
+  onSelect: (featureFlagKey: FeatureFlagKey) => void
+}) {
+  return (
+    <div className="flex flex-col">
+      <div className="px-3 pt-3 pb-1 text-sm font-semibold text-foreground">{heading}</div>
+      <CommandList className="max-h-[28rem] min-h-72">
+        {flags.length === 0 ? (
+          <p className="px-3 py-6 text-center text-xs text-muted-foreground">{emptyLabel}</p>
+        ) : (
+          <CommandGroup>
+            {flags.map((flag) => (
+              <CommandItem
+                key={flag.key}
+                value={flag.key}
+                onSelect={() => onSelect(flag.key)}
+                className="items-start cursor-pointer"
+              >
+                {icon}
                 <div className="flex flex-col">
-                  <span className="font-medium">{flag.key}</span>
+                  <span className="font-medium capitalize">{flag.key}</span>
                   <span className="text-xs text-muted-foreground">{flag.description}</span>
                 </div>
-              </DropdownMenuItem>
+              </CommandItem>
             ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+          </CommandGroup>
+        )}
+      </CommandList>
     </div>
   )
 }

--- a/apps/web/src/backoffice/features/backoffice/components/ProjectsPanel.tsx
+++ b/apps/web/src/backoffice/features/backoffice/components/ProjectsPanel.tsx
@@ -84,6 +84,7 @@ function WithData() {
         header: () => <span className="text-muted-foreground">Feature flags</span>,
         cell: ({ row }) => (
           <FeatureFlagCell
+            projectName={row.original.name}
             enabledFlags={row.original.featureFlags}
             onAdd={(featureFlagKey) =>
               dispatch(
@@ -131,7 +132,11 @@ function WithData() {
   }
 
   const handleRowClick = (event: React.MouseEvent, projectId: string) => {
-    if ((event.target as HTMLElement).closest("[data-no-navigate]")) return
+    const target = event.target as HTMLElement
+    // Ignore clicks that bubble through the React tree from portaled UI (e.g. the
+    // feature-flags dialog/overlay), which are not DOM descendants of the row.
+    if (!event.currentTarget.contains(target)) return
+    if (target.closest("[data-no-navigate]")) return
     navigate(BackofficeProjectRoutes.project.build({ projectId }))
   }
 

--- a/apps/web/src/backoffice/routes/BackofficeProjectDetailRoute.tsx
+++ b/apps/web/src/backoffice/routes/BackofficeProjectDetailRoute.tsx
@@ -8,6 +8,7 @@ import { AsyncRoute } from "@/common/routes/AsyncRoute"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import { selectBackofficeProjectDetail } from "../features/backoffice/backoffice.selectors"
 import { backofficeActions } from "../features/backoffice/backoffice.slice"
+import { FeatureFlagCell } from "../features/backoffice/components/BackofficeTable"
 import {
   BackofficeAgentRoutes,
   BackofficeOrganizationRoutes,
@@ -38,6 +39,7 @@ export function BackofficeProjectDetailRoute() {
 
 function WithData() {
   const navigate = useNavigate()
+  const dispatch = useAppDispatch()
   const project = useValue(selectBackofficeProjectDetail)
 
   return (
@@ -54,17 +56,29 @@ function WithData() {
         </Button>
       </div>
 
-      <div className="space-y-1">
-        <h2 className="text-xl font-semibold">{project.name}</h2>
-        <Link
-          to={BackofficeOrganizationRoutes.organization.build({
-            organizationId: project.organizationId,
-          })}
-          className="text-muted-foreground hover:underline flex items-center gap-1 w-fit"
-        >
-          {project.organizationName}
-          <ExternalLinkIcon className="size-3 opacity-60" />
-        </Link>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">{project.name}</h2>
+          <Link
+            to={BackofficeOrganizationRoutes.organization.build({
+              organizationId: project.organizationId,
+            })}
+            className="text-muted-foreground hover:underline flex items-center gap-1 w-fit"
+          >
+            {project.organizationName}
+            <ExternalLinkIcon className="size-3 opacity-60" />
+          </Link>
+        </div>
+        <FeatureFlagCell
+          projectName={project.name}
+          enabledFlags={project.featureFlags}
+          onAdd={(featureFlagKey) =>
+            dispatch(backofficeActions.addFeatureFlag({ projectId: project.id, featureFlagKey }))
+          }
+          onRemove={(featureFlagKey) =>
+            dispatch(backofficeActions.removeFeatureFlag({ projectId: project.id, featureFlagKey }))
+          }
+        />
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">


### PR DESCRIPTION
## Summary

Reworks how project feature flags are viewed and edited in the Backoffice. The old cell showed all enabled flags as removable chips plus a separate, unsearchable "Add flag" dropdown — cluttered and hard to scan with ~10 flags.

Now each project shows a compact **`N flags`** trigger that opens a dialog with:
- a **searchable** input (substring match on flag key + description, with a clear button)
- a two-column **Available / Enabled** transfer layout — click a flag on the left (green `+`) to enable, on the right (red `−`) to disable
- the project name in the dialog title so it's clear what you're editing
- flags sorted alphabetically

The editor is now available in **two places**: the projects list table and the **project detail page**.

## Notes
- Reuses the existing shadcn `Dialog`, `Command`, and `Button` components (matching the `DocumentTagPicker` pattern already in the repo).
- Feature-flag add/remove thunks already keep both the projects-list and project-detail Redux state in sync, so no store changes were needed.
- Fixed a navigation bug: clicking the dialog overlay (portaled) no longer bubbles through the React tree to trigger the table row's navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)