### PR TITLE
fix(i18n): translate resource library picker strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- French UI: the "Add library" button on an agent's Resources tab is now translated
 
 ### Security
 

--- a/apps/web/src/studio/features/resource-libraries/components/ResourceLibraryPicker.tsx
+++ b/apps/web/src/studio/features/resource-libraries/components/ResourceLibraryPicker.tsx
@@ -10,6 +10,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@caseai-connect/ui/shad/popover"
 import { PlusIcon } from "lucide-react"
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import type { ResourceLibrary } from "../resource-libraries.models"
 
 export function ResourceLibraryPicker({
@@ -21,6 +22,7 @@ export function ResourceLibraryPicker({
   attachedLibraryIds: string[]
   onAdd: (resourceLibraryId: string) => void
 }) {
+  const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState("")
 
@@ -42,18 +44,20 @@ export function ResourceLibraryPicker({
       <PopoverTrigger asChild>
         <Button type="button" variant="outline" size="sm" className="gap-1">
           <PlusIcon className="size-3" />
-          Add library
+          {t("resourceLibrary:picker.addLibrary")}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput
-            placeholder="Search libraries..."
+            placeholder={t("resourceLibrary:picker.searchPlaceholder")}
             value={search}
             onValueChange={setSearch}
           />
           <CommandList>
-            {filteredLibraries.length === 0 && <CommandEmpty>No libraries found</CommandEmpty>}
+            {filteredLibraries.length === 0 && (
+              <CommandEmpty>{t("resourceLibrary:picker.noResults")}</CommandEmpty>
+            )}
             {filteredLibraries.length > 0 && (
               <CommandGroup>
                 {filteredLibraries.map((library) => (

--- a/apps/web/src/studio/features/resource-libraries/locales/resource-library.en.json
+++ b/apps/web/src/studio/features/resource-libraries/locales/resource-library.en.json
@@ -57,6 +57,11 @@
     "agentTab": {
       "label": "Resource libraries",
       "description": "The assistant can surface resources from the selected libraries when a user's request matches a resource's title or description."
+    },
+    "picker": {
+      "addLibrary": "Add library",
+      "searchPlaceholder": "Search libraries...",
+      "noResults": "No libraries found"
     }
   }
 }

--- a/apps/web/src/studio/features/resource-libraries/locales/resource-library.fr.json
+++ b/apps/web/src/studio/features/resource-libraries/locales/resource-library.fr.json
@@ -57,6 +57,11 @@
     "agentTab": {
       "label": "Bibliothèques de ressources",
       "description": "L'assistant peut proposer des ressources des bibliothèques sélectionnées lorsqu'une demande de l'utilisateur correspond au titre ou à la description d'une ressource."
+    },
+    "picker": {
+      "addLibrary": "Ajouter une bibliothèque",
+      "searchPlaceholder": "Rechercher des bibliothèques...",
+      "noResults": "Aucune bibliothèque trouvée"
     }
   }
 }


### PR DESCRIPTION
## Summary
On an agent's **Resources** tab, the `ResourceLibraryPicker` popover had hardcoded English strings with no i18n, so the **"Add library"** button (and the picker's search placeholder / empty-state) stayed English in the French UI.

- Added a `picker` section to the resource-library `en`/`fr` locale files (`Add library` → `Ajouter une bibliothèque`, plus search placeholder and no-results text).
- Wired `useTranslation()` through `ResourceLibraryPicker.tsx`.

The Resources **tab label** itself was already translated on `main` (commit ce341516, `agent:tabs.resourceLibraries` = "Bibliothèques de ressources") — the original screenshot predated that fix, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)