### PR TITLE
fix(extraction): live-update run page on cancel and cap uploads at 25 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - (beta) Evaluations: conversation-agent evaluation moved from the Studio into the Evaluation app — build datasets of input/expected-output records (add them inline one after another or paste a batch as CSV), run them against a chosen version of an agent's settings in the background, and follow each run's scores (rated 0–5 by an LLM judge whose model you pick per run) live on its own report page; the run's "view agent" panel shows the exact settings version that was scored, and existing Studio evaluations are migrated into a "Studio evaluations" dataset per project
 
 ### Fixed
+- Extraction runs: the run page updates live after cancelling a run, and refreshes when switching runs
+- Extraction document uploads are capped at 25 MB, with files over the limit rejected upfront
 - (beta) Evaluations: conversation and extraction runs now execute the agent exactly as the Studio does — same master prompt and same tools (document retrieval, sources, resource libraries, MCP servers, sub-agents) — so evaluation scores reflect the agent's real behaviour; previously evaluated agents ran with a legacy prompt and no tools at all
 - (beta) Evaluations: cancelling and retrying conversation-evaluation runs is now reliable — a cancelled run can no longer restart itself, a failed retry no longer leaves records stuck, and the run page updates live after a retry instead of freezing on "pending"
 - Renaming an agent no longer creates an extra settings version in the agent's history

--- a/apps/api/src/domains/agents/agent.entity.ts
+++ b/apps/api/src/domains/agents/agent.entity.ts
@@ -29,6 +29,7 @@ export class Agent extends ConnectEntityBase {
   @Column({ type: "varchar", default: "conversation" })
   type!: AgentType
 
+  // NOTE: We kept this because the agentSettingsId is linked on the Message, not the session. (specific case for public chat bot)
   @OneToMany(
     () => ConversationAgentSession,
     (conversationAgentSession) => conversationAgentSession.agent,

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-processor.service.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-processor.service.ts
@@ -222,7 +222,9 @@ export class AgentCsvExtractionRunProcessorService {
     id: string
     connectScope: RequiredConnectScope
   }): Promise<AgentCsvExtractionRun> {
-    const run = await this.runConnectRepository.getOneById(connectScope, id)
+    const run = await this.runConnectRepository.getOneById(connectScope, id, {
+      relations: ["agentSettings"],
+    })
     if (!run) {
       throw new NotFoundException(`Agent CSV run with id ${id} not found`)
     }
@@ -294,7 +296,7 @@ export class AgentCsvExtractionRunProcessorService {
       agentCsvExtractionRunId: agentCsvExtractionRun.id,
       organizationId: agentCsvExtractionRun.organizationId,
       projectId: agentCsvExtractionRun.projectId,
-      agentSettingsId: agentCsvExtractionRun.agentSettingsId,
+      agentId: agentCsvExtractionRun.agentSettings.agentId,
       status: agentCsvExtractionRun.status,
       summary: agentCsvExtractionRun.summary,
       updatedAt: agentCsvExtractionRun.updatedAt.getTime(),

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-status-notifier.service.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-status-notifier.service.ts
@@ -18,7 +18,7 @@ export class AgentCsvExtractionRunStatusNotifierService extends PostgresStatusNo
     agentCsvExtractionRunId: string
     organizationId: string
     projectId: string
-    agentSettingsId: string
+    agentId: string
     status: AgentCsvExtractionRunStatusDto
     summary: AgentCsvExtractionRunSummaryDto | null
     updatedAt: number
@@ -28,7 +28,7 @@ export class AgentCsvExtractionRunStatusNotifierService extends PostgresStatusNo
       agentCsvExtractionRunId: params.agentCsvExtractionRunId,
       organizationId: params.organizationId,
       projectId: params.projectId,
-      agentSettingsId: params.agentSettingsId,
+      agentId: params.agentId,
       status: params.status,
       summary: params.summary,
       updatedAt: params.updatedAt,

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
@@ -153,8 +153,8 @@ export class AgentCsvExtractionRunsController {
     const connectScope = getRequiredConnectScope(request)
     const agentCsvExtractionRunId = request.agentCsvExtractionRun.id
 
-    //remove pending asap - do not wait for completion, continue in parallel
-    const removePendingJobsForRunDone = this.agentCsvExtractionRunsService.removePendingJobsForRun({
+    // NOTE: Do not await -> shoot and forget -> no db transaction, it just kills workers jobs
+    this.agentCsvExtractionRunsService.removePendingJobsForRun({
       agentCsvExtractionRunId,
       connectScope,
     })
@@ -174,17 +174,14 @@ export class AgentCsvExtractionRunsController {
     }
 
     await this.statusNotifierService.notifyRunStatusChanged({
-      agentCsvExtractionRunId: run.id,
+      agentCsvExtractionRunId,
       organizationId: run.organizationId,
       projectId: run.projectId,
-      agentSettingsId: run.agentSettingsId,
+      agentId: run.agentSettings.agentId,
       status: run.status,
       summary: run.summary,
       updatedAt: run.updatedAt.getTime(),
     })
-
-    //wait completion
-    await removePendingJobsForRunDone
 
     return { data: toAgentCsvExtractionRunDto(run) }
   }

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
@@ -153,8 +153,7 @@ export class AgentCsvExtractionRunsController {
     const connectScope = getRequiredConnectScope(request)
     const agentCsvExtractionRunId = request.agentCsvExtractionRun.id
 
-    // NOTE: Do not await -> shoot and forget -> no db transaction, it just kills workers jobs
-    this.agentCsvExtractionRunsService.removePendingJobsForRun({
+    await this.agentCsvExtractionRunsService.removePendingJobsForRun({
       agentCsvExtractionRunId,
       connectScope,
     })

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.service.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.service.ts
@@ -248,18 +248,11 @@ export class AgentCsvExtractionRunsService {
 
     const batches = batchArray(unfinishedRecords, BATCH_SIZE)
 
-    try {
-      await Promise.all(
-        batches.map(
-          async (batch) =>
-            await this.batchService.removePendingRunRecords(batch.map((runRecord) => runRecord.id)),
-        ),
-      )
-    } catch (error) {
-      throw new UnprocessableEntityException(
-        `Failed to remove pending jobs for run ${agentCsvExtractionRunId}. Error: ${error instanceof Error ? error.message : "No error message"}`,
-      )
-    }
+    // NOTE: Do not await -> shoot and forget -> it just kills workers jobs and nobody cares if it fails, the run will be marked as cancelled anyway
+    batches.map(
+      async (batch) =>
+        await this.batchService.removePendingRunRecords(batch.map((runRecord) => runRecord.id)),
+    )
   }
 
   async deleteRun({

--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.service.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.service.ts
@@ -104,7 +104,14 @@ export class AgentCsvExtractionRunsService {
       fields: { status: "cancelled" },
     })
 
-    return this.runConnectRepository.saveOne(agentCsvExtractionRun)
+    await this.runConnectRepository.saveOne(agentCsvExtractionRun)
+    const run = await this.runConnectRepository.getOneById(connectScope, agentCsvExtractionRun.id, {
+      relations: ["agentSettings"],
+    })
+    if (!run) {
+      throw new NotFoundException(`Agent CSV run with id ${agentCsvExtractionRun.id} not found`)
+    }
+    return run
   }
 
   async enqueueExecuteRun({

--- a/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
@@ -37,7 +37,11 @@ export function AgentCsvExtractionRunRoute() {
     return () => setOpen(true)
   }, [setOpen])
 
-  useMount({ actions: agentCsvExtractionRunsActions, condition: !!runId && !open })
+  useMount({
+    actions: agentCsvExtractionRunsActions,
+    condition: !!runId && !open,
+    refreshOn: [runId],
+  })
 
   if (!runId) return <LoadingRoute />
   return (

--- a/apps/web/src/common/routes/agents/extraction/AgentExtractionRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentExtractionRoute.tsx
@@ -134,6 +134,7 @@ function FileManager({
         action={
           <FileUploader
             maxFiles={1}
+            maxSize={25 * 1024 * 1024} // 25 MB
             allowedMimeTypes={{
               "application/pdf": true,
               "image/jpeg": true,


### PR DESCRIPTION
## Summary
- Extraction run page updates live after cancelling a run: status change is notified by `agentId` (loading the `agentSettings` relation on the cancelled run), and the run route refreshes when switching between runs.
- Pending batch jobs are removed on cancel via a fire-and-forget call inside the service (records are still `running` when the removal is dispatched, before `markRunCancelled` flips them), so cancel no longer blocks on worker-job cleanup and a failure there doesn't fail the request.
- Extraction document uploads are capped at 25 MB, rejecting oversized files upfront.