### PR TITLE
fix(resource-libraries): limit resource link upload to a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Renaming an agent no longer creates an extra settings version in the agent's history
 - Tags management panel: the tag list scrolls, so long or nested tag lists stay reachable
 - French UI: the "Add library" button on an agent's Resources tab is now translated
+- Resource library link field accepts only a single file upload
 
 ### Security
 

--- a/apps/web/src/studio/features/resource-libraries/components/ResourceLinkField.tsx
+++ b/apps/web/src/studio/features/resource-libraries/components/ResourceLinkField.tsx
@@ -62,7 +62,8 @@ export function ResourceLinkField({
         <div className="flex items-center gap-3">
           <FileUploader
             allowedMimeTypes={allowedDocumentUploadMimeTypesForFileUploader}
-            maxSize={25 * 1024 * 1024}
+            maxSize={25 * 1024 * 1024} // 25MB
+            maxFiles={1}
             onProcessFiles={handleUpload}
           />
           {resource.file && (


### PR DESCRIPTION
## Summary

- Pass `maxFiles={1}` explicitly to the `FileUploader` in `ResourceLinkField` so a resource link accepts only one file.
- Document the `25MB` size limit inline for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)