### PR TITLE
feat(agents): settings version history with diff compare and one-click restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Added
 -  (beta) Gemini 3.1 Flash Lite & Gemini 3.5 Flash available for all Agents
+- Agent editor shows the settings version history: browse versions, compare changes, restore in one click
 - Agent session chat shows a live activity timeline while the assistant is streaming, with descriptive per-tool statuses and a check once each step completes
 - Agent session chat has a message navigator to jump to any earlier message in the thread
 

--- a/apps/api/src/domains/agents/agents.controller.ts
+++ b/apps/api/src/domains/agents/agents.controller.ts
@@ -13,10 +13,13 @@ import {
   Controller,
   Delete,
   Get,
+  NotFoundException,
+  Param,
   Patch,
   Post,
   Put,
   Req,
+  UnprocessableEntityException,
   UseGuards,
   UsePipes,
 } from "@nestjs/common"
@@ -30,6 +33,7 @@ import { ResourceContextGuard } from "@/common/context/resource-context.guard"
 import { CheckPolicy } from "@/common/policies/check-policy.decorator"
 import { ZodValidationPipe } from "@/common/zod-validation-pipe"
 import { TrackActivity } from "@/domains/activities/track-activity.decorator"
+import { extractAgentSettingsUpdateFields } from "@/domains/agents/settings/agent.settings.functions"
 import type { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { AgentSettingsService } from "@/domains/agents/settings/agent-settings.service"
@@ -129,6 +133,40 @@ export class AgentsController {
       return toAgentDto({ agent: request.agent, agentSettings: as })
     })
     return { data: results }
+  }
+
+  @Post(AgentHistoryRoutes.restoreOne.path)
+  @CheckPolicy((policy) => policy.canUpdate())
+  @AddContext("agent")
+  @TrackActivity({ action: "agent.update", entityFrom: "agent" })
+  async restoreOneHistory(
+    @Req() request: EndpointRequestWithAgent,
+    @Param("revision") revisionParam: string,
+  ): Promise<typeof AgentHistoryRoutes.restoreOne.response> {
+    const revision = Number(revisionParam)
+    if (!Number.isInteger(revision) || revision < 1) {
+      throw new UnprocessableEntityException(`Invalid revision "${revisionParam}"`)
+    }
+
+    const connectScope = getRequiredConnectScope(request)
+    const targetSettings = await this.agentSettingsService.get({
+      connectScope,
+      agentId: request.agent.id,
+      revision,
+    })
+    if (!targetSettings) {
+      throw new NotFoundException(
+        `Revision ${revision} not found for agent with id ${request.agent.id}`,
+      )
+    }
+
+    await this.agentsService.updateAgent({
+      connectScope,
+      agentId: request.agent.id,
+      fieldsToUpdate: extractAgentSettingsUpdateFields(targetSettings),
+    })
+
+    return { data: { success: true } }
   }
 
   @Get(AgentSubAgentsRoutes.getAll.path)

--- a/apps/api/src/domains/agents/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/agents/e2e-tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { AgentsRoutes } from "@caseai-connect/api-contracts"
+import { AgentHistoryRoutes, AgentsRoutes } from "@caseai-connect/api-contracts"
 import { afterAll } from "@jest/globals"
 import type { INestApplication } from "@nestjs/common"
 import type { App } from "supertest/types"
@@ -221,6 +221,48 @@ describe("Agents - Auth", () => {
       expectResponse(await subject(), 404) //exception thrown by guard
     })
     it("doesn't allow a simple member to delete a agent", async () => {
+      await createContextForRole("member")
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+    })
+  })
+
+  describe("AgentHistoryRoutes.restoreOne", () => {
+    const subject = async () =>
+      request({
+        route: AgentHistoryRoutes.restoreOne,
+        pathParams: removeNullish({ organizationId, projectId, agentId, revision: "1" }),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+    it("requires a valid organization ID", async () => {
+      await createContextForRole("owner")
+      organizationId = null
+      expectResponse(await subject(), 400, AUTH_ERRORS.NO_ORGANIZATION_ID)
+    })
+    it("requires a valid project ID", async () => {
+      await createContextForRole("owner")
+      // Use a valid UUID format that doesn't exist in the database
+      projectId = randomUUID()
+      expectResponse(await subject(), 404)
+    })
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+    it("requires the agent to be part of the project", async () => {
+      const { organization } = await createContextForRole("owner")
+      const project2 = await repositories.projectRepository.save(
+        projectFactory.transient({ organization }).build(),
+      )
+      projectId = project2.id
+      expectResponse(await subject(), 404) //exception thrown by guard
+    })
+    it("doesn't allow a simple member to restore a revision", async () => {
       await createContextForRole("member")
       expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
     })

--- a/apps/api/src/domains/agents/e2e-tests/history-restore-one.spec.ts
+++ b/apps/api/src/domains/agents/e2e-tests/history-restore-one.spec.ts
@@ -1,0 +1,127 @@
+import { AgentHistoryRoutes, AgentModel } from "@caseai-connect/api-contracts"
+import { afterAll } from "@jest/globals"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { sdk } from "@/external/llm/open-telemetry-init"
+import { setupUserGuardForTesting } from "../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../test/request"
+import { AgentsModule } from "../agents.module"
+
+describe("Agent History - restoreOne", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let organizationId: string
+  let projectId: string
+  let agentId: string
+  let revision = "1"
+  let accessToken: string | undefined = "token"
+  let auth0Id = "auth0|123"
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [AgentsModule],
+      applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    accessToken = "token"
+    auth0Id = "auth0|123"
+    revision = "1"
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await sdk.shutdown()
+    await app.close()
+  })
+
+  const createContext = async () => {
+    const { user, organization, project, agent, agentSettings } =
+      await createOrganizationWithAgent(repositories)
+    organizationId = organization.id
+    projectId = project.id
+    agentId = agent.id
+    auth0Id = user.auth0Id
+    return { organization, project, agent, agentSettings, user }
+  }
+
+  const subject = async () =>
+    request({
+      route: AgentHistoryRoutes.restoreOne,
+      pathParams: removeNullish({ organizationId, projectId, agentId, revision }),
+      token: accessToken,
+    })
+
+  it("should copy the target revision as a new revision", async () => {
+    const { organization, project, agent, agentSettings } = await createContext()
+
+    const agentSettingsRev2 = agentSettingsFactory
+      .transient({ organization, project, agent })
+      .build({
+        instructions: "Rev 2",
+        model: AgentModel.Gemini25Flash,
+        revision: 2,
+      })
+    await repositories.agentSettingsRepository.save(agentSettingsRev2)
+
+    revision = "1"
+    const response = await subject()
+
+    expectResponse(response, 201)
+    expect(response.body.data).toEqual({ success: true })
+
+    const revisions = await repositories.agentSettingsRepository.find({
+      where: { agentId: agent.id },
+      order: { revision: "DESC" },
+    })
+    expect(revisions).toHaveLength(3)
+    expect(revisions[0]?.revision).toBe(3)
+    expect(revisions[0]?.instructions).toBe(agentSettings.instructions)
+    expect(revisions[0]?.model).toBe(agentSettings.model)
+  })
+
+  it("should not create a new revision when the target equals the latest revision", async () => {
+    const { agent } = await createContext()
+
+    revision = "1"
+    const response = await subject()
+
+    expectResponse(response, 201)
+    const revisions = await repositories.agentSettingsRepository.find({
+      where: { agentId: agent.id },
+    })
+    expect(revisions).toHaveLength(1)
+  })
+
+  it("should return 404 when the revision does not exist", async () => {
+    await createContext()
+
+    revision = "42"
+    expectResponse(await subject(), 404)
+  })
+
+  it("should return 422 when the revision is not a number", async () => {
+    await createContext()
+
+    revision = "not-a-number"
+    expectResponse(await subject(), 422)
+  })
+})

--- a/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-run-processor.service.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-run-processor.service.spec.ts
@@ -80,7 +80,7 @@ describe("EvaluationExtractionRunProcessorService", () => {
           finalName: "question",
           role: "input",
         },
-        ["col-answer"]: {
+        "col-answer": {
           id: "col-answer",
           index: 1,
           originalName: "answer",
@@ -95,7 +95,7 @@ describe("EvaluationExtractionRunProcessorService", () => {
       organizationId: organization.id,
       projectId: project.id,
       evaluationExtractionDatasetId: dataset.id,
-      data: { "col-question": "1+1", ["col-answer"]: "2" },
+      data: { "col-question": "1+1", "col-answer": "2" },
     })
     await repositories.evaluationExtractionDatasetRecordRepository.save(datasetRecord)
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@caseai-connect/api-contracts": "*",
     "@caseai-connect/ui": "*",
     "@hookform/resolvers": "^5.2.2",
+    "@pierre/diffs": "^1.2.12",
     "@reduxjs/toolkit": "^2.11.2",
     "@tabler/icons-react": "^3.37.1",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/web/src/common/features/agents/agents.spi.ts
+++ b/apps/web/src/common/features/agents/agents.spi.ts
@@ -16,4 +16,15 @@ export interface IAgentsSpi {
     projectId: string
     agentId: string
   }) => Promise<void>
+  getHistory: (params: {
+    organizationId: string
+    projectId: string
+    agentId: string
+  }) => Promise<Agent[]>
+  restoreRevision: (params: {
+    organizationId: string
+    projectId: string
+    agentId: string
+    revision: number
+  }) => Promise<void>
 }

--- a/apps/web/src/common/features/agents/external/agents.api.ts
+++ b/apps/web/src/common/features/agents/external/agents.api.ts
@@ -1,4 +1,4 @@
-import { type AgentDto, AgentsRoutes } from "@caseai-connect/api-contracts"
+import { type AgentDto, AgentHistoryRoutes, AgentsRoutes } from "@caseai-connect/api-contracts"
 import { getAxiosInstance } from "@/external/axios"
 import type { Agent } from "../agents.models"
 import type { IAgentsSpi } from "../agents.spi"
@@ -28,6 +28,19 @@ export default {
   deleteOne: async (params) => {
     const axios = getAxiosInstance()
     await axios.delete(AgentsRoutes.deleteOne.getPath(params))
+  },
+  getHistory: async (params) => {
+    const axios = getAxiosInstance()
+    const response = await axios.get<typeof AgentHistoryRoutes.getAll.response>(
+      AgentHistoryRoutes.getAll.getPath(params),
+    )
+    return response.data.data.map(toAgent)
+  },
+  restoreRevision: async ({ revision, ...params }) => {
+    const axios = getAxiosInstance()
+    await axios.post(
+      AgentHistoryRoutes.restoreOne.getPath({ ...params, revision: String(revision) }),
+    )
   },
 } satisfies IAgentsSpi
 

--- a/apps/web/src/common/features/agents/locales/agent.en.json
+++ b/apps/web/src/common/features/agents/locales/agent.en.json
@@ -108,6 +108,26 @@
       "title": "Unsaved changes",
       "description": "You have unsaved changes that will be lost. Do you want to discard them?"
     },
+    "history": {
+      "button": "History",
+      "title": "Version history",
+      "description": "Browse, compare and restore previous settings of {{name}}.",
+      "loadError": "Failed to load version history",
+      "revisionLabel": "Version {{revision}}",
+      "currentBadge": "Current",
+      "compareWithPrevious": "Changes in this version",
+      "compareWithCurrent": "Compare with current",
+      "comparing": "Showing changes from version {{before}} to version {{after}}.",
+      "noChangesTitle": "No differences",
+      "noChangesDescription": "These two versions have identical settings.",
+      "onlyVersionTitle": "Only one version",
+      "onlyVersionDescription": "This agent has a single settings version, so there is nothing to compare yet.",
+      "restore": "Restore this version",
+      "restoreDialog": {
+        "title": "Restore version {{revision}}?",
+        "description": "The settings of version {{revision}} will be copied as a new version and become the current settings. No version is deleted."
+      }
+    },
     "orchestration": {
       "selectedTitle": "Sub-agents",
       "availableTitle": "Available conversation agents",

--- a/apps/web/src/common/features/agents/locales/agent.fr.json
+++ b/apps/web/src/common/features/agents/locales/agent.fr.json
@@ -108,6 +108,26 @@
       "title": "Modifications non enregistrées",
       "description": "Vous avez des modifications non enregistrées qui seront perdues. Voulez-vous les abandonner ?"
     },
+    "history": {
+      "button": "Historique",
+      "title": "Historique des versions",
+      "description": "Parcourez, comparez et restaurez les paramètres précédents de {{name}}.",
+      "loadError": "Échec du chargement de l'historique des versions",
+      "revisionLabel": "Version {{revision}}",
+      "currentBadge": "Actuelle",
+      "compareWithPrevious": "Changements de cette version",
+      "compareWithCurrent": "Comparer avec l'actuelle",
+      "comparing": "Changements de la version {{before}} à la version {{after}}.",
+      "noChangesTitle": "Aucune différence",
+      "noChangesDescription": "Ces deux versions ont des paramètres identiques.",
+      "onlyVersionTitle": "Une seule version",
+      "onlyVersionDescription": "Cet agent n'a qu'une seule version de paramètres, il n'y a donc rien à comparer pour le moment.",
+      "restore": "Restaurer cette version",
+      "restoreDialog": {
+        "title": "Restaurer la version {{revision}} ?",
+        "description": "Les paramètres de la version {{revision}} seront copiés comme nouvelle version et deviendront les paramètres actuels. Aucune version n'est supprimée."
+      }
+    },
     "orchestration": {
       "selectedTitle": "Sous-agents",
       "availableTitle": "Agents conversationnels disponibles",

--- a/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
+++ b/apps/web/src/stories/routes/studio/AgentEditorRoute.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import type { Agent } from "@/common/features/agents/agents.models"
+import type { IAgentsSpi } from "@/common/features/agents/agents.spi"
 import { buildDecorator, render } from "@/stories/decorators"
 import {
   buildStudioData,
@@ -13,6 +15,38 @@ import { studioRoutes } from "@/studio/routes/StudioRoutes"
 
 type StoryArgs = StudioStoryArgs & {
   withSubAgents?: boolean
+}
+
+/** Older revisions of the agent so the version history sheet has content to compare. */
+function buildVersions(agent: Agent): Agent[] {
+  return [
+    { ...agent },
+    {
+      ...agent,
+      revision: 2,
+      temperature: 0.2,
+      instructions: `${agent.instructions}\nAlways cite your sources.`,
+    },
+    {
+      ...agent,
+      revision: 1,
+      instructions: "You are a helpful assistant.",
+    },
+  ]
+}
+
+/** Serves the seeded data back so history/restore interactions work inside the story. */
+function buildMockAgentsService(agents: Agent[], versions: Agent[]): IAgentsSpi {
+  return {
+    getAll: async () => agents,
+    createOne: async () => {
+      throw new Error("createOne is not supported in this story")
+    },
+    updateOne: async () => {},
+    deleteOne: async () => {},
+    getHistory: async () => versions,
+    restoreRevision: async () => {},
+  }
 }
 
 const meta = {
@@ -46,6 +80,7 @@ export const ConversationAgent: Story = {
         ...rawParentAgent,
         name: "Helpful Assistant",
         type: "conversation" as const,
+        revision: 3,
       }
       const childAgents = rawChildAgents.map((agent, index) => ({
         ...agent,
@@ -61,14 +96,20 @@ export const ConversationAgent: Story = {
               }),
             ]
           : []
+      const allAgents = [parentAgent, ...childAgents]
+      const versions = buildVersions(parentAgent)
 
       return {
         state: mergeSeeds(
           baseSeeds,
-          seed.agents([parentAgent, ...childAgents], { currentId: parentAgent.id }),
+          seed.agents(allAgents, { currentId: parentAgent.id }),
           seed.studio.agentSubAgents(subAgents),
           seed.studio.documentTags([]),
+          seed.studio.agentHistory(versions),
         ),
+        services: {
+          agents: buildMockAgentsService(allAgents, versions),
+        },
       }
     }),
   ],

--- a/apps/web/src/stories/routes/studio/agent/AgentVersionHistory.stories.tsx
+++ b/apps/web/src/stories/routes/studio/agent/AgentVersionHistory.stories.tsx
@@ -1,0 +1,109 @@
+import { AgentLocale, AgentModel, DocumentsRagMode } from "@caseai-connect/api-contracts"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { agentFactory, agentOutputJsonSchemaFactory } from "@/common/features/agents/agent.factory"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { organizationFactory } from "@/common/features/organizations/organization.factory"
+import { projectFactory } from "@/common/features/projects/projects.factory"
+import { withRedux } from "@/stories/decorators"
+import { AgentVersionExplorer } from "@/studio/features/agents/components/AgentVersionExplorer"
+
+const organization = organizationFactory.build()
+const project = projectFactory.transient({ organization }).build()
+
+const baseAgent = agentFactory.transient({ project }).build({
+  type: "conversation",
+  name: "Helpful Assistant",
+  instructions: "You are a helpful assistant.\nAnswer clearly and concisely.",
+  model: AgentModel.Gemini25Flash,
+  temperature: 0.7,
+  locale: AgentLocale.EN,
+  documentsRagMode: DocumentsRagMode.None,
+  greetingMessage: undefined,
+  outputJsonSchema: undefined,
+})
+
+/** Revisions ordered newest first, as returned by the history endpoint. */
+const versions: Agent[] = [
+  {
+    ...baseAgent,
+    revision: 4,
+    instructions:
+      "You are a helpful assistant.\nAnswer clearly and concisely.\nAlways cite your sources.",
+    temperature: 0.3,
+    documentsRagMode: DocumentsRagMode.All,
+    updatedAt: Date.now() - 1000 * 60 * 60,
+  },
+  {
+    ...baseAgent,
+    revision: 3,
+    instructions:
+      "You are a helpful assistant.\nAnswer clearly and concisely.\nAlways cite your sources.",
+    temperature: 0.3,
+    updatedAt: Date.now() - 1000 * 60 * 60 * 24,
+  },
+  {
+    ...baseAgent,
+    revision: 2,
+    model: AgentModel.Gemini25Pro,
+    greetingMessage: "Hi! How can I help you today?",
+    updatedAt: Date.now() - 1000 * 60 * 60 * 24 * 6,
+  },
+  {
+    ...baseAgent,
+    revision: 1,
+    instructions: "You are a helpful assistant.",
+    updatedAt: Date.now() - 1000 * 60 * 60 * 24 * 30,
+  },
+]
+
+const schemaAgent = agentFactory.transient({ project }).build({
+  type: "extraction",
+  name: "Document Extractor",
+  outputJsonSchema: agentOutputJsonSchemaFactory.build(),
+})
+
+const schemaVersions: Agent[] = [
+  {
+    ...schemaAgent,
+    revision: 2,
+    outputJsonSchema: agentOutputJsonSchemaFactory.build({
+      properties: {
+        title: { type: "string", description: "Short title" },
+        summary: { type: "string", description: "One-paragraph summary" },
+        dueDate: { type: "string", description: "Due date if present" },
+      },
+    }),
+    updatedAt: Date.now() - 1000 * 60 * 30,
+  },
+  {
+    ...schemaAgent,
+    revision: 1,
+    updatedAt: Date.now() - 1000 * 60 * 60 * 24 * 3,
+  },
+]
+
+const meta = {
+  title: "routes/studio/project/agent/AgentVersionHistory",
+  component: AgentVersionExplorer,
+  decorators: [withRedux({})],
+  render: (args) => (
+    <div className="flex h-[600px] flex-col border">
+      <AgentVersionExplorer {...args} />
+    </div>
+  ),
+} satisfies Meta<typeof AgentVersionExplorer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ManyVersions: Story = {
+  args: { versions },
+}
+
+export const SchemaChange: Story = {
+  args: { versions: schemaVersions },
+}
+
+export const SingleVersion: Story = {
+  args: { versions: [{ ...baseAgent, revision: 1 }] },
+}

--- a/apps/web/src/stories/seed.ts
+++ b/apps/web/src/stories/seed.ts
@@ -319,6 +319,10 @@ export const seed = {
     agentSubAgents(subAgents: AgentSubAgent[]): StoryPreloadedState {
       return { agentSubAgents: { data: ads.fulfilled(subAgents) } }
     },
+
+    agentHistory(versions: Agent[]): StoryPreloadedState {
+      return { agentHistory: { data: ads.fulfilled(versions) } }
+    },
   },
 
   backoffice: {

--- a/apps/web/src/studio/features/agents/agent-history.functions.ts
+++ b/apps/web/src/studio/features/agents/agent-history.functions.ts
@@ -1,0 +1,51 @@
+import type { Agent } from "@/common/features/agents/agents.models"
+
+/** Settings fields that are versioned by the backend (one revision per change). */
+export const agentSettingsDiffKeys = [
+  "instructions",
+  "greetingMessage",
+  "model",
+  "temperature",
+  "locale",
+  "documentsRagMode",
+  "outputJsonSchema",
+] as const
+
+export type AgentSettingsDiffKey = (typeof agentSettingsDiffKeys)[number]
+
+/** The file name drives @pierre/diffs syntax highlighting (md for prose, json for the schema). */
+export const agentSettingsDiffFileNames: Record<AgentSettingsDiffKey, string> = {
+  instructions: "instructions.md",
+  greetingMessage: "greeting-message.md",
+  model: "model.txt",
+  temperature: "temperature.txt",
+  locale: "language.txt",
+  documentsRagMode: "documents-rag-mode.txt",
+  outputJsonSchema: "output-json-schema.json",
+}
+
+export const agentSettingsDiffLabelKeys: Record<AgentSettingsDiffKey, string> = {
+  instructions: "agent:props.instructions",
+  greetingMessage: "agent:props.greeting",
+  model: "agent:props.model",
+  temperature: "agent:props.temperature",
+  locale: "agent:props.locale",
+  documentsRagMode: "agent:props.documentsRagMode",
+  outputJsonSchema: "agent:props.outputJsonSchema",
+}
+
+export function serializeAgentSettingsField(agent: Agent, key: AgentSettingsDiffKey): string {
+  const value = agent[key]
+  if (value === undefined || value === null) return ""
+  if (key === "outputJsonSchema") return JSON.stringify(value, null, 2)
+  return String(value)
+}
+
+export function listChangedAgentSettingsFields(
+  before: Agent,
+  after: Agent,
+): AgentSettingsDiffKey[] {
+  return agentSettingsDiffKeys.filter(
+    (key) => serializeAgentSettingsField(before, key) !== serializeAgentSettingsField(after, key),
+  )
+}

--- a/apps/web/src/studio/features/agents/agent-history.selectors.ts
+++ b/apps/web/src/studio/features/agents/agent-history.selectors.ts
@@ -1,0 +1,3 @@
+import type { RootState } from "@/common/store"
+
+export const selectAgentHistoryData = (state: RootState) => state.agentHistory.data

--- a/apps/web/src/studio/features/agents/agent-history.slice.ts
+++ b/apps/web/src/studio/features/agents/agent-history.slice.ts
@@ -1,0 +1,43 @@
+import { createSlice } from "@reduxjs/toolkit"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data-status"
+import { listAgentHistory } from "./agent-history.thunks"
+
+interface State {
+  data: AsyncData<Agent[]>
+}
+
+const initialState: State = {
+  data: defaultAsyncData,
+}
+
+const slice = createSlice({
+  name: "agentHistory",
+  initialState,
+  reducers: {
+    reset: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(listAgentHistory.pending, (state) => {
+        if (!ADS.isFulfilled(state.data)) state.data.status = ADS.Loading
+        state.data.error = null
+      })
+      .addCase(listAgentHistory.fulfilled, (state, action) => {
+        state.data = {
+          status: ADS.Fulfilled,
+          error: null,
+          value: action.payload,
+        }
+      })
+      .addCase(listAgentHistory.rejected, (state, action) => {
+        state.data.status = ADS.Error
+        state.data.error = action.error.message || "Failed to load agent version history"
+      })
+  },
+})
+
+export type { State as AgentHistoryState }
+export const agentHistoryInitialState = initialState
+export const agentHistoryActions = { ...slice.actions }
+export const agentHistorySlice = slice

--- a/apps/web/src/studio/features/agents/agent-history.thunks.ts
+++ b/apps/web/src/studio/features/agents/agent-history.thunks.ts
@@ -1,0 +1,28 @@
+import { createAsyncThunk } from "@reduxjs/toolkit"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { getCurrentId } from "@/common/features/helpers"
+import type { RootState, ThunkExtraArg } from "@/common/store"
+
+type ThunkConfig = { state: RootState; extra: ThunkExtraArg }
+
+export const listAgentHistory = createAsyncThunk<Agent[], void, ThunkConfig>(
+  "agentHistory/list",
+  async (_, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const agentId = getCurrentId({ state, name: "agentId" })
+    return await services.agents.getHistory({ organizationId, projectId, agentId })
+  },
+)
+
+export const restoreAgentRevision = createAsyncThunk<void, { revision: number }, ThunkConfig>(
+  "agentHistory/restore",
+  async ({ revision }, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const agentId = getCurrentId({ state, name: "agentId" })
+    await services.agents.restoreRevision({ organizationId, projectId, agentId, revision })
+  },
+)

--- a/apps/web/src/studio/features/agents/agents.middleware.ts
+++ b/apps/web/src/studio/features/agents/agents.middleware.ts
@@ -2,7 +2,13 @@ import { createListenerMiddleware, isAnyOf } from "@reduxjs/toolkit"
 import { listAgents } from "@/common/features/agents/agents.thunks"
 import { fetchMe } from "@/common/features/me/me.thunks"
 import { notificationsActions } from "@/common/features/notifications/notifications.slice"
+import { ADS } from "@/common/store/async-data-status"
 import type { AppDispatch, RootState } from "@/common/store/types"
+import { selectAgentHistoryData } from "@/studio/features/agents/agent-history.selectors"
+import {
+  listAgentHistory,
+  restoreAgentRevision,
+} from "@/studio/features/agents/agent-history.thunks"
 import {
   createAgent,
   deleteAgent,
@@ -95,10 +101,41 @@ function registerListeners() {
     effect: async (_, listenerApi) => {
       listenerApi.dispatch(listAgents())
 
+      // Keep the version history in sync when it has already been opened.
+      if (ADS.isFulfilled(selectAgentHistoryData(listenerApi.getState()))) {
+        listenerApi.dispatch(listAgentHistory())
+      }
+
       listenerApi.dispatch(
         notificationsActions.show({
           title: "Agent updated successfully",
           type: "success",
+        }),
+      )
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: restoreAgentRevision.fulfilled,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(listAgents())
+      listenerApi.dispatch(listAgentHistory())
+
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Agent version restored successfully",
+          type: "success",
+        }),
+      )
+    },
+  })
+  listenerMiddleware.startListening({
+    actionCreator: restoreAgentRevision.rejected,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Agent version restore failed",
+          type: "error",
         }),
       )
     },

--- a/apps/web/src/studio/features/agents/components/AgentEditor.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentEditor.tsx
@@ -19,6 +19,7 @@ import { AgentOutputTab } from "./AgentOutputTab"
 import { AgentResourceLibrariesTab } from "./AgentResourceLibrariesTab"
 import { AgentSessionCategoriesTab } from "./AgentSessionCategoriesTab"
 import { AgentSourcesTab } from "./AgentSourcesTab"
+import { AgentVersionHistory } from "./AgentVersionHistory"
 
 export type AgentEditorOrchestration = {
   agents: Agent[]
@@ -180,14 +181,23 @@ export function AgentEditor({
   return (
     <div className={className}>
       <Tabs value={nav.active} onValueChange={requestTabChange}>
-        <TabsList>
-          {tabs.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value}>
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-        <TabsContent key={activeTab.value} value={activeTab.value} className="mt-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TabsList>
+            {tabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <AgentVersionHistory agent={agent} />
+        </div>
+        {/* Also keyed on the revision so the active tab form reloads fresh defaults after a
+            version is restored from the history sheet. */}
+        <TabsContent
+          key={`${activeTab.value}-${agent.revision}`}
+          value={activeTab.value}
+          className="mt-4"
+        >
           {activeTab.render(setDirty)}
         </TabsContent>
       </Tabs>

--- a/apps/web/src/studio/features/agents/components/AgentSettingsFieldDiff.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSettingsFieldDiff.tsx
@@ -1,0 +1,53 @@
+import { parseDiffFromFile } from "@pierre/diffs"
+import { FileDiff } from "@pierre/diffs/react"
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+import {
+  type AgentSettingsDiffKey,
+  agentSettingsDiffFileNames,
+  agentSettingsDiffLabelKeys,
+  serializeAgentSettingsField,
+} from "../agent-history.functions"
+
+/**
+ * Settings values are not files: a missing trailing newline is meaningless here, so add one
+ * before diffing to keep @pierre/diffs from rendering its "No newline at end of file" row.
+ */
+function toDiffContents(value: string): string {
+  if (value === "" || value.endsWith("\n")) return value
+  return `${value}\n`
+}
+
+/** Diff of a single versioned settings field between two revisions, rendered with @pierre/diffs. */
+export function AgentSettingsFieldDiff({
+  fieldKey,
+  before,
+  after,
+}: {
+  fieldKey: AgentSettingsDiffKey
+  before: Agent
+  after: Agent
+}) {
+  const { t } = useTranslation()
+
+  const fileDiff = useMemo(() => {
+    const name = agentSettingsDiffFileNames[fieldKey]
+    return parseDiffFromFile(
+      { name, contents: toDiffContents(serializeAgentSettingsField(before, fieldKey)) },
+      { name, contents: toDiffContents(serializeAgentSettingsField(after, fieldKey)) },
+    )
+  }, [fieldKey, before, after])
+
+  return (
+    <section className="space-y-2">
+      <h4 className="text-sm font-medium">{t(agentSettingsDiffLabelKeys[fieldKey])}</h4>
+      <div className="overflow-hidden rounded-md border">
+        <FileDiff
+          fileDiff={fileDiff}
+          options={{ diffStyle: "unified", disableFileHeader: true, overflow: "wrap" }}
+        />
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentVersionCompare.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionCompare.tsx
@@ -1,0 +1,97 @@
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@caseai-connect/ui/shad/empty"
+import { ToggleGroup, ToggleGroupItem } from "@caseai-connect/ui/shad/toggle-group"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { listChangedAgentSettingsFields } from "../agent-history.functions"
+import { AgentSettingsFieldDiff } from "./AgentSettingsFieldDiff"
+import { AgentVersionRestoreButton } from "./AgentVersionRestoreButton"
+
+export type AgentVersionCompareMode = "previous" | "current"
+
+/**
+ * Right pane of the version history: pick what the selected revision is compared against
+ * ("what this version changed" vs "how it differs from the current version"), review the
+ * per-field diffs, and restore the selected revision.
+ */
+export function AgentVersionCompare({
+  before,
+  after,
+  selected,
+  isCurrent,
+  mode,
+  onModeChange,
+  canComparePrevious,
+  canCompareCurrent,
+}: {
+  before: Agent
+  after: Agent
+  selected: Agent
+  isCurrent: boolean
+  mode: AgentVersionCompareMode
+  onModeChange: (mode: AgentVersionCompareMode) => void
+  canComparePrevious: boolean
+  canCompareCurrent: boolean
+}) {
+  const { t } = useTranslation()
+  const changedFields = listChangedAgentSettingsFields(before, after)
+  const canCompare = canComparePrevious || canCompareCurrent
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b p-4">
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={mode}
+          onValueChange={(next) => next && onModeChange(next as AgentVersionCompareMode)}
+        >
+          <ToggleGroupItem value="previous" disabled={!canComparePrevious}>
+            {t("agent:history.compareWithPrevious")}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="current" disabled={!canCompareCurrent}>
+            {t("agent:history.compareWithCurrent")}
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <AgentVersionRestoreButton revision={selected.revision} disabled={isCurrent} />
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4">
+        {!canCompare ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>{t("agent:history.onlyVersionTitle")}</EmptyTitle>
+              <EmptyDescription>{t("agent:history.onlyVersionDescription")}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              {t("agent:history.comparing", {
+                before: before.revision,
+                after: after.revision,
+              })}
+            </p>
+            {changedFields.length === 0 ? (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyTitle>{t("agent:history.noChangesTitle")}</EmptyTitle>
+                  <EmptyDescription>{t("agent:history.noChangesDescription")}</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : (
+              changedFields.map((fieldKey) => (
+                <AgentSettingsFieldDiff
+                  key={fieldKey}
+                  fieldKey={fieldKey}
+                  before={before}
+                  after={after}
+                />
+              ))
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentVersionExplorer.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionExplorer.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { AgentVersionCompare, type AgentVersionCompareMode } from "./AgentVersionCompare"
+import { AgentVersionList } from "./AgentVersionList"
+
+/**
+ * Two-pane version explorer: revision timeline on the left, comparison on the right.
+ * `versions` comes from the history endpoint, ordered by revision descending (index 0 is
+ * the current version).
+ */
+export function AgentVersionExplorer({ versions }: { versions: Agent[] }) {
+  // Preselect the previous version: that is the one users open the history to inspect.
+  const [selectedRevision, setSelectedRevision] = useState<number | null>(null)
+  const [mode, setMode] = useState<AgentVersionCompareMode>("current")
+
+  const current = versions[0]
+  if (!current) return null
+
+  const effectiveRevision =
+    (selectedRevision !== null && versions.some((version) => version.revision === selectedRevision)
+      ? selectedRevision
+      : null) ??
+    versions[1]?.revision ??
+    current.revision
+  const selectedIndex = versions.findIndex((version) => version.revision === effectiveRevision)
+  const selected = versions[selectedIndex] ?? current
+  const previous = versions[selectedIndex + 1]
+
+  const isCurrent = selected.revision === current.revision
+  const canComparePrevious = previous !== undefined
+  const canCompareCurrent = !isCurrent
+
+  // Fall back to whichever comparison is possible when the requested one is not.
+  let effectiveMode: AgentVersionCompareMode = mode
+  if (mode === "current" && !canCompareCurrent) effectiveMode = "previous"
+  if (mode === "previous" && !canComparePrevious) effectiveMode = "current"
+
+  const [before, after] =
+    effectiveMode === "current" ? [selected, current] : [previous ?? selected, selected]
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <AgentVersionList
+        versions={versions}
+        selectedRevision={selected.revision}
+        onSelect={setSelectedRevision}
+      />
+      <AgentVersionCompare
+        before={before}
+        after={after}
+        selected={selected}
+        isCurrent={isCurrent}
+        mode={effectiveMode}
+        onModeChange={setMode}
+        canComparePrevious={canComparePrevious}
+        canCompareCurrent={canCompareCurrent}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentVersionHistory.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionHistory.tsx
@@ -1,0 +1,73 @@
+import { Alert, AlertDescription, AlertTitle } from "@caseai-connect/ui/shad/alert"
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import { Button } from "@caseai-connect/ui/shad/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@caseai-connect/ui/shad/sheet"
+import { Skeleton } from "@caseai-connect/ui/shad/skeleton"
+import { AlertTriangleIcon, HistoryIcon } from "lucide-react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { ADS } from "@/common/store/async-data-status"
+import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { selectAgentHistoryData } from "../agent-history.selectors"
+import { listAgentHistory } from "../agent-history.thunks"
+import { AgentVersionExplorer } from "./AgentVersionExplorer"
+
+/**
+ * Entry point of the agent settings versioning UI: a trigger button showing the current
+ * revision, opening a side sheet with the revision timeline, per-field diffs and restore.
+ */
+export function AgentVersionHistory({ agent }: { agent: Agent }) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const [open, setOpen] = useState(false)
+  const history = useAppSelector(selectAgentHistoryData)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) dispatch(listAgentHistory())
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <HistoryIcon className="size-4" />
+          {t("agent:history.button")}
+          <Badge variant="secondary">v{agent.revision}</Badge>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full gap-0 sm:max-w-4xl">
+        <SheetHeader className="border-b">
+          <SheetTitle>{t("agent:history.title")}</SheetTitle>
+          <SheetDescription>
+            {t("agent:history.description", { name: agent.name })}
+          </SheetDescription>
+        </SheetHeader>
+
+        {ADS.isFulfilled(history) ? (
+          <AgentVersionExplorer versions={history.value} />
+        ) : ADS.isError(history) ? (
+          <Alert variant="destructive" className="m-4 w-auto">
+            <AlertTriangleIcon className="size-4" />
+            <AlertTitle>{t("agent:history.loadError")}</AlertTitle>
+            <AlertDescription>{history.error}</AlertDescription>
+          </Alert>
+        ) : (
+          <div className="space-y-3 p-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentVersionList.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionList.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import { cn } from "@caseai-connect/ui/utils"
+import { useTranslation } from "react-i18next"
+import type { Agent } from "@/common/features/agents/agents.models"
+import { buildDate, buildSince } from "@/common/utils/build-date"
+
+/** Timeline of an agent's settings revisions, newest first. */
+export function AgentVersionList({
+  versions,
+  selectedRevision,
+  onSelect,
+}: {
+  versions: Agent[]
+  selectedRevision: number
+  onSelect: (revision: number) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <aside className="w-52 shrink-0 overflow-y-auto border-r">
+      <ol>
+        {versions.map((version, index) => (
+          <li key={version.revision}>
+            <button
+              type="button"
+              onClick={() => onSelect(version.revision)}
+              aria-current={version.revision === selectedRevision}
+              className={cn(
+                "w-full border-b px-4 py-3 text-left transition-colors hover:bg-muted/50",
+                version.revision === selectedRevision && "bg-muted hover:bg-muted",
+              )}
+            >
+              <span className="flex items-center justify-between gap-2 text-sm font-medium">
+                {t("agent:history.revisionLabel", { revision: version.revision })}
+                {index === 0 && (
+                  <Badge variant="secondary">{t("agent:history.currentBadge")}</Badge>
+                )}
+              </span>
+              <span
+                className="mt-1 block text-xs text-muted-foreground"
+                title={buildDate(version.updatedAt)}
+              >
+                {buildSince(version.updatedAt)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ol>
+    </aside>
+  )
+}

--- a/apps/web/src/studio/features/agents/components/AgentVersionRestoreButton.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionRestoreButton.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@caseai-connect/ui/shad/button"
+import { RotateCcwIcon } from "lucide-react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ConfirmDialog } from "@/common/components/ConfirmDialog"
+import { useAppDispatch } from "@/common/store/hooks"
+import { restoreAgentRevision } from "../agent-history.thunks"
+
+/** One-click restore: copies the selected revision's settings as a new (current) revision. */
+export function AgentVersionRestoreButton({
+  revision,
+  disabled,
+}: {
+  revision: number
+  disabled: boolean
+}) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [isRestoring, setIsRestoring] = useState(false)
+
+  const handleConfirm = async () => {
+    setIsRestoring(true)
+    try {
+      await dispatch(restoreAgentRevision({ revision })).unwrap()
+    } catch {
+      // The studio agents middleware shows the error notification.
+    } finally {
+      setIsRestoring(false)
+      setConfirmOpen(false)
+    }
+  }
+
+  return (
+    <>
+      <Button size="sm" disabled={disabled || isRestoring} onClick={() => setConfirmOpen(true)}>
+        <RotateCcwIcon className="size-4" />
+        {t("agent:history.restore")}
+      </Button>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t("agent:history.restoreDialog.title", { revision })}
+        description={t("agent:history.restoreDialog.description", { revision })}
+        confirmLabel={t("agent:history.restore")}
+        confirmIcon={<RotateCcwIcon className="size-5" />}
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </>
+  )
+}

--- a/apps/web/src/studio/store/slices.ts
+++ b/apps/web/src/studio/store/slices.ts
@@ -34,6 +34,7 @@ import { projectMembershipsSlice } from "@/studio/features/project-memberships/p
 import { reviewCampaignsMiddleware } from "@/studio/features/review-campaigns/review-campaigns.middleware"
 import { reviewCampaignsSlice } from "@/studio/features/review-campaigns/review-campaigns.slice"
 import { createSliceManager } from "../../common/store/dynamic-middleware"
+import { agentHistorySlice } from "../features/agents/agent-history.slice"
 import { studioAgentsMiddleware } from "../features/agents/agents.middleware"
 import { documentsMiddleware } from "../features/documents/documents.middleware"
 import { documentsSlice } from "../features/documents/documents.slice"
@@ -73,6 +74,7 @@ export const studioSliceList = [
   agentAnalyticsSlice,
   agentCsvExtractionRunsSlice,
   agentEmbedConfigsSlice,
+  agentHistorySlice,
   agentMembershipsSlice,
   agentMessageFeedbackSlice,
   agentSubAgentsSlice,

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,7 @@
         "@caseai-connect/api-contracts": "*",
         "@caseai-connect/ui": "*",
         "@hookform/resolvers": "^5.2.2",
+        "@pierre/diffs": "^1.2.12",
         "@reduxjs/toolkit": "^2.11.2",
         "@tabler/icons-react": "^3.37.1",
         "@tailwindcss/vite": "^4.1.18",
@@ -1654,7 +1655,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2936,6 +2937,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2958,6 +2960,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2980,6 +2983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2996,6 +3000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3012,6 +3017,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3028,6 +3034,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3044,6 +3051,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3060,6 +3068,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3076,6 +3085,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3092,6 +3102,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3108,6 +3119,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3124,6 +3136,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3140,6 +3153,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3162,6 +3176,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3184,6 +3199,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3206,6 +3222,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3228,6 +3245,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3250,6 +3268,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3272,6 +3291,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3294,6 +3314,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3316,6 +3337,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3335,6 +3357,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3354,6 +3377,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3373,6 +3397,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6030,6 +6055,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6046,6 +6072,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6062,6 +6089,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6078,6 +6106,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6094,6 +6123,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6110,6 +6140,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6126,6 +6157,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6142,6 +6174,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6780,6 +6813,73 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.12.tgz",
+      "integrity": "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.1.0",
+        "@pierre/theming": "0.0.2",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@pierre/theming": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-0.0.2.tgz",
+      "integrity": "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==",
+      "license": "apache-2.0",
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -9088,6 +9188,33 @@
         "@shikijs/types": "3.23.0"
       }
     },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
+      "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@shikijs/themes": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
@@ -9095,6 +9222,48 @@
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.3.1.tgz",
+      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
@@ -13005,7 +13174,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -22291,6 +22460,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/packages/api-contracts/src/agents/settings/agent-history.routes.ts
+++ b/packages/api-contracts/src/agents/settings/agent-history.routes.ts
@@ -1,4 +1,4 @@
-import type { ResponseData } from "../../generic"
+import type { ResponseData, SuccessResponseDTO } from "../../generic"
 import { defineRoute } from "../../helpers"
 import type { AgentDto } from "../agents.dto"
 
@@ -6,5 +6,9 @@ export const AgentHistoryRoutes = {
   getAll: defineRoute<ResponseData<AgentDto[]>>({
     method: "get",
     path: "organizations/:organizationId/projects/:projectId/agents/:agentId/history",
+  }),
+  restoreOne: defineRoute<ResponseData<SuccessResponseDTO>>({
+    method: "post",
+    path: "organizations/:organizationId/projects/:projectId/agents/:agentId/history/:revision/restore",
   }),
 }


### PR DESCRIPTION
## Summary

Adds a full version-history experience for agent settings (which the backend already snapshots per change but the frontend never surfaced):

- **Backend**: new `POST .../agents/:agentId/history/:revision/restore` endpoint that copies a previous revision's settings as a new current revision (reuses `updateAgent`, so validation and legacy field sync apply; restoring identical settings is a no-op). Covered by a new e2e spec (copy-as-new-revision, no-op, 404, 422) plus auth tests for the route.
- **Frontend**: a **History** button in the agent editor (shows the current revision, e.g. `v12`) opens a side sheet with:
  - a revision timeline (newest first, relative dates, "Current" badge),
  - per-field diffs rendered with [`@pierre/diffs`](https://diffs.com) for prompt, greeting, model, temperature, language, RAG mode and JSON output schema, with a toggle between *"Changes in this version"* (vs previous) and *"Compare with current"*,
  - one-click **Restore this version** with a confirmation dialog; the agent list and history refetch afterwards and the open tab reloads the restored values.
- New `agentHistory` slice/thunks/selectors + middleware listeners, `getHistory`/`restoreRevision` on the agents SPI, EN/FR strings, Storybook scenario stories (`AgentVersionHistory`), a `seed.studio.agentHistory` helper, and an interactive mock service in the AgentEditorRoute story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)