### PR TITLE
refactor(web): extract reusable startPolling listener helper

### DIFF
--- a/apps/web/src/common/features/me/me.middleware.ts
+++ b/apps/web/src/common/features/me/me.middleware.ts
@@ -1,5 +1,6 @@
 import { createListenerMiddleware } from "@reduxjs/toolkit"
 import { notificationsActions } from "@/common/features/notifications/notifications.slice"
+import { startPolling } from "@/common/store/polling"
 import type { AppDispatch, RootState } from "@/common/store/types"
 import { logoutAuth0 } from "@/external/auth0Client"
 import { acceptInvitation } from "@/studio/features/invitations/invitations.thunks"
@@ -14,24 +15,12 @@ const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
 
 listenerMiddleware.startListening({
   actionCreator: meActions.mountOnboarding,
-  effect: async (_, listenerApi) => {
-    // Ensure a single polling loop runs even if onboarding mounts several times.
-    listenerApi.cancelActiveListeners()
-
-    // Fetch immediately, then poll while onboarding stays mounted.
-    listenerApi.dispatch(fetchPendingInvitations())
-
-    const pollingTask = listenerApi.fork(async (forkApi) => {
-      while (true) {
-        await forkApi.delay(PENDING_INVITATIONS_POLL_INTERVAL_MS)
-        listenerApi.dispatch(fetchPendingInvitations())
-      }
-    })
-
-    // Stop polling once onboarding unmounts.
-    await listenerApi.condition(meActions.unmountOnboarding.match)
-    pollingTask.cancel()
-  },
+  effect: (_, listenerApi) =>
+    startPolling(listenerApi, {
+      stopWhen: meActions.unmountOnboarding.match,
+      intervalMs: PENDING_INVITATIONS_POLL_INTERVAL_MS,
+      poll: () => listenerApi.dispatch(fetchPendingInvitations()),
+    }),
 })
 
 listenerMiddleware.startListening({

--- a/apps/web/src/common/store/polling.ts
+++ b/apps/web/src/common/store/polling.ts
@@ -1,0 +1,62 @@
+import type { AnyListenerPredicate, ListenerEffectAPI } from "@reduxjs/toolkit"
+import type { AppDispatch, RootState } from "./types"
+
+type ListenerApi = ListenerEffectAPI<RootState, AppDispatch>
+
+interface StartPollingOptions {
+  /**
+   * Predicate that resolves the polling loop when it matches — typically the
+   * `.match` of an unmount action (e.g. `meActions.unmountOnboarding.match`).
+   */
+  stopWhen: AnyListenerPredicate<RootState>
+  /** Delay between polls, in milliseconds. */
+  intervalMs: number
+  /** Runs immediately when polling starts, then after every interval. */
+  poll: () => void
+  /**
+   * Whether to run `poll` once immediately when polling starts. When `false`,
+   * the first poll happens after `intervalMs`. Defaults to `true`.
+   */
+  pollImmediately?: boolean
+}
+
+/**
+ * Runs a polling loop from inside a listener effect until `stopWhen` matches.
+ *
+ * Fetches immediately, then repeats every `intervalMs` while the effect stays
+ * active. Cancels any previously started loop so a single one runs even if the
+ * start action is dispatched several times.
+ *
+ * ```ts
+ * listenerMiddleware.startListening({
+ *   actionCreator: meActions.mountOnboarding,
+ *   effect: (_, listenerApi) =>
+ *     startPolling(listenerApi, {
+ *       stopWhen: meActions.unmountOnboarding.match,
+ *       intervalMs: 30_000,
+ *       poll: () => listenerApi.dispatch(fetchPendingInvitations()),
+ *     }),
+ * })
+ * ```
+ */
+export async function startPolling(
+  listenerApi: ListenerApi,
+  { stopWhen, intervalMs, poll, pollImmediately = true }: StartPollingOptions,
+): Promise<void> {
+  // Ensure a single polling loop runs even if the start action fires several times.
+  listenerApi.cancelActiveListeners()
+
+  // Poll immediately, then repeat while the effect stays active.
+  if (pollImmediately) poll()
+
+  const pollingTask = listenerApi.fork(async (forkApi) => {
+    while (true) {
+      await forkApi.delay(intervalMs)
+      poll()
+    }
+  })
+
+  // Stop polling once the stop condition matches.
+  await listenerApi.condition(stopWhen)
+  pollingTask.cancel()
+}


### PR DESCRIPTION
## Summary
Extracts the pending-invitations polling loop from `me.middleware.ts` into a reusable `startPolling` helper for Redux listener effects.

- New `apps/web/src/common/store/polling.ts` — `startPolling(listenerApi, { stopWhen, intervalMs, poll, pollImmediately })` handles the fork/cancel/condition mechanics and de-dupes concurrent loops via `cancelActiveListeners()`.
- `pollImmediately` option (defaults to `true`) controls whether the first poll fires on start or after one interval.
- `me.middleware.ts` now uses the helper instead of a hand-rolled loop; behavior unchanged.

Typed against the app's `RootState`/`AppDispatch`, so it drops into any listener middleware without extra typing. `biome:check` and `typecheck` pass.