### PR TITLE
fix(agents): render version-history diff on first open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Agent version history now shows the diff on the first open instead of a blank panel
 
 ### Security
 

--- a/apps/web/src/stories/routes/studio/agent/AgentVersionHistory.stories.tsx
+++ b/apps/web/src/stories/routes/studio/agent/AgentVersionHistory.stories.tsx
@@ -5,6 +5,7 @@ import type { Agent } from "@/common/features/agents/agents.models"
 import { organizationFactory } from "@/common/features/organizations/organization.factory"
 import { projectFactory } from "@/common/features/projects/projects.factory"
 import { withRedux } from "@/stories/decorators"
+import { seed } from "@/stories/seed"
 import { AgentVersionExplorer } from "@/studio/features/agents/components/AgentVersionExplorer"
 
 const organization = organizationFactory.build()
@@ -85,10 +86,9 @@ const schemaVersions: Agent[] = [
 const meta = {
   title: "routes/studio/project/agent/AgentVersionHistory",
   component: AgentVersionExplorer,
-  decorators: [withRedux({})],
-  render: (args) => (
+  render: () => (
     <div className="flex h-[600px] flex-col border">
-      <AgentVersionExplorer {...args} />
+      <AgentVersionExplorer />
     </div>
   ),
 } satisfies Meta<typeof AgentVersionExplorer>
@@ -97,13 +97,13 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const ManyVersions: Story = {
-  args: { versions },
+  decorators: [withRedux({ state: seed.studio.agentHistory(versions) })],
 }
 
 export const SchemaChange: Story = {
-  args: { versions: schemaVersions },
+  decorators: [withRedux({ state: seed.studio.agentHistory(schemaVersions) })],
 }
 
 export const SingleVersion: Story = {
-  args: { versions: [{ ...baseAgent, revision: 1 }] },
+  decorators: [withRedux({ state: seed.studio.agentHistory([{ ...baseAgent, revision: 1 }]) })],
 }

--- a/apps/web/src/studio/features/agents/agent-history.middleware.ts
+++ b/apps/web/src/studio/features/agents/agent-history.middleware.ts
@@ -1,0 +1,16 @@
+import { createListenerMiddleware } from "@reduxjs/toolkit"
+import type { AppDispatch, RootState } from "@/common/store/types"
+import { listAgentHistory } from "@/studio/features/agents/agent-history.thunks"
+import { agentHistoryActions } from "./agent-history.slice"
+
+const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
+
+function registerListeners() {
+  listenerMiddleware.startListening({
+    actionCreator: agentHistoryActions.mount,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(listAgentHistory())
+    },
+  })
+}
+export const agentHistoryMiddleware = { listenerMiddleware, registerListeners }

--- a/apps/web/src/studio/features/agents/agent-history.slice.ts
+++ b/apps/web/src/studio/features/agents/agent-history.slice.ts
@@ -15,6 +15,8 @@ const slice = createSlice({
   name: "agentHistory",
   initialState,
   reducers: {
+    mount: () => {},
+    unmount: () => {},
     reset: () => initialState,
   },
   extraReducers: (builder) => {

--- a/apps/web/src/studio/features/agents/components/AgentSettingsFieldDiff.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSettingsFieldDiff.tsx
@@ -1,6 +1,17 @@
-import { parseDiffFromFile } from "@pierre/diffs"
+import { Skeleton } from "@caseai-connect/ui/shad/skeleton"
+import {
+  areLanguagesAttached,
+  areThemesAttached,
+  DEFAULT_THEMES,
+  getFiletypeFromFileName,
+  getThemes,
+  isHighlighterLoaded,
+  parseDiffFromFile,
+  preloadHighlighter,
+  type SupportedLanguages,
+} from "@pierre/diffs"
 import { FileDiff } from "@pierre/diffs/react"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { Agent } from "@/common/features/agents/agents.models"
 import {
@@ -19,6 +30,40 @@ function toDiffContents(value: string): string {
   return `${value}\n`
 }
 
+/**
+ * Gate the diff on the shared Shiki highlighter being fully loaded for `lang`.
+ *
+ * @pierre/diffs renders nothing on its first pass when the highlighter is not ready yet and
+ * leans on an async re-render to fill in. Under React StrictMode the component is mounted twice
+ * on the same node: the first (unready) pass leaves an empty `<pre>` in the shadow DOM, and the
+ * second mount hydrates from that empty node without ever rendering — so the diff stays blank
+ * until an interaction forces a fresh render. Waiting for the highlighter keeps the first render
+ * synchronous and non-empty, which sidesteps the whole race. The highlighter is a module-level
+ * singleton, so this only shows a placeholder for the very first diff of the session.
+ */
+function useHighlighterReady(lang: SupportedLanguages): boolean {
+  const [ready, setReady] = useState(
+    () => isHighlighterLoaded() && areThemesAttached(DEFAULT_THEMES) && areLanguagesAttached(lang),
+  )
+
+  useEffect(() => {
+    if (ready) return
+    let active = true
+    const markReady = () => {
+      if (active) setReady(true)
+    }
+    preloadHighlighter({ themes: getThemes(DEFAULT_THEMES), langs: [lang] }).then(
+      markReady,
+      markReady,
+    )
+    return () => {
+      active = false
+    }
+  }, [ready, lang])
+
+  return ready
+}
+
 /** Diff of a single versioned settings field between two revisions, rendered with @pierre/diffs. */
 export function AgentSettingsFieldDiff({
   fieldKey,
@@ -31,22 +76,28 @@ export function AgentSettingsFieldDiff({
 }) {
   const { t } = useTranslation()
 
+  const name = agentSettingsDiffFileNames[fieldKey]
+  const ready = useHighlighterReady(getFiletypeFromFileName(name))
+
   const fileDiff = useMemo(() => {
-    const name = agentSettingsDiffFileNames[fieldKey]
     return parseDiffFromFile(
       { name, contents: toDiffContents(serializeAgentSettingsField(before, fieldKey)) },
       { name, contents: toDiffContents(serializeAgentSettingsField(after, fieldKey)) },
     )
-  }, [fieldKey, before, after])
+  }, [name, fieldKey, before, after])
 
   return (
     <section className="space-y-2">
       <h4 className="text-sm font-medium">{t(agentSettingsDiffLabelKeys[fieldKey])}</h4>
       <div className="overflow-hidden rounded-md border">
-        <FileDiff
-          fileDiff={fileDiff}
-          options={{ diffStyle: "unified", disableFileHeader: true, overflow: "wrap" }}
-        />
+        {ready ? (
+          <FileDiff
+            fileDiff={fileDiff}
+            options={{ diffStyle: "unified", disableFileHeader: true, overflow: "wrap" }}
+          />
+        ) : (
+          <Skeleton className="h-16 w-full" />
+        )}
       </div>
     </section>
   )

--- a/apps/web/src/studio/features/agents/components/AgentVersionExplorer.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionExplorer.tsx
@@ -1,28 +1,47 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { Agent } from "@/common/features/agents/agents.models"
+import { useValue } from "@/common/hooks/use-value"
+import { selectAgentHistoryData } from "../agent-history.selectors"
 import { AgentVersionCompare, type AgentVersionCompareMode } from "./AgentVersionCompare"
 import { AgentVersionList } from "./AgentVersionList"
 
-/**
- * Two-pane version explorer: revision timeline on the left, comparison on the right.
- * `versions` comes from the history endpoint, ordered by revision descending (index 0 is
- * the current version).
- */
-export function AgentVersionExplorer({ versions }: { versions: Agent[] }) {
-  // Preselect the previous version: that is the one users open the history to inspect.
-  const [selectedRevision, setSelectedRevision] = useState<number | null>(null)
-  const [mode, setMode] = useState<AgentVersionCompareMode>("current")
+interface AgentVersionComparison {
+  /** The most recent version (`versions[0]`). */
+  current: Agent
+  /** The version highlighted in the timeline and shown in the diff. */
+  selected: Agent
+  /** The version immediately older than `selected`, if any. */
+  previous: Agent | undefined
+  isCurrent: boolean
+  canComparePrevious: boolean
+  canCompareCurrent: boolean
+  /** The requested `mode`, downgraded to whichever comparison is actually possible. */
+  effectiveMode: AgentVersionCompareMode
+  /** Older/newer versions fed to the diff, derived from `effectiveMode`. */
+  before: Agent
+  after: Agent
+}
 
+/**
+ * Resolve everything the two panes need from the raw version list plus the current UI state.
+ *
+ * `versions` is ordered by revision descending, so `versions[0]` is the current version and
+ * each following index is one step older. Returns `null` when there is no version to show.
+ */
+function buildComparison(
+  versions: Agent[],
+  selectedRevision: number | null,
+  mode: AgentVersionCompareMode,
+): AgentVersionComparison | null {
   const current = versions[0]
   if (!current) return null
 
-  const effectiveRevision =
-    (selectedRevision !== null && versions.some((version) => version.revision === selectedRevision)
-      ? selectedRevision
-      : null) ??
-    versions[1]?.revision ??
-    current.revision
-  const selectedIndex = versions.findIndex((version) => version.revision === effectiveRevision)
+  // Default to the previous version (index 1) — the one users open the history to inspect —
+  // until they pick another revision from the timeline. Clamp to the current version when it
+  // is the only one available.
+  const requestedIndex = versions.findIndex((version) => version.revision === selectedRevision)
+  const selectedIndex = requestedIndex === -1 ? Math.min(1, versions.length - 1) : requestedIndex
+
   const selected = versions[selectedIndex] ?? current
   const previous = versions[selectedIndex + 1]
 
@@ -30,13 +49,50 @@ export function AgentVersionExplorer({ versions }: { versions: Agent[] }) {
   const canComparePrevious = previous !== undefined
   const canCompareCurrent = !isCurrent
 
-  // Fall back to whichever comparison is possible when the requested one is not.
-  let effectiveMode: AgentVersionCompareMode = mode
+  // Honour the requested mode, but fall back to whichever comparison is possible.
+  let effectiveMode = mode
   if (mode === "current" && !canCompareCurrent) effectiveMode = "previous"
   if (mode === "previous" && !canComparePrevious) effectiveMode = "current"
 
   const [before, after] =
     effectiveMode === "current" ? [selected, current] : [previous ?? selected, selected]
+
+  return {
+    current,
+    selected,
+    previous,
+    isCurrent,
+    canComparePrevious,
+    canCompareCurrent,
+    effectiveMode,
+    before,
+    after,
+  }
+}
+
+/**
+ * Two-pane version explorer: revision timeline on the left, comparison on the right.
+ */
+export function AgentVersionExplorer() {
+  const versions = useValue(selectAgentHistoryData)
+  const [selectedRevision, setSelectedRevision] = useState<number | null>(null)
+  const [mode, setMode] = useState<AgentVersionCompareMode>("current")
+
+  const comparison = useMemo(
+    () => buildComparison(versions, selectedRevision, mode),
+    [versions, selectedRevision, mode],
+  )
+  if (!comparison) return null
+
+  const {
+    selected,
+    before,
+    after,
+    isCurrent,
+    effectiveMode,
+    canComparePrevious,
+    canCompareCurrent,
+  } = comparison
 
   return (
     <div className="flex min-h-0 flex-1">

--- a/apps/web/src/studio/features/agents/components/AgentVersionHistory.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentVersionHistory.tsx
@@ -1,4 +1,3 @@
-import { Alert, AlertDescription, AlertTitle } from "@caseai-connect/ui/shad/alert"
 import { Badge } from "@caseai-connect/ui/shad/badge"
 import { Button } from "@caseai-connect/ui/shad/button"
 import {
@@ -9,15 +8,15 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@caseai-connect/ui/shad/sheet"
-import { Skeleton } from "@caseai-connect/ui/shad/skeleton"
-import { AlertTriangleIcon, HistoryIcon } from "lucide-react"
+import { HistoryIcon } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { Agent } from "@/common/features/agents/agents.models"
-import { ADS } from "@/common/store/async-data-status"
-import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { useMount } from "@/common/hooks/use-mount"
+import { AsyncRoute } from "@/common/routes/AsyncRoute"
+import { useAppSelector } from "@/common/store/hooks"
 import { selectAgentHistoryData } from "../agent-history.selectors"
-import { listAgentHistory } from "../agent-history.thunks"
+import { agentHistoryActions } from "../agent-history.slice"
 import { AgentVersionExplorer } from "./AgentVersionExplorer"
 
 /**
@@ -26,13 +25,16 @@ import { AgentVersionExplorer } from "./AgentVersionExplorer"
  */
 export function AgentVersionHistory({ agent }: { agent: Agent }) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const [open, setOpen] = useState(false)
   const history = useAppSelector(selectAgentHistoryData)
 
+  useMount({
+    actions: agentHistoryActions,
+    refreshOn: [agent.id],
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen)
-    if (nextOpen) dispatch(listAgentHistory())
   }
 
   return (
@@ -52,21 +54,9 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
           </SheetDescription>
         </SheetHeader>
 
-        {ADS.isFulfilled(history) ? (
-          <AgentVersionExplorer versions={history.value} />
-        ) : ADS.isError(history) ? (
-          <Alert variant="destructive" className="m-4 w-auto">
-            <AlertTriangleIcon className="size-4" />
-            <AlertTitle>{t("agent:history.loadError")}</AlertTitle>
-            <AlertDescription>{history.error}</AlertDescription>
-          </Alert>
-        ) : (
-          <div className="space-y-3 p-4">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-          </div>
-        )}
+        <AsyncRoute data={[history]}>
+          <AgentVersionExplorer />
+        </AsyncRoute>
       </SheetContent>
     </Sheet>
   )

--- a/apps/web/src/studio/store/slices.ts
+++ b/apps/web/src/studio/store/slices.ts
@@ -34,6 +34,7 @@ import { projectMembershipsSlice } from "@/studio/features/project-memberships/p
 import { reviewCampaignsMiddleware } from "@/studio/features/review-campaigns/review-campaigns.middleware"
 import { reviewCampaignsSlice } from "@/studio/features/review-campaigns/review-campaigns.slice"
 import { createSliceManager } from "../../common/store/dynamic-middleware"
+import { agentHistoryMiddleware } from "../features/agents/agent-history.middleware"
 import { agentHistorySlice } from "../features/agents/agent-history.slice"
 import { studioAgentsMiddleware } from "../features/agents/agents.middleware"
 import { documentsMiddleware } from "../features/documents/documents.middleware"
@@ -49,6 +50,7 @@ const studioMiddlewareList = [
   agentAnalyticsMiddleware,
   agentCsvExtractionRunsMiddleware,
   agentEmbedConfigsMiddleware,
+  agentHistoryMiddleware,
   agentMembershipsMiddleware,
   agentMessageFeedbackMiddleware,
   agentsMiddleware,
@@ -63,8 +65,8 @@ const studioMiddlewareList = [
   formAgentSessionsMiddleware,
   projectAnalyticsMiddleware,
   projectMembershipsMiddleware,
-  reviewCampaignsMiddleware,
   resourceLibrariesMiddleware,
+  reviewCampaignsMiddleware,
   reviewCampaignsReportsMiddleware,
   studioAgentsMiddleware,
   studioProjectsMiddleware,
@@ -77,9 +79,9 @@ export const studioSliceList = [
   agentHistorySlice,
   agentMembershipsSlice,
   agentMessageFeedbackSlice,
-  agentSubAgentsSlice,
   agentSessionMessagesSlice,
   agentsSlice,
+  agentSubAgentsSlice,
   conversationAgentSessionsSlice,
   currentIdsSlice,
   documentsSlice,


### PR DESCRIPTION
## Summary

The agent version-history panel showed a blank diff on first open, only rendering after the user interacted (switching compare mode or selecting another version).

**Root cause** — a React StrictMode double-mount race in `@pierre/diffs`:
1. On first open the shared Shiki highlighter isn't loaded yet, so `FileDiff`'s first render produces an empty `<pre>` and defers to an async highlight callback.
2. StrictMode unmounts and remounts on the same DOM node; since `FileDiff` is container-managed, the empty `<pre>` is left behind.
3. The remounted instance sees a non-null `<pre>`, takes the hydrate-from-existing-DOM path, and never renders — leaving the panel blank until an interaction forces a fresh render.

**Fix** — gate `FileDiff` behind a `useHighlighterReady(lang)` hook that preloads the highlighter (language + default themes), showing a skeleton until ready. With the highlighter loaded, the first render is synchronous and non-empty, so the StrictMode remount hydrates from populated DOM. The highlighter is a module-level singleton, so the skeleton only appears for the very first diff of a session.

Also included:
- Wires agent version-history data loading through `useMount` + listener middleware + `AsyncRoute` (per the web data-loading ADR).
- Reseeds the Storybook story from Redux now that `AgentVersionExplorer` reads from the store instead of a `versions` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)