### PR TITLE
feat(web): disable terms submit until both agreements accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Editing a single agent tab no longer clears the agent's greeting message
 - Agent temperature is returned as a number instead of a string, matching the API contract
 - Submitting a message in an agent session no longer jumps the transcript to the first message
+- Accepting the terms now advances past the terms screen instead of leaving the user stuck on it
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Agent session chat has a better message-scroller
 - Agent editor saves each configuration tab independently, so editing one tab no longer requires re-saving the whole agent; switching tabs with unsaved edits prompts to discard them
 - Backoffice feature flags are now managed through a searchable dialog with side-by-side Available/Enabled columns, reachable from both the projects list and the project detail page
+- Terms acceptance submit button stays disabled until both the general conditions and privacy policy are accepted
 
 ### Fixed
 - Editing a single agent tab no longer clears the agent's greeting message

--- a/apps/web/src/common/features/me/me.thunks.ts
+++ b/apps/web/src/common/features/me/me.thunks.ts
@@ -49,9 +49,11 @@ export const updateMe = createAsyncThunk<void, { name: string }, ThunkConfig>(
   },
 )
 
-export const acceptTerms = createAsyncThunk<void, { aiUsagePolicyAccepted: boolean }, ThunkConfig>(
-  "termsAcceptance/accept",
-  async (params, { extra: { services } }) => {
-    await services.me.acceptTerms(params)
-  },
-)
+export const acceptTerms = createAsyncThunk<
+  void,
+  { aiUsagePolicyAccepted: boolean; onSuccess: () => void },
+  ThunkConfig
+>("termsAcceptance/accept", async (params, { extra: { services } }) => {
+  await services.me.acceptTerms(params)
+  params.onSuccess()
+})

--- a/apps/web/src/common/routes/TermsRoute.tsx
+++ b/apps/web/src/common/routes/TermsRoute.tsx
@@ -43,6 +43,7 @@ export function TermsRoute() {
     control,
     handleSubmit,
     formState: { errors },
+    watch,
   } = useForm<TermsFormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -59,6 +60,8 @@ export function TermsRoute() {
   }
 
   const showMandatoryError = !!(errors.generalConditionsAccepted || errors.privacyPolicyAccepted)
+
+  const disabled = !(watch("generalConditionsAccepted") && watch("privacyPolicyAccepted"))
 
   return (
     <FullPageCenterLayout className="min-h-screen p-4">
@@ -115,7 +118,9 @@ export function TermsRoute() {
               </p>
             )}
 
-            <Button type="submit">{t("termsAcceptance:submit")}</Button>
+            <Button disabled={disabled} type="submit">
+              {t("termsAcceptance:submit")}
+            </Button>
           </form>
         </CardContent>
       </Card>

--- a/apps/web/src/common/routes/TermsRoute.tsx
+++ b/apps/web/src/common/routes/TermsRoute.tsx
@@ -56,7 +56,7 @@ export function TermsRoute() {
   if (!currentTerms) return null
 
   const onSubmit = ({ aiUsagePolicyAccepted }: TermsFormValues) => {
-    dispatch(acceptTerms({ aiUsagePolicyAccepted }))
+    dispatch(acceptTerms({ aiUsagePolicyAccepted, onSuccess: () => window.location.reload() }))
   }
 
   const showMandatoryError = !!(errors.generalConditionsAccepted || errors.privacyPolicyAccepted)


### PR DESCRIPTION
## Summary

On the terms acceptance screen, the submit button now stays disabled until both the general conditions and the privacy policy checkboxes are checked. This prevents users from submitting the form before accepting the mandatory agreements, complementing the existing validation-error messaging.