### PR TITLE
fix(document-tags): make tags management list scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Tags management panel: the tag list scrolls, so long or nested tag lists stay reachable
 
 ### Security
 

--- a/apps/web/src/studio/features/document-tags/components/DocumentTagsSheet.tsx
+++ b/apps/web/src/studio/features/document-tags/components/DocumentTagsSheet.tsx
@@ -33,16 +33,18 @@ export function DocumentTagsSheet({ documentTags }: { documentTags: DocumentTag[
         <SheetHeader>
           <SheetTitle>{t("sheet.title")}</SheetTitle>
         </SheetHeader>
-        <div className="flex flex-col gap-3 px-4 pb-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4">
           <div className="flex justify-end">
             <DocumentTagCreator allTags={documentTags} />
           </div>
           {documentTags.length === 0 ? (
             <p className="text-sm text-muted-foreground">{t("sheet.empty")}</p>
           ) : (
-            tagTree.map((tag) => (
-              <DocumentTagSheetNode key={tag.id} tag={tag} allTags={documentTags} />
-            ))
+            <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+              {tagTree.map((tag) => (
+                <DocumentTagSheetNode key={tag.id} tag={tag} allTags={documentTags} />
+              ))}
+            </div>
           )}
         </div>
       </SheetContent>


### PR DESCRIPTION
## Summary
The Étiquettes (tags) management panel could not be scrolled — long or nested tag lists overflowed the fixed-height Sheet, leaving lower items unreachable.

The tag list now lives in a `min-h-0 flex-1 overflow-y-auto` container so it scrolls independently, while the "Create tag" button stays pinned at the top. Uses the same scroll pattern already used elsewhere in the app.