### PR TITLE
docs(help): add MCP servers + message feedback guides and feature-flag callouts

### DIFF
--- a/apps/help/CLAUDE.md
+++ b/apps/help/CLAUDE.md
@@ -63,6 +63,9 @@ detail. Everything here was learned the hard way — don't skip a step.
    no step omitted** (§Writing style → Level of detail): from the entry point to the
    final result, every screen/dialog/tab/field/label in bold verbatim, serving end
    users *and* AI agents. If it's not in the guide, the AI cannot answer it.
+   **If the feature is feature-flagged, add the flag callout** (§Feature-flag
+   callout) — a blockquote in both EN + FR telling the reader the feature is optional
+   and how to get it enabled.
 8. **Verify — the gate** (§Fidelity Phase 5, §Validate): `astro build` **and**
    `astro check` at 0 errors; grep the built HTML for **every** tab/label; **diff the
    tab set (count + order) against the component**; confirm the pages render.
@@ -147,8 +150,9 @@ platform palette (coral `--primary`, neutral greys) on its **own scoped root cla
 (`.msw` / `.anw` / `.caw` / …), so the site-wide Bayes beige/gold rebrand never leaks
 in — the animation must look like **apps/web / `packages/ui`** Studio, NOT the brand
 DA. Do NOT restyle animations to beige/gold, and do NOT mix in a different form:
-every widget shares the same shell (208px sidebar, 680px height), controls,
-`DUR = 6000`, and mechanics (see "Consistency" below). A one-off that uses global
+every widget shares the same shell (208px sidebar, 680px height — save the non-Studio
+exception in §Walkthrough component spec), controls, `DUR = 6000`, and mechanics (see
+"Consistency" below). A one-off that uses global
 tokens or the real component markup will clash with the other guides — don't.
 
 ---
@@ -337,6 +341,52 @@ FR headings are fixed translations: `## Le parcours complet en un coup d'œil`,
 `## Étape par étape`, `## Conseils`, `## Dépannage`. The concept heading is
 feature-specific (e.g. `## Comment les agents utilisent les documents`).
 
+**Extra `##` sections are allowed, additively.** Beyond this spine a guide MAY add
+feature-specific sections when the feature has real content that doesn't fit the
+canonical ones: one or more extra **concept** `##` *before* the walkthrough (as in
+apps-overview), and/or feature sections *after* `## Step by step` and before
+`## Tips` (e.g. `## Version history`, `## What happens at runtime`). Extras must carry
+genuine content (not padding), be mirrored EN + FR, and **never reorder, rename, or
+replace a canonical section**.
+
+## Feature-flag callout (MANDATORY when the feature is flagged)
+
+Some features only render when a **feature flag** is enabled on the project — the
+Phase-1 render inventory records this (§Fidelity Phase 1). Flags live in `apps/web`:
+grep `feature="<key>"` and `hasFeature("<key>")` (e.g. in `StudioRoutes.tsx`,
+`SidebarFooterChildren.tsx`, `AgentEditor.tsx`, the `*Button.tsx` gates). Known
+flags that gate a documented feature: `web-sources`, `project-analytics`,
+`evaluation` (Evaluations **and** Evaluation dashboard), `agent-orchestration`,
+`agent-embed`, `agent-mcp`.
+
+If the guide's feature is behind a flag, you **MUST** add a **blockquote callout**
+right after the intro/placement paragraph (before the first `##` heading, or before
+any existing disambiguation blockquote), in **both** EN and FR. It states the feature
+is optional and how to get it enabled — flags are set platform-side, so the reader
+must ask the Bayes team (a workspace admin cannot toggle them). Tailor the "if you
+don't see it" locator to the feature (sidebar item / workspace-card button / editor
+tab), and reuse the exact bold label from the locales.
+
+Templates (adapt the feature name + locator, keep the form byte-consistent):
+
+```
+> **Optional feature — ask to have it enabled.** <Feature> is turned on per
+> workspace. If you don't see <exact bold locator> in Studio, the feature isn't
+> enabled for your workspace yet — contact the Bayes team to request it.
+```
+```
+> **Fonctionnalité optionnelle — à faire activer.** <Fonctionnalité> s'active espace
+> de travail par espace de travail. Si vous ne voyez pas <repère exact en gras> dans
+> Studio, c'est que la fonctionnalité n'est pas encore activée pour votre espace de
+> travail — contactez l'équipe Bayes pour en faire la demande.
+```
+
+When the guide's intro already says "It's an optional feature", keep that sentence
+and still add the callout — the sentence states the fact, the callout states the
+**action** (how to get it turned on). Shorten the callout's opening to
+**`> **Ask to have it enabled.**`** / **`> **À faire activer.**`** in that case to
+avoid repeating "optional".
+
 ## Guide categories (a `guides` parent with nested sub-categories)
 
 Categories form a **two-level tree** (`src/i18n/categories.ts`): a top-level
@@ -382,9 +432,14 @@ Therefore:
   action. If clicking something opens a dialog, the dialog is its own step. If a page
   has three tabs, all three are covered. "Obvious" intermediate steps are still
   written — the AI agent and the first-time user do not find them obvious.
-- **One numbered `### n` sub-section per discrete action or screen**, matching the
-  walkthrough steps 1:1 (see §Deriving the flow & cutting the steps). A screen shown
-  in the animation with no matching prose section is a gap to fix.
+- **Numbered `### n` sub-sections track the walkthrough steps — 1:1 by default.**
+  You MAY fold a short run of *adjacent, closely-related* animation steps (e.g. the
+  `⋮` row menu + bulk-select + select-all) into one numbered step — but only when the
+  fold drops **no** content: every action, screen, dialog and label those steps show
+  must still appear, in bold, in that step's prose. Never the reverse: a paragraph
+  must not describe a screen the animation doesn't show, and no animated action may be
+  left undocumented. A screen shown in the animation whose content appears in **no**
+  prose step is a gap to fix.
 - **Every on-screen label appears verbatim and in bold** — buttons, tabs, fields,
   menu items, empty-state text, status badges, validation messages — in both EN and
   FR, taken from the locale files (§Fidelity Phase 2). Never paraphrase a label.
@@ -425,6 +480,13 @@ not, a step or label is missing.
 - **Shell** (platform `variant="inset"`): `grid-template-columns: 208px 1fr;
   height: 680px`. Left sidebar (see below) + inset card (`.inset`) with a top bar
   (`panel-left` toggle) + dotted `.canvas` + a coral `.fab`.
+  - **Exception — non-Studio surfaces.** A walkthrough for a screen that isn't inside
+    the Studio sidebar layout — the app launcher, login/onboarding, and the full-page
+    Evaluation / Test / Review dashboards — MAY drop the 208px sidebar and use its own
+    `.frame` layout. It MUST still keep the **680px height** and every other shared
+    element (controls, `DUR = 6000`, spot/observe mechanics, coral palette). This
+    exception is limited to genuinely non-Studio views; **every walkthrough of a
+    Studio page keeps the `208px 1fr` / 680px shell.**
 - **Controls**: **Prev / Next** buttons + `Step X / N` counter + clickable dots +
   play/pause + a progress bar. `const DUR = 6000` (the `progress i.run` CSS
   `var(--dur, 6000ms)` default MUST match).
@@ -485,8 +547,11 @@ tags (button) `tags` · single tag `tag` · external link `external-link` · che
 All guides share the **exact same form**, only content differs: the MDX `##`
 skeleton, the component shell (208px sidebar, 680px height), controls, `DUR = 6000`,
 highlight mechanics, theme handling, terminology, and sample identity must be
-byte-for-byte consistent with the existing guides. When adding one, diff its
-skeleton and its `DUR`/`grid-template-columns` against the siblings.
+byte-for-byte consistent with the existing guides — save the three documented
+exceptions: the **non-Studio shell** (§Walkthrough component spec), **additive extra
+`##` sections** (§MDX skeleton), and **step folding** (§Writing style → Level of
+detail). When adding one, diff its skeleton and its `DUR`/`grid-template-columns`
+against the siblings.
 
 ## Validate (Astro build; `npx` is NOT on PATH)
 

--- a/apps/help/src/components/AppsOverviewWalkthrough.astro
+++ b/apps/help/src/components/AppsOverviewWalkthrough.astro
@@ -168,7 +168,7 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
   .aow * { box-sizing: border-box; }
   .aow svg { width: 1em; height: 1em; stroke: currentColor; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; flex-shrink: 0; display: inline-block; vertical-align: middle; }
 
-  .aow .frame { display: flex; flex-direction: column; height: 560px; background: var(--background); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
+  .aow .frame { display: flex; flex-direction: column; height: 680px; background: var(--background); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
   .aow .nav { height: 4rem; flex-shrink: 0; background: var(--background); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 0.6rem; padding: 0 1rem; }
   .aow .logo { width: 2rem; height: 2rem; display: inline-flex; align-items: center; justify-content: center; padding: 0.15rem; }
   .aow .logo svg { width: 100%; height: 100%; stroke: none; }
@@ -213,7 +213,7 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
   @keyframes aow-fill { to { width: 100%; } }
 
   @media (max-width: 640px) {
-    .aow .frame { height: 520px; }
+    .aow .frame { height: 560px; }
     .aow .panel { padding: 1rem; }
   }
   @media (prefers-reduced-motion: reduce) {

--- a/apps/help/src/components/McpServersWalkthrough.astro
+++ b/apps/help/src/components/McpServersWalkthrough.astro
@@ -1,0 +1,501 @@
+---
+/**
+ * Walkthrough of MCP Servers (connecting external tool servers to a workspace and
+ * enabling them per agent). Derived from the real components (verified, not copied
+ * blind): SidebarFooterChildren.tsx (NavMcpServers, ServerIcon, sibling of Sources/
+ * Members/Admin, flag `agent-mcp`), StudioRoutes.tsx (McpServersRoute),
+ * McpServersList.tsx (empty state + New Server + GridCard), McpServerItem.tsx
+ * (name + url + delete Trash2Icon, NO edit/overflow), CreateMcpServerDialog.tsx
+ * (Name / URL / API Key fields; url placeholder hardcoded https://mcp.example.com),
+ * AgentEditor.tsx (MCP Servers tab is LAST, shown when flag `agent-mcp` &&
+ * projectMcpServers.length > 0), AgentMcpServersTab.tsx (per-agent Switch +
+ * "Manage servers" ExternalLinkIcon link). Labels verbatim from the mcp-servers /
+ * agent / actions locales (EN + FR); "project" in the mcpServers:description /
+ * create.description strings is rendered as "workspace"/"espace de travail" to keep
+ * the help center's workspace terminology. Uses the PRODUCT (coral) palette, pinned
+ * locally. Derived 2026-07-21.
+ */
+type Lang = "en" | "fr"
+const { lang = "en" } = Astro.props as { lang?: Lang }
+
+const STRINGS = {
+  en: {
+    org: "Bayes Impact Demo", studio: "Studio", agents: "Agents",
+    agent1: "Helpful Assistant", conversationAgent: "Conversation Agent", extractionAgent: "Extraction Agent",
+    settingsName: "Demo", settings: "Settings", evaluations: "Evaluations", analytics: "Analytics", sources: "Sources",
+    mcpServers: "MCP Servers", members: "Members", admin: "Admin",
+    userName: "Alex Martin", userEmail: "alex.martin@example.com",
+    workspace: "Workspace", conversation: "Conversation", extraction: "Extraction",
+    pageTitle: "MCP Servers",
+    pageDesc: "Manage external tool servers connected to this workspace.",
+    empty: "No MCP servers configured yet. Add one to give your agents access to external tools.",
+    newServer: "New Server",
+    createTitle: "Add MCP Server", createDesc: "Connect an external MCP server to this workspace.",
+    fldName: "Name", namePh: "Enter server name",
+    fldUrl: "URL", urlPh: "https://mcp.example.com",
+    fldApiKey: "API Key", apiKeyPh: "Optional authentication key",
+    cancel: "Cancel", create: "Create", del: "Delete",
+    serverName: "Example Tools", serverUrl: "https://mcp.example.com",
+    server2: "Search Tools", server2Url: "https://search.example.com",
+    deleteTitle: "Delete MCP Server",
+    deleteDesc: "Are you sure you want to delete “Example Tools”? Agents using this server will lose access to its tools.",
+    editTitle: "Edit Conversation Agent", editDesc: "Edit details for this conversation agent",
+    tabGeneral: "General", tabModel: "Model", tabSources: "Sources", tabResources: "Resource libraries",
+    tabCategories: "Conversation categories", tabOrchestration: "Orchestration", tabEmbed: "Embed", tabMcp: "MCP Servers",
+    tabHeader: "MCP Servers", manage: "Manage servers",
+    prev: "Prev", next: "Next", step: "Step",
+    steps: [
+      "In Studio, open MCP Servers in the left sidebar.",
+      "The page lists your servers. Click New Server to connect one.",
+      "In Add MCP Server, enter a Name and the server URL, plus an optional API Key, then click Create.",
+      "The server appears as a card showing its name and URL.",
+      "Remove a server with the trash icon on its card.",
+      "Confirm in Delete MCP Server — agents using it lose access to its tools.",
+      "To let an agent use a server, open a conversation agent to edit it.",
+      "Open the MCP Servers tab — it appears once the workspace has at least one server.",
+      "Toggle a server on to give this agent access to its tools; toggle it off to remove access.",
+      "Use Manage servers to jump back to the workspace's MCP Servers page.",
+    ],
+  },
+  fr: {
+    org: "Bayes Impact Demo", studio: "Studio", agents: "Agents",
+    agent1: "Helpful Assistant", conversationAgent: "Conversation Agent", extractionAgent: "Extraction Agent",
+    settingsName: "Demo", settings: "Paramètres", evaluations: "Évaluations", analytics: "Analytique", sources: "Sources",
+    mcpServers: "Serveurs MCP", members: "Membres", admin: "Admin",
+    userName: "Alex Martin", userEmail: "alex.martin@example.com",
+    workspace: "Espace de travail", conversation: "Conversation", extraction: "Extraction",
+    pageTitle: "Serveurs MCP",
+    pageDesc: "Gérer les serveurs d'outils externes connectés à cet espace de travail.",
+    empty: "Aucun serveur MCP configuré. Ajoutez-en un pour donner à vos agents accès à des outils externes.",
+    newServer: "Nouveau serveur",
+    createTitle: "Ajouter un serveur MCP", createDesc: "Connecter un serveur MCP externe à cet espace de travail.",
+    fldName: "Nom", namePh: "Entrez le nom du serveur",
+    fldUrl: "URL", urlPh: "https://mcp.example.com",
+    fldApiKey: "Clé API", apiKeyPh: "Clé d'authentification optionnelle",
+    cancel: "Annuler", create: "Créer", del: "Supprimer",
+    serverName: "Example Tools", serverUrl: "https://mcp.example.com",
+    server2: "Search Tools", server2Url: "https://search.example.com",
+    deleteTitle: "Supprimer le serveur MCP",
+    deleteDesc: "Êtes-vous sûr de vouloir supprimer « Example Tools » ? Les agents utilisant ce serveur perdront l'accès à ses outils.",
+    editTitle: "Modifier l'agent conversationnel", editDesc: "Modifier les détails de cet agent conversationnel",
+    tabGeneral: "Général", tabModel: "Modèle", tabSources: "Sources", tabResources: "Bibliothèques de ressources",
+    tabCategories: "Catégories de conversation", tabOrchestration: "Orchestration", tabEmbed: "Intégration", tabMcp: "Serveurs MCP",
+    tabHeader: "Serveurs MCP", manage: "Gérer les serveurs",
+    prev: "Précédent", next: "Suivant", step: "Étape",
+    steps: [
+      "Dans Studio, ouvrez Serveurs MCP dans le menu de gauche.",
+      "La page liste vos serveurs. Cliquez sur Nouveau serveur pour en connecter un.",
+      "Dans Ajouter un serveur MCP, saisissez un Nom et l'URL du serveur, plus une Clé API facultative, puis cliquez sur Créer.",
+      "Le serveur apparaît sous forme de carte affichant son nom et son URL.",
+      "Supprimez un serveur avec l'icône corbeille sur sa carte.",
+      "Confirmez dans Supprimer le serveur MCP — les agents qui l'utilisent perdent l'accès à ses outils.",
+      "Pour qu'un agent utilise un serveur, ouvrez un agent conversationnel pour le modifier.",
+      "Ouvrez l'onglet Serveurs MCP — il apparaît dès que l'espace de travail a au moins un serveur.",
+      "Basculez un serveur pour donner à cet agent l'accès à ses outils, ou désactivez-le pour retirer l'accès.",
+      "Utilisez Gérer les serveurs pour revenir à la page Serveurs MCP de l'espace de travail.",
+    ],
+  },
+} as const
+
+const s = STRINGS[lang]
+
+const TABS = [
+  { key: "general", label: s.tabGeneral },
+  { key: "model", label: s.tabModel },
+  { key: "sources", label: s.tabSources },
+  { key: "resources", label: s.tabResources },
+  { key: "categories", label: s.tabCategories },
+  { key: "orchestration", label: s.tabOrchestration },
+  { key: "embed", label: s.tabEmbed },
+  { key: "mcp", label: s.tabMcp },
+]
+
+const convIcon = '<path d="M12 6V2H8"/><path d="m8 18-4 4V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2Z"/><path d="M9 11v2"/><path d="M15 11v2"/>'
+const extractIcon = '<path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><path d="M7 8h8"/><path d="M7 12h10"/><path d="M7 16h6"/>'
+const serverIcon = '<rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/>'
+
+const steps = [
+  { page: "overview", nav: "", spot: "navMcp", observe: [] },
+  { page: "mcpEmpty", nav: "mcp", spot: "btnNew", observe: [] },
+  { page: "createDialog", nav: "mcp", spot: "btnCreate", observe: ["obsFields"] },
+  { page: "mcpGrid", nav: "mcp", spot: "", observe: ["obsCard"] },
+  { page: "mcpGrid", nav: "mcp", spot: "rowDelete", observe: [] },
+  { page: "deleteDialog", nav: "mcp", spot: "", observe: ["obsConfirm"] },
+  { page: "overview", nav: "", spot: "navAgent1", observe: [] },
+  { page: "mcpTab", nav: "agent", spot: "tab-mcp", observe: [] },
+  { page: "mcpTab", nav: "agent", spot: "", observe: ["obsToggle"] },
+  { page: "mcpTab", nav: "agent", spot: "linkManage", observe: [] },
+].map((step, i) => ({ ...step, text: s.steps[i] }))
+
+const labels = { prev: s.prev, next: s.next, step: s.step }
+---
+
+<div class="mcw" role="group" aria-label={s.mcpServers}>
+  <div class="shell">
+    <!-- Sidebar -->
+    <aside class="sb">
+      <div class="sb-head">
+        <span class="logo"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410.85 405.35" aria-hidden="true"><path d="M366.77,161.43H247V41.61a41.37,41.37,0,1,0-82.74,0V161.43H44.39a41.37,41.37,0,0,0,0,82.74H164.21V364A41.37,41.37,0,1,0,247,364V244.17H366.77a41.37,41.37,0,1,0,0-82.74Z"/><circle cx="205.58" cy="364.27" r="41.05"/><circle cx="369.79" cy="202.64" r="41.05"/><circle cx="41.05" cy="202.64" r="41.05"/><circle cx="205.58" cy="41.05" r="41.05"/><circle cx="205.58" cy="202.64" r="41.05"/></svg></span>
+        <span class="org"><b>{s.org}</b><small>{s.studio}</small></span>
+      </div>
+      <div class="sb-scroll">
+        <div class="grp-label">{s.agents}<span class="add"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></div>
+        <div class="navitem" id="navAgent1"><svg viewBox="0 0 24 24" set:html={convIcon}></svg><span>{s.agent1}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24" set:html={convIcon}></svg><span>{s.conversationAgent}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24" set:html={extractIcon}></svg><span>{s.extractionAgent}</span></div>
+
+        <div class="grp-label stack"><span class="name">{s.settingsName}</span><span>{s.settings}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg><span>{s.evaluations}</span><svg class="chev" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg><span>{s.analytics}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 15 21.84"/><path d="M21 5V8"/><path d="M21 12L18 17H22L19 22"/><path d="M3 12A9 3 0 0 0 14.59 14.87"/></svg><span>{s.sources}</span><svg class="chev" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></div>
+        <div class="navitem" id="navMcp"><svg viewBox="0 0 24 24" set:html={serverIcon}></svg><span>{s.mcpServers}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg><span>{s.members}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg><span>{s.admin}</span></div>
+      </div>
+      <div class="sb-user">
+        <span class="avatar">AM</span>
+        <span class="who"><b>{s.userName}</b><small>{s.userEmail}</small></span>
+        <span class="updown"><svg viewBox="0 0 24 24"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span>
+      </div>
+    </aside>
+
+    <!-- Main inset -->
+    <div class="inset">
+      <div class="topbar">
+        <span class="trig"><svg viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/></svg></span>
+      </div>
+      <div class="canvas">
+        <span class="fab"><svg viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg></span>
+
+        <!-- workspace overview (steps 1 & 7) -->
+        <div class="page" data-page="overview" data-active="true">
+          <div class="page-head plain">
+            <span><span class="ttl">{s.settingsName}</span><span class="desc">{s.workspace}</span></span>
+          </div>
+          <div class="cards3">
+            <div class="ecard"><span class="cat">{s.conversation}</span><b class="ic"><svg viewBox="0 0 24 24" set:html={convIcon}></svg> {s.agent1}</b><span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span></div>
+            <div class="ecard"><span class="cat">{s.conversation}</span><b class="ic"><svg viewBox="0 0 24 24" set:html={convIcon}></svg> {s.conversationAgent}</b><span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span></div>
+            <div class="ecard"><span class="cat">{s.extraction}</span><b class="ic"><svg viewBox="0 0 24 24" set:html={extractIcon}></svg> {s.extractionAgent}</b><span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span></div>
+          </div>
+        </div>
+
+        <!-- MCP servers empty (step 2) -->
+        <div class="page" data-page="mcpEmpty">
+          <div class="page-head">
+            <span class="btn icon-round"><svg viewBox="0 0 24 24"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg></span>
+            <span><span class="ttl">{s.pageTitle}</span><span class="desc">{s.pageDesc}</span></span>
+            <span class="right"><span class="btn sm" id="btnNew"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg> {s.newServer}</span></span>
+          </div>
+          <div class="emptybox">
+            <svg class="empty-ico" viewBox="0 0 24 24" set:html={serverIcon}></svg>
+            <p>{s.empty}</p>
+            <span class="btn sm"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg> {s.newServer}</span>
+          </div>
+        </div>
+
+        <!-- create dialog (step 3) -->
+        <div class="page" data-page="createDialog">
+          <div class="scrim"></div>
+          <div class="modal">
+            <div class="mhead"><b>{s.createTitle}</b><p>{s.createDesc}</p></div>
+            <div id="obsFields">
+              <p class="lbl">{s.fldName}</p>
+              <span class="input block">{s.serverName}</span>
+              <p class="lbl">{s.fldUrl}</p>
+              <span class="input block mono">{s.serverUrl}</span>
+              <p class="lbl">{s.fldApiKey}</p>
+              <span class="input block muted-input">••••••••••••</span>
+            </div>
+            <div class="row" style="justify-content:flex-end; margin-top:1rem; gap:0.5rem"><span class="btn ghost">{s.cancel}</span><span class="btn" id="btnCreate">{s.create}</span></div>
+          </div>
+        </div>
+
+        <!-- MCP servers grid (steps 4 & 5) -->
+        <div class="page" data-page="mcpGrid">
+          <div class="page-head">
+            <span class="btn icon-round"><svg viewBox="0 0 24 24"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg></span>
+            <span><span class="ttl">{s.pageTitle}</span><span class="desc">{s.pageDesc}</span></span>
+            <span class="right"><span class="btn sm"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg> {s.newServer}</span></span>
+          </div>
+          <div class="gcards">
+            <div class="gcard" id="obsCard">
+              <span class="gc-media"><svg viewBox="0 0 24 24" set:html={serverIcon}></svg></span>
+              <span class="gc-body"><b>{s.serverName}</b><small class="mono">{s.serverUrl}</small></span>
+              <span class="iconbtn danger" id="rowDelete"><svg viewBox="0 0 24 24"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg></span>
+            </div>
+            <div class="gcard">
+              <span class="gc-media"><svg viewBox="0 0 24 24" set:html={serverIcon}></svg></span>
+              <span class="gc-body"><b>{s.server2}</b><small class="mono">{s.server2Url}</small></span>
+              <span class="iconbtn danger"><svg viewBox="0 0 24 24"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- delete confirm (step 6) -->
+        <div class="page" data-page="deleteDialog">
+          <div class="scrim"></div>
+          <div class="modal" id="obsConfirm">
+            <div class="mhead"><b>{s.deleteTitle}</b><p>{s.deleteDesc}</p></div>
+            <div class="row" style="justify-content:flex-end; margin-top:1rem; gap:0.5rem"><span class="btn ghost">{s.cancel}</span><span class="btn danger-btn">{s.del}</span></div>
+          </div>
+        </div>
+
+        <!-- agent editor: MCP Servers tab (steps 8-10) -->
+        <div class="page" data-page="mcpTab">
+          <div class="page-head">
+            <span class="btn icon-round"><svg viewBox="0 0 24 24"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg></span>
+            <span><span class="ttl">{s.editTitle}</span><span class="desc">{s.editDesc}</span></span>
+          </div>
+          <div class="editor">
+            <div class="tablist">{TABS.map((tb) => <span class:list={["tab", tb.key === "mcp" && "on"]} id={tb.key === "mcp" ? "tab-mcp" : undefined}>{tb.label}</span>)}</div>
+            <div class="tabbody">
+              <div class="tab-header">
+                <span class="th-label">{s.tabHeader}</span>
+                <span class="mlink" id="linkManage">{s.manage} <svg viewBox="0 0 24 24"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6"/></svg></span>
+              </div>
+              <div class="srv-list">
+                <div class="srv-item">
+                  <span class="srv-media"><svg viewBox="0 0 24 24" set:html={serverIcon}></svg></span>
+                  <span class="srv-name">{s.serverName}</span>
+                  <span class="switch on" id="obsToggle"><i></i></span>
+                </div>
+                <div class="srv-item">
+                  <span class="srv-media"><svg viewBox="0 0 24 24" set:html={serverIcon}></svg></span>
+                  <span class="srv-name">{s.server2}</span>
+                  <span class="switch"><i></i></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div class="controls">
+    <button class="navbtn" data-prev><svg viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"/></svg> {s.prev}</button>
+    <button class="ctrl" data-playpause aria-label="Play / pause">⏸</button>
+    <span class="cap"><span class="st" data-stepcount></span><span class="tx" data-captext></span></span>
+    <span class="dots-nav" data-dots role="tablist" aria-label="Steps"></span>
+    <button class="navbtn primary" data-next>{s.next} <svg viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></button>
+  </div>
+  <div class="progress"><i data-bar></i></div>
+</div>
+
+<script define:vars={{ steps, labels }}>
+  const cs = document.currentScript
+  const mcw =
+    cs && cs.previousElementSibling && cs.previousElementSibling.classList.contains("mcw")
+      ? cs.previousElementSibling
+      : document.querySelector(".mcw")
+  const q = (sel) => mcw.querySelector(sel)
+  const pages = [...mcw.querySelectorAll(".page")]
+  const dotsWrap = mcw.querySelector("[data-dots]")
+  const bar = mcw.querySelector("[data-bar]")
+  const capText = mcw.querySelector("[data-captext]")
+  const stepCount = mcw.querySelector("[data-stepcount]")
+  const playPause = mcw.querySelector("[data-playpause]")
+  const prevBtn = mcw.querySelector("[data-prev]")
+  const nextBtn = mcw.querySelector("[data-next]")
+  const DUR = 6000
+  let idx = 0, playing = true, timer = null
+
+  steps.forEach((_, i) => {
+    const b = document.createElement("button")
+    b.className = "dotnav"; b.setAttribute("role", "tab"); b.setAttribute("aria-label", labels.step + " " + (i + 1))
+    b.addEventListener("click", () => go(i)); dotsWrap.appendChild(b)
+  })
+  const dots = [...dotsWrap.children]
+
+  function clearMarks() {
+    mcw.querySelectorAll(".spot-on").forEach((el) => el.classList.remove("spot-on"))
+    mcw.querySelectorAll(".observe-on").forEach((el) => el.classList.remove("observe-on"))
+  }
+  function render() {
+    const step = steps[idx]
+    pages.forEach((p) => p.setAttribute("data-active", String(p.dataset.page === step.page)))
+    dots.forEach((d, i) => d.classList.toggle("on", i === idx))
+    stepCount.textContent = labels.step + " " + (idx + 1) + " / " + steps.length
+    capText.textContent = step.text
+
+    // Actions have consequences: the MCP Servers page marks its sidebar item active;
+    // the agent-editor steps mark the edited agent active in the AGENTS list.
+    q("#navMcp")?.classList.toggle("on", step.nav === "mcp")
+    q("#navAgent1")?.classList.toggle("on", step.nav === "agent")
+
+    clearMarks()
+    const active = idx
+    setTimeout(() => {
+      if (active !== idx) return
+      if (step.spot) q("#" + step.spot)?.classList.add("spot-on")
+      step.observe.forEach((id) => q("#" + id)?.classList.add("observe-on"))
+    }, 260)
+
+    bar.classList.remove("run"); void bar.offsetWidth
+    bar.style.setProperty("--dur", DUR + "ms")
+    if (playing) bar.classList.add("run")
+  }
+  function schedule() { clearTimeout(timer); if (playing) timer = setTimeout(() => go(idx + 1), DUR) }
+  function go(n) { idx = (n + steps.length) % steps.length; render(); schedule() }
+  function setPlaying(p) {
+    playing = p; playPause.textContent = p ? "⏸" : "▶"
+    if (p) { bar.classList.add("run"); schedule() } else { clearTimeout(timer); bar.classList.remove("run") }
+  }
+  prevBtn.addEventListener("click", () => go(idx - 1))
+  nextBtn.addEventListener("click", () => go(idx + 1))
+  playPause.addEventListener("click", () => setPlaying(!playing))
+
+  render(); schedule()
+</script>
+
+<style>
+  .mcw {
+    --background: oklch(1 0 0); --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0); --card-foreground: oklch(0.145 0 0);
+    --primary: var(--brand-primary, oklch(62.8% 0.2 303.9)); --player-accent: oklch(74.137% 0.13055 37.323); --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0); --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0); --muted-foreground: oklch(0.556 0 0);
+    --border: oklch(0.922 0 0); --input: oklch(0.922 0 0); --destructive: oklch(0.577 0.245 27.325);
+    --sidebar: oklch(0.985 0 0); --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-accent: oklch(0.97 0 0); --sidebar-accent-foreground: oklch(0.205 0 0); --sidebar-border: oklch(0.922 0 0);
+    --radius: 0.625rem;
+    --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 12px 32px rgba(0,0,0,0.08);
+    --spot: color-mix(in oklab, var(--primary) 55%, transparent);
+    display: block; margin: 1.5rem 0; color: var(--foreground);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  .mcw * { box-sizing: border-box; }
+  .mcw svg { width: 1em; height: 1em; stroke: currentColor; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; flex-shrink: 0; display: inline-block; vertical-align: middle; }
+
+  .mcw .shell { display: grid; grid-template-columns: 208px 1fr; height: 680px; background: var(--sidebar); color: var(--sidebar-foreground); border: 1px solid var(--sidebar-border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
+  .mcw .sb { display: flex; flex-direction: column; padding: 0.5rem; min-height: 0; }
+  .mcw .sb-head { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.4rem 0.6rem; }
+  .mcw .logo { width: 1.9rem; height: 1.9rem; display: inline-flex; align-items: center; justify-content: center; }
+  .mcw .logo svg { width: 100%; height: 100%; stroke: none; }
+  .mcw .logo svg path { fill: var(--brand-primary, #f18c6e); }
+  .mcw .logo svg circle { fill: #010101; }
+  .mcw .org { display: flex; flex-direction: column; line-height: 1.05; }
+  .mcw .org b { font-size: 0.92rem; font-weight: 700; }
+  .mcw .org small { color: var(--primary); font-size: 0.72rem; }
+  .mcw .sb-scroll { flex: 1; overflow: hidden; display: flex; flex-direction: column; gap: 0.1rem; }
+  .mcw .grp-label { font-size: 0.66rem; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; padding: 0.4rem 0.5rem 0.2rem; display: flex; align-items: center; gap: 0.4rem; }
+  .mcw .grp-label .add { margin-left: auto; color: var(--muted-foreground); font-size: 0.9rem; }
+  .mcw .grp-label.stack { flex-direction: column; align-items: flex-start; gap: 0.05rem; line-height: 1.2; margin-top: auto; }
+  .mcw .grp-label.stack .name { color: var(--sidebar-foreground); font-size: 0.76rem; text-transform: none; font-weight: 700; }
+  .mcw .navitem { display: flex; align-items: center; gap: 0.55rem; padding: 0.3rem 0.5rem; border-radius: 7px; font-size: 0.82rem; color: var(--sidebar-foreground); }
+  .mcw .navitem svg { font-size: 1rem; color: var(--muted-foreground); }
+  .mcw .navitem .chev { margin-left: auto; font-size: 0.9rem; }
+  .mcw .navitem.on { background: var(--sidebar-accent); color: var(--sidebar-accent-foreground); font-weight: 600; }
+  .mcw .navitem.on svg { color: var(--sidebar-accent-foreground); }
+  .mcw .sb-user { display: flex; align-items: center; gap: 0.55rem; margin-top: auto; padding: 0.45rem 0.5rem; }
+  .mcw .avatar { width: 1.9rem; height: 1.9rem; border-radius: 8px; background: var(--muted); display: grid; place-items: center; font-size: 0.68rem; font-weight: 600; color: var(--muted-foreground); }
+  .mcw .who { display: flex; flex-direction: column; line-height: 1.15; min-width: 0; }
+  .mcw .who b { font-size: 0.76rem; font-weight: 600; }
+  .mcw .who small { font-size: 0.68rem; color: var(--muted-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mcw .updown { margin-left: auto; color: var(--muted-foreground); font-size: 0.9rem; }
+
+  .mcw .inset { position: relative; margin: 0.5rem 0.5rem 0.5rem 0; background: var(--background); color: var(--foreground); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; min-width: 0; box-shadow: var(--shadow); }
+  .mcw .topbar { height: 3rem; flex-shrink: 0; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 0.6rem; padding: 0 1rem; }
+  .mcw .trig { color: var(--muted-foreground); font-size: 1.05rem; }
+  .mcw .canvas { position: relative; flex: 1; min-height: 0; background: radial-gradient(circle, color-mix(in oklab, var(--muted-foreground) 20%, transparent) 1px, transparent 1px) 0 0 / 22px 22px; }
+  .mcw .fab { position: absolute; right: 1rem; bottom: 1rem; width: 2.3rem; height: 2.3rem; border-radius: 999px; background: var(--primary); color: var(--primary-foreground); display: grid; place-items: center; box-shadow: var(--shadow); font-size: 1.1rem; z-index: 6; }
+
+  .mcw .page { position: absolute; inset: 0; padding: 1.1rem 1.2rem; overflow: auto; opacity: 0; transform: translateY(8px); transition: opacity 0.4s ease, transform 0.4s ease; pointer-events: none; }
+  .mcw .page[data-active="true"] { opacity: 1; transform: none; pointer-events: auto; }
+
+  .mcw .spot-on { position: relative; z-index: 7; animation: mcw-spot 1.4s ease-in-out infinite; border-radius: 8px; }
+  @keyframes mcw-spot { 0%,100% { box-shadow: 0 0 0 0 var(--spot); } 50% { box-shadow: 0 0 0 6px color-mix(in oklab, var(--primary) 8%, transparent), 0 0 0 2px var(--spot); } }
+  .mcw .observe-on { outline: 2px dashed var(--spot); outline-offset: 3px; border-radius: 10px; }
+
+  .mcw .btn { display: inline-flex; align-items: center; gap: 0.35rem; background: var(--primary); color: var(--primary-foreground); border-radius: 8px; font-size: 0.8rem; font-weight: 500; padding: 0.4rem 0.7rem; }
+  .mcw .btn svg { font-size: 0.95rem; }
+  .mcw .btn.sm { font-size: 0.76rem; padding: 0.32rem 0.55rem; }
+  .mcw .btn.ghost { background: transparent; color: var(--foreground); }
+  .mcw .btn.icon-round { border-radius: 999px; width: 2rem; height: 2rem; padding: 0; justify-content: center; background: var(--secondary); color: var(--secondary-foreground); }
+  .mcw .btn.danger-btn { background: var(--destructive); color: var(--primary-foreground); }
+
+  .mcw .page-head { border-bottom: 1px solid var(--border); padding-bottom: 0.9rem; margin-bottom: 1rem; display: flex; align-items: flex-start; gap: 0.7rem; }
+  .mcw .page-head.plain { border: 0; }
+  .mcw .ttl { font-size: 1.3rem; font-weight: 600; line-height: 1.15; display: block; }
+  .mcw .desc { font-size: 0.88rem; color: var(--muted-foreground); margin-top: 0.2rem; display: block; }
+  .mcw .right { margin-left: auto; display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+
+  .mcw .cards3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.8rem; }
+  .mcw .ecard { border: 1px solid var(--border); border-radius: var(--radius); background: var(--card); padding: 0.8rem; min-height: 116px; display: flex; flex-direction: column; }
+  .mcw .ecard .cat { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted-foreground); font-weight: 600; margin-bottom: 0.2rem; }
+  .mcw .ecard b { font-size: 0.88rem; }
+  .mcw .ecard b.ic { display: flex; align-items: center; gap: 0.35rem; }
+  .mcw .ecard b.ic svg { color: var(--muted-foreground); font-size: 0.95rem; }
+  .mcw .arrowbtn { margin-top: auto; align-self: flex-start; width: 1.8rem; height: 1.8rem; border: 1px solid var(--border); border-radius: 8px; display: inline-grid; place-items: center; color: var(--muted-foreground); }
+
+  .mcw .emptybox { border: 1px solid var(--border); border-radius: var(--radius); background: var(--card); padding: 2.2rem 1rem; display: flex; flex-direction: column; align-items: center; gap: 0.5rem; text-align: center; }
+  .mcw .emptybox .empty-ico { color: var(--muted-foreground); font-size: 1.6rem; }
+  .mcw .emptybox p { font-size: 0.8rem; color: var(--muted-foreground); margin: 0 0 0.4rem; max-width: 26rem; }
+
+  .mcw .lbl { font-size: 0.78rem; font-weight: 500; margin: 0.6rem 0 0.3rem; }
+  .mcw .input { border: 1px solid var(--input); border-radius: 8px; padding: 0.42rem 0.6rem; font-size: 0.8rem; color: var(--foreground); background: var(--background); }
+  .mcw .input.block { display: block; }
+  .mcw .input.muted-input { color: var(--muted-foreground); letter-spacing: 0.1em; }
+  .mcw .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .mcw .row { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+
+  .mcw .scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.35); z-index: 4; }
+  .mcw .modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(380px, 84%); background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; box-shadow: var(--shadow); z-index: 5; }
+  .mcw .mhead { margin-bottom: 0.5rem; }
+  .mcw .mhead b { font-size: 0.98rem; font-weight: 600; }
+  .mcw .mhead p { font-size: 0.78rem; color: var(--muted-foreground); margin: 0.2rem 0 0; }
+
+  .mcw .gcards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.7rem; }
+  .mcw .gcard { display: flex; align-items: center; gap: 0.6rem; border: 1px solid var(--border); border-radius: 10px; background: var(--card); padding: 0.7rem 0.8rem; }
+  .mcw .gc-media { width: 2rem; height: 2rem; border-radius: 8px; background: var(--muted); display: grid; place-items: center; color: var(--muted-foreground); flex-shrink: 0; }
+  .mcw .gc-body { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+  .mcw .gc-body b { font-size: 0.84rem; }
+  .mcw .gc-body small { font-size: 0.72rem; color: var(--muted-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mcw .iconbtn { width: 1.9rem; height: 1.9rem; border-radius: 8px; display: inline-grid; place-items: center; color: var(--muted-foreground); flex-shrink: 0; }
+  .mcw .iconbtn.danger { color: var(--destructive); }
+
+  .mcw .editor { border: 1px solid var(--border); border-radius: var(--radius); background: var(--card); padding: 1rem; }
+  .mcw .tablist { display: flex; gap: 0.1rem; border-bottom: 1px solid var(--border); margin-bottom: 1rem; flex-wrap: wrap; }
+  .mcw .tab { padding: 0.4rem 0.6rem; font-size: 0.8rem; color: var(--muted-foreground); border-bottom: 2px solid transparent; margin-bottom: -1px; white-space: nowrap; }
+  .mcw .tab.on { color: var(--foreground); font-weight: 600; border-bottom-color: var(--primary); }
+  .mcw .tabbody { padding: 0.2rem 0; }
+  .mcw .tab-header { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.7rem; }
+  .mcw .th-label { font-size: 0.82rem; font-weight: 600; }
+  .mcw .mlink { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.78rem; color: var(--primary); font-weight: 500; }
+  .mcw .mlink svg { font-size: 0.9rem; }
+
+  .mcw .srv-list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .mcw .srv-item { display: flex; align-items: center; gap: 0.6rem; border: 1px solid var(--border); border-radius: 10px; padding: 0.6rem 0.7rem; }
+  .mcw .srv-media { width: 2rem; height: 2rem; border-radius: 8px; background: var(--muted); display: grid; place-items: center; color: var(--muted-foreground); flex-shrink: 0; }
+  .mcw .srv-name { font-size: 0.84rem; flex: 1; min-width: 0; }
+  .mcw .switch { width: 1.9rem; height: 1.1rem; border-radius: 999px; background: var(--muted); position: relative; display: inline-block; flex-shrink: 0; }
+  .mcw .switch i { position: absolute; top: 2px; left: 2px; width: 0.8rem; height: 0.8rem; border-radius: 999px; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.2); }
+  .mcw .switch.on { background: var(--primary); }
+  .mcw .switch.on i { left: calc(100% - 0.9rem); }
+
+  .mcw .controls { display: flex; align-items: center; gap: 0.7rem; margin-top: 0.75rem; padding: 0.7rem 0.9rem; border: 1px solid var(--border); border-radius: 12px; background: var(--card); box-shadow: var(--shadow); }
+  .mcw .navbtn { display: inline-flex; align-items: center; gap: 0.35rem; border: 1px solid var(--border); background: var(--background); color: var(--foreground); border-radius: 8px; padding: 0.45rem 0.7rem; font-size: 0.83rem; font-weight: 500; cursor: pointer; }
+  .mcw .navbtn.primary { background: var(--player-accent); color: var(--primary-foreground); border-color: transparent; }
+  .mcw .ctrl { border: 1px solid var(--border); background: var(--background); color: var(--foreground); border-radius: 8px; width: 2.1rem; height: 2.1rem; cursor: pointer; font-size: 0.95rem; display: grid; place-items: center; }
+  .mcw .cap { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+  .mcw .cap .st { font-size: 0.7rem; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.04em; }
+  .mcw .cap .tx { font-size: 0.88rem; font-weight: 500; }
+  .mcw .dots-nav { display: flex; gap: 0.4rem; flex-wrap: wrap; max-width: 200px; }
+  .mcw .dotnav { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--border); border: none; padding: 0; cursor: pointer; transition: background 0.2s, transform 0.2s; }
+  .mcw .dotnav.on { background: var(--player-accent); transform: scale(1.3); }
+  .mcw .progress { height: 3px; background: var(--border); border-radius: 999px; overflow: hidden; margin-top: 0.55rem; }
+  .mcw .progress i { display: block; height: 100%; width: 0; background: var(--player-accent); }
+  .mcw .progress i.run { animation: mcw-fill var(--dur, 6000ms) linear forwards; }
+  @keyframes mcw-fill { to { width: 100%; } }
+
+  @media (max-width: 640px) {
+    .mcw .shell { grid-template-columns: 1fr; height: 560px; }
+    .mcw .sb { display: none; }
+    .mcw .inset { margin: 0.5rem; }
+    .mcw .cards3, .mcw .gcards { grid-template-columns: 1fr; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mcw .page, .mcw .spot-on, .mcw .progress i { transition: none !important; animation: none !important; }
+  }
+</style>

--- a/apps/help/src/components/MessageFeedbackWalkthrough.astro
+++ b/apps/help/src/components/MessageFeedbackWalkthrough.astro
@@ -1,0 +1,397 @@
+---
+/**
+ * Walkthrough of the admin view of agent message feedback (the "Report a problem
+ * with this message" reports). Derived from the real components (verified, not
+ * copied blind): AgentSessionListHeader.tsx (Feedback card, shown when
+ * canManageAgent), FeedbackButton.tsx (card title/description + GoButton), the
+ * feedback route StudioRoutes.feedback (`/a/:agentId/f`, RestrictedAccess
+ * ability="canManageAgent" — NOT a feature flag), FeedbackRoute.tsx +
+ * FeedbackItem.tsx (per-row: outline card = reported message + Session ID/Message
+ * ID; muted card = date + free-text content), EmptyFeedback.tsx
+ * (MessageSquareWarningIcon + empty title/description). Labels verbatim from the
+ * agent-message-feedback locales (EN + FR). The sibling agent-page cards (Analytics,
+ * Playground) are representative context. Uses the PRODUCT (coral) palette, pinned
+ * locally. Derived 2026-07-22.
+ */
+type Lang = "en" | "fr"
+const { lang = "en" } = Astro.props as { lang?: Lang }
+
+const STRINGS = {
+  en: {
+    org: "Bayes Impact Demo", studio: "Studio", agents: "Agents",
+    agent1: "Helpful Assistant", conversationAgent: "Conversation Agent", extractionAgent: "Extraction Agent",
+    settingsName: "Demo", settings: "Settings", evaluations: "Evaluations", analytics: "Analytics", sources: "Sources",
+    members: "Members", admin: "Admin",
+    userName: "Alex Martin", userEmail: "alex.martin@example.com",
+    conversation: "Conversation",
+    cardFeedback: "Feedback", cardFeedbackDesc: "Manage feedback on agent messages.",
+    cardAnalytics: "Analytics", cardAnalyticsDesc: "See how this agent is used.",
+    cardPlayground: "Playground", cardPlaygroundDesc: "Chat with this agent to test it.",
+    pageTitle: "Feedback",
+    sessionId: "Session ID:", messageId: "Message ID:",
+    msg1: "To reset your password, open Settings and choose Security.",
+    sid1: "sess_8f2a", mid1: "msg_1c7d", date1: "14 May 2026",
+    comment1: "This points to the wrong menu — there is no Security tab.",
+    msg2: "Our office hours are Monday to Friday, 9am–5pm.",
+    sid2: "sess_3b9e", mid2: "msg_4a2f", date2: "12 May 2026",
+    comment2: "These hours are out of date.",
+    emptyTitle: "No feedback yet", emptyDesc: "No feedback on the agent's messages.",
+    prev: "Prev", next: "Next", step: "Step",
+    steps: [
+      "From the agent's page, open the Feedback card.",
+      "The Feedback page lists every reported message, newest first.",
+      "Each entry shows the exact agent message that was reported, with its Session ID and Message ID.",
+      "Below it sits the report itself — the date it was sent and the reporter's comment.",
+      "Until someone reports a message, the page shows No feedback yet.",
+    ],
+  },
+  fr: {
+    org: "Bayes Impact Demo", studio: "Studio", agents: "Agents",
+    agent1: "Helpful Assistant", conversationAgent: "Conversation Agent", extractionAgent: "Extraction Agent",
+    settingsName: "Demo", settings: "Paramètres", evaluations: "Évaluations", analytics: "Analytique", sources: "Sources",
+    members: "Membres", admin: "Admin",
+    userName: "Alex Martin", userEmail: "alex.martin@example.com",
+    conversation: "Conversation",
+    cardFeedback: "Retours utilisateurs", cardFeedbackDesc: "Gérez les retours sur les messages de l'agent.",
+    cardAnalytics: "Analytique", cardAnalyticsDesc: "Voyez comment cet agent est utilisé.",
+    cardPlayground: "Playground", cardPlaygroundDesc: "Discutez avec cet agent pour le tester.",
+    pageTitle: "Retours utilisateurs",
+    sessionId: "ID de session :", messageId: "ID de message :",
+    msg1: "Pour réinitialiser votre mot de passe, ouvrez Paramètres puis Sécurité.",
+    sid1: "sess_8f2a", mid1: "msg_1c7d", date1: "14 mai 2026",
+    comment1: "Cela pointe vers le mauvais menu — il n'y a pas d'onglet Sécurité.",
+    msg2: "Nos horaires sont du lundi au vendredi, 9h–17h.",
+    sid2: "sess_3b9e", mid2: "msg_4a2f", date2: "12 mai 2026",
+    comment2: "Ces horaires ne sont plus à jour.",
+    emptyTitle: "Pas encore de retours", emptyDesc: "Aucun avis sur les messages de l'agent.",
+    prev: "Précédent", next: "Suivant", step: "Étape",
+    steps: [
+      "Depuis la page de l'agent, ouvrez la carte Retours utilisateurs.",
+      "La page Retours utilisateurs liste chaque message signalé, du plus récent au plus ancien.",
+      "Chaque entrée montre le message exact de l'agent qui a été signalé, avec son ID de session et son ID de message.",
+      "En dessous se trouve le signalement lui-même — la date d'envoi et le commentaire du rapporteur.",
+      "Tant que personne n'a signalé de message, la page affiche Pas encore de retours.",
+    ],
+  },
+} as const
+
+const s = STRINGS[lang]
+
+const convIcon = '<path d="M12 6V2H8"/><path d="m8 18-4 4V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2Z"/><path d="M9 11v2"/><path d="M15 11v2"/>'
+const extractIcon = '<path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><path d="M7 8h8"/><path d="M7 12h10"/><path d="M7 16h6"/>'
+const warnIcon = '<path d="M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"/><path d="M12 15h.01"/><path d="M12 7v4"/>'
+const thumbsDownIcon = '<path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z"/><path d="M17 14V2"/>'
+
+const steps = [
+  { page: "agent", spot: "cardFeedback", observe: [] },
+  { page: "list", spot: "", observe: ["obsList"] },
+  { page: "list", spot: "", observe: ["obsMsg"] },
+  { page: "list", spot: "", observe: ["obsReport"] },
+  { page: "empty", spot: "", observe: ["obsEmpty"] },
+].map((step, i) => ({ ...step, text: s.steps[i] }))
+
+const labels = { prev: s.prev, next: s.next, step: s.step }
+---
+
+<div class="fbw" role="group" aria-label={s.cardFeedback}>
+  <div class="shell">
+    <!-- Sidebar -->
+    <aside class="sb">
+      <div class="sb-head">
+        <span class="logo"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410.85 405.35" aria-hidden="true"><path d="M366.77,161.43H247V41.61a41.37,41.37,0,1,0-82.74,0V161.43H44.39a41.37,41.37,0,0,0,0,82.74H164.21V364A41.37,41.37,0,1,0,247,364V244.17H366.77a41.37,41.37,0,1,0,0-82.74Z"/><circle cx="205.58" cy="364.27" r="41.05"/><circle cx="369.79" cy="202.64" r="41.05"/><circle cx="41.05" cy="202.64" r="41.05"/><circle cx="205.58" cy="41.05" r="41.05"/><circle cx="205.58" cy="202.64" r="41.05"/></svg></span>
+        <span class="org"><b>{s.org}</b><small>{s.studio}</small></span>
+      </div>
+      <div class="sb-scroll">
+        <div class="grp-label">{s.agents}<span class="add"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></div>
+        <div class="navitem" id="navAgent1"><svg viewBox="0 0 24 24" set:html={convIcon}></svg><span>{s.agent1}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24" set:html={convIcon}></svg><span>{s.conversationAgent}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24" set:html={extractIcon}></svg><span>{s.extractionAgent}</span></div>
+
+        <div class="grp-label stack"><span class="name">{s.settingsName}</span><span>{s.settings}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg><span>{s.evaluations}</span><svg class="chev" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg><span>{s.analytics}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 15 21.84"/><path d="M21 5V8"/><path d="M21 12L18 17H22L19 22"/><path d="M3 12A9 3 0 0 0 14.59 14.87"/></svg><span>{s.sources}</span><svg class="chev" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg><span>{s.members}</span></div>
+        <div class="navitem"><svg viewBox="0 0 24 24"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg><span>{s.admin}</span></div>
+      </div>
+      <div class="sb-user">
+        <span class="avatar">AM</span>
+        <span class="who"><b>{s.userName}</b><small>{s.userEmail}</small></span>
+        <span class="updown"><svg viewBox="0 0 24 24"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span>
+      </div>
+    </aside>
+
+    <!-- Main inset -->
+    <div class="inset">
+      <div class="topbar">
+        <span class="trig"><svg viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/></svg></span>
+      </div>
+      <div class="canvas">
+        <span class="fab"><svg viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg></span>
+
+        <!-- agent page (step 1) -->
+        <div class="page" data-page="agent" data-active="true">
+          <div class="page-head plain">
+            <span><span class="ttl">{s.agent1}</span><span class="desc">{s.conversation}</span></span>
+          </div>
+          <div class="cards3">
+            <div class="ecard" id="cardFeedback">
+              <b class="ic"><svg viewBox="0 0 24 24" set:html={warnIcon}></svg> {s.cardFeedback}</b>
+              <p>{s.cardFeedbackDesc}</p>
+              <div class="mock"><span class="mockline"><svg class="tdn" viewBox="0 0 24 24" set:html={thumbsDownIcon}></svg><i></i></span><span class="mockline"><svg viewBox="0 0 24 24" set:html={warnIcon}></svg><i></i></span></div>
+              <span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+            </div>
+            <div class="ecard">
+              <b class="ic"><svg viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg> {s.cardAnalytics}</b>
+              <p>{s.cardAnalyticsDesc}</p>
+              <span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+            </div>
+            <div class="ecard">
+              <b class="ic"><svg viewBox="0 0 24 24" set:html={convIcon}></svg> {s.cardPlayground}</b>
+              <p>{s.cardPlaygroundDesc}</p>
+              <span class="arrowbtn"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- feedback list (steps 2-4) -->
+        <div class="page" data-page="list">
+          <div class="page-head">
+            <span class="btn icon-round"><svg viewBox="0 0 24 24"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg></span>
+            <span><span class="ttl">{s.pageTitle}</span><span class="desc"><svg class="dsc-ic" viewBox="0 0 24 24" set:html={convIcon}></svg> {s.agent1} · {s.conversation}</span></span>
+          </div>
+          <div class="fb-list" id="obsList">
+            <div class="fb-item">
+              <div class="fb-msg" id="obsMsg">
+                <p class="fb-body">{s.msg1}</p>
+                <p class="fb-meta">{s.sessionId} {s.sid1} · {s.messageId} {s.mid1}</p>
+              </div>
+              <div class="fb-report" id="obsReport">
+                <p class="fb-date">{s.date1}</p>
+                <p class="fb-comment">{s.comment1}</p>
+              </div>
+            </div>
+            <div class="fb-item">
+              <div class="fb-msg">
+                <p class="fb-body">{s.msg2}</p>
+                <p class="fb-meta">{s.sessionId} {s.sid2} · {s.messageId} {s.mid2}</p>
+              </div>
+              <div class="fb-report">
+                <p class="fb-date">{s.date2}</p>
+                <p class="fb-comment">{s.comment2}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- empty state (step 5) -->
+        <div class="page" data-page="empty">
+          <div class="page-head">
+            <span class="btn icon-round"><svg viewBox="0 0 24 24"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg></span>
+            <span><span class="ttl">{s.pageTitle}</span><span class="desc"><svg class="dsc-ic" viewBox="0 0 24 24" set:html={convIcon}></svg> {s.agent1} · {s.conversation}</span></span>
+          </div>
+          <div class="emptybox" id="obsEmpty">
+            <svg class="empty-ico" viewBox="0 0 24 24" set:html={warnIcon}></svg>
+            <b>{s.emptyTitle}</b>
+            <p>{s.emptyDesc}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div class="controls">
+    <button class="navbtn" data-prev><svg viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"/></svg> {s.prev}</button>
+    <button class="ctrl" data-playpause aria-label="Play / pause">⏸</button>
+    <span class="cap"><span class="st" data-stepcount></span><span class="tx" data-captext></span></span>
+    <span class="dots-nav" data-dots role="tablist" aria-label="Steps"></span>
+    <button class="navbtn primary" data-next>{s.next} <svg viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></button>
+  </div>
+  <div class="progress"><i data-bar></i></div>
+</div>
+
+<script define:vars={{ steps, labels }}>
+  const cs = document.currentScript
+  const fbw =
+    cs && cs.previousElementSibling && cs.previousElementSibling.classList.contains("fbw")
+      ? cs.previousElementSibling
+      : document.querySelector(".fbw")
+  const q = (sel) => fbw.querySelector(sel)
+  const pages = [...fbw.querySelectorAll(".page")]
+  const dotsWrap = fbw.querySelector("[data-dots]")
+  const bar = fbw.querySelector("[data-bar]")
+  const capText = fbw.querySelector("[data-captext]")
+  const stepCount = fbw.querySelector("[data-stepcount]")
+  const playPause = fbw.querySelector("[data-playpause]")
+  const prevBtn = fbw.querySelector("[data-prev]")
+  const nextBtn = fbw.querySelector("[data-next]")
+  const DUR = 6000
+  let idx = 0, playing = true, timer = null
+
+  steps.forEach((_, i) => {
+    const b = document.createElement("button")
+    b.className = "dotnav"; b.setAttribute("role", "tab"); b.setAttribute("aria-label", labels.step + " " + (i + 1))
+    b.addEventListener("click", () => go(i)); dotsWrap.appendChild(b)
+  })
+  const dots = [...dotsWrap.children]
+
+  function clearMarks() {
+    fbw.querySelectorAll(".spot-on").forEach((el) => el.classList.remove("spot-on"))
+    fbw.querySelectorAll(".observe-on").forEach((el) => el.classList.remove("observe-on"))
+  }
+  function render() {
+    const step = steps[idx]
+    pages.forEach((p) => p.setAttribute("data-active", String(p.dataset.page === step.page)))
+    dots.forEach((d, i) => d.classList.toggle("on", i === idx))
+    stepCount.textContent = labels.step + " " + (idx + 1) + " / " + steps.length
+    capText.textContent = step.text
+
+    // The agent whose feedback we're reading stays active in the AGENTS list.
+    q("#navAgent1")?.classList.add("on")
+
+    clearMarks()
+    const active = idx
+    setTimeout(() => {
+      if (active !== idx) return
+      if (step.spot) q("#" + step.spot)?.classList.add("spot-on")
+      step.observe.forEach((id) => q("#" + id)?.classList.add("observe-on"))
+    }, 260)
+
+    bar.classList.remove("run"); void bar.offsetWidth
+    bar.style.setProperty("--dur", DUR + "ms")
+    if (playing) bar.classList.add("run")
+  }
+  function schedule() { clearTimeout(timer); if (playing) timer = setTimeout(() => go(idx + 1), DUR) }
+  function go(n) { idx = (n + steps.length) % steps.length; render(); schedule() }
+  function setPlaying(p) {
+    playing = p; playPause.textContent = p ? "⏸" : "▶"
+    if (p) { bar.classList.add("run"); schedule() } else { clearTimeout(timer); bar.classList.remove("run") }
+  }
+  prevBtn.addEventListener("click", () => go(idx - 1))
+  nextBtn.addEventListener("click", () => go(idx + 1))
+  playPause.addEventListener("click", () => setPlaying(!playing))
+
+  render(); schedule()
+</script>
+
+<style>
+  .fbw {
+    --background: oklch(1 0 0); --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0); --card-foreground: oklch(0.145 0 0);
+    --primary: var(--brand-primary, oklch(62.8% 0.2 303.9)); --player-accent: oklch(74.137% 0.13055 37.323); --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0); --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0); --muted-foreground: oklch(0.556 0 0);
+    --border: oklch(0.922 0 0); --input: oklch(0.922 0 0); --destructive: oklch(0.577 0.245 27.325);
+    --sidebar: oklch(0.985 0 0); --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-accent: oklch(0.97 0 0); --sidebar-accent-foreground: oklch(0.205 0 0); --sidebar-border: oklch(0.922 0 0);
+    --radius: 0.625rem;
+    --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 12px 32px rgba(0,0,0,0.08);
+    --spot: color-mix(in oklab, var(--primary) 55%, transparent);
+    display: block; margin: 1.5rem 0; color: var(--foreground);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  .fbw * { box-sizing: border-box; }
+  .fbw svg { width: 1em; height: 1em; stroke: currentColor; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; flex-shrink: 0; display: inline-block; vertical-align: middle; }
+
+  .fbw .shell { display: grid; grid-template-columns: 208px 1fr; height: 680px; background: var(--sidebar); color: var(--sidebar-foreground); border: 1px solid var(--sidebar-border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
+  .fbw .sb { display: flex; flex-direction: column; padding: 0.5rem; min-height: 0; }
+  .fbw .sb-head { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.4rem 0.6rem; }
+  .fbw .logo { width: 1.9rem; height: 1.9rem; display: inline-flex; align-items: center; justify-content: center; }
+  .fbw .logo svg { width: 100%; height: 100%; stroke: none; }
+  .fbw .logo svg path { fill: var(--brand-primary, #f18c6e); }
+  .fbw .logo svg circle { fill: #010101; }
+  .fbw .org { display: flex; flex-direction: column; line-height: 1.05; }
+  .fbw .org b { font-size: 0.92rem; font-weight: 700; }
+  .fbw .org small { color: var(--primary); font-size: 0.72rem; }
+  .fbw .sb-scroll { flex: 1; overflow: hidden; display: flex; flex-direction: column; gap: 0.1rem; }
+  .fbw .grp-label { font-size: 0.66rem; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; padding: 0.4rem 0.5rem 0.2rem; display: flex; align-items: center; gap: 0.4rem; }
+  .fbw .grp-label .add { margin-left: auto; color: var(--muted-foreground); font-size: 0.9rem; }
+  .fbw .grp-label.stack { flex-direction: column; align-items: flex-start; gap: 0.05rem; line-height: 1.2; margin-top: auto; }
+  .fbw .grp-label.stack .name { color: var(--sidebar-foreground); font-size: 0.76rem; text-transform: none; font-weight: 700; }
+  .fbw .navitem { display: flex; align-items: center; gap: 0.55rem; padding: 0.3rem 0.5rem; border-radius: 7px; font-size: 0.82rem; color: var(--sidebar-foreground); }
+  .fbw .navitem svg { font-size: 1rem; color: var(--muted-foreground); }
+  .fbw .navitem .chev { margin-left: auto; font-size: 0.9rem; }
+  .fbw .navitem.on { background: var(--sidebar-accent); color: var(--sidebar-accent-foreground); font-weight: 600; }
+  .fbw .navitem.on svg { color: var(--sidebar-accent-foreground); }
+  .fbw .sb-user { display: flex; align-items: center; gap: 0.55rem; margin-top: auto; padding: 0.45rem 0.5rem; }
+  .fbw .avatar { width: 1.9rem; height: 1.9rem; border-radius: 8px; background: var(--muted); display: grid; place-items: center; font-size: 0.68rem; font-weight: 600; color: var(--muted-foreground); }
+  .fbw .who { display: flex; flex-direction: column; line-height: 1.15; min-width: 0; }
+  .fbw .who b { font-size: 0.76rem; font-weight: 600; }
+  .fbw .who small { font-size: 0.68rem; color: var(--muted-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .fbw .updown { margin-left: auto; color: var(--muted-foreground); font-size: 0.9rem; }
+
+  .fbw .inset { position: relative; margin: 0.5rem 0.5rem 0.5rem 0; background: var(--background); color: var(--foreground); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; min-width: 0; box-shadow: var(--shadow); }
+  .fbw .topbar { height: 3rem; flex-shrink: 0; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 0.6rem; padding: 0 1rem; }
+  .fbw .trig { color: var(--muted-foreground); font-size: 1.05rem; }
+  .fbw .canvas { position: relative; flex: 1; min-height: 0; background: radial-gradient(circle, color-mix(in oklab, var(--muted-foreground) 20%, transparent) 1px, transparent 1px) 0 0 / 22px 22px; }
+  .fbw .fab { position: absolute; right: 1rem; bottom: 1rem; width: 2.3rem; height: 2.3rem; border-radius: 999px; background: var(--primary); color: var(--primary-foreground); display: grid; place-items: center; box-shadow: var(--shadow); font-size: 1.1rem; z-index: 6; }
+
+  .fbw .page { position: absolute; inset: 0; padding: 1.1rem 1.2rem; overflow: auto; opacity: 0; transform: translateY(8px); transition: opacity 0.4s ease, transform 0.4s ease; pointer-events: none; }
+  .fbw .page[data-active="true"] { opacity: 1; transform: none; pointer-events: auto; }
+
+  .fbw .spot-on { position: relative; z-index: 7; animation: fbw-spot 1.4s ease-in-out infinite; border-radius: 8px; }
+  @keyframes fbw-spot { 0%,100% { box-shadow: 0 0 0 0 var(--spot); } 50% { box-shadow: 0 0 0 6px color-mix(in oklab, var(--primary) 8%, transparent), 0 0 0 2px var(--spot); } }
+  .fbw .observe-on { outline: 2px dashed var(--spot); outline-offset: 3px; border-radius: 10px; }
+
+  .fbw .btn { display: inline-flex; align-items: center; gap: 0.35rem; background: var(--primary); color: var(--primary-foreground); border-radius: 8px; font-size: 0.8rem; font-weight: 500; padding: 0.4rem 0.7rem; }
+  .fbw .btn.icon-round { border-radius: 999px; width: 2rem; height: 2rem; padding: 0; justify-content: center; background: var(--secondary); color: var(--secondary-foreground); }
+
+  .fbw .page-head { border-bottom: 1px solid var(--border); padding-bottom: 0.9rem; margin-bottom: 1rem; display: flex; align-items: flex-start; gap: 0.7rem; }
+  .fbw .page-head.plain { border: 0; }
+  .fbw .ttl { font-size: 1.3rem; font-weight: 600; line-height: 1.15; display: block; }
+  .fbw .desc { font-size: 0.88rem; color: var(--muted-foreground); margin-top: 0.2rem; display: flex; align-items: center; gap: 0.35rem; }
+  .fbw .desc .dsc-ic { font-size: 0.95rem; }
+
+  .fbw .cards3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.8rem; }
+  .fbw .ecard { border: 1px solid var(--border); border-radius: var(--radius); background: var(--card); padding: 0.8rem; min-height: 140px; display: flex; flex-direction: column; }
+  .fbw .ecard b { font-size: 0.88rem; }
+  .fbw .ecard b.ic { display: flex; align-items: center; gap: 0.35rem; }
+  .fbw .ecard b.ic svg { color: var(--muted-foreground); font-size: 0.95rem; }
+  .fbw .ecard p { font-size: 0.74rem; color: var(--muted-foreground); margin: 0.2rem 0 0.6rem; }
+  .fbw .ecard .arrowbtn { margin-top: auto; align-self: flex-start; width: 1.8rem; height: 1.8rem; border: 1px solid var(--border); border-radius: 8px; display: inline-grid; place-items: center; color: var(--muted-foreground); }
+  .fbw .mock { display: flex; flex-direction: column; gap: 0.3rem; margin-bottom: 0.4rem; }
+  .fbw .mockline { display: flex; align-items: center; gap: 0.4rem; }
+  .fbw .mockline svg { font-size: 0.85rem; color: var(--muted-foreground); }
+  .fbw .mockline .tdn { color: var(--destructive); }
+  .fbw .mockline i { flex: 1; height: 0.4rem; border-radius: 999px; background: var(--muted); }
+
+  .fbw .emptybox { border: 1px solid var(--border); border-radius: var(--radius); background: var(--card); padding: 2.2rem 1rem; display: flex; flex-direction: column; align-items: center; gap: 0.4rem; text-align: center; }
+  .fbw .emptybox .empty-ico { color: var(--muted-foreground); font-size: 1.6rem; }
+  .fbw .emptybox b { font-size: 0.9rem; }
+  .fbw .emptybox p { font-size: 0.8rem; color: var(--muted-foreground); margin: 0; }
+
+  .fbw .fb-list { display: flex; flex-direction: column; gap: 1rem; }
+  .fbw .fb-item { display: flex; flex-direction: column; gap: 0.5rem; }
+  .fbw .fb-msg { border: 1px solid var(--border); border-radius: 10px; background: var(--card); padding: 0.75rem 0.85rem; }
+  .fbw .fb-body { font-size: 0.82rem; margin: 0; line-height: 1.5; }
+  .fbw .fb-meta { font-size: 0.68rem; color: var(--muted-foreground); margin: 0.5rem 0 0; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .fbw .fb-report { border: 1px solid var(--border); border-radius: 10px; background: var(--muted); padding: 0.7rem 0.85rem; }
+  .fbw .fb-date { font-size: 0.7rem; color: var(--muted-foreground); font-weight: 600; margin: 0 0 0.3rem; }
+  .fbw .fb-comment { font-size: 0.82rem; margin: 0; line-height: 1.5; }
+
+  .fbw .controls { display: flex; align-items: center; gap: 0.7rem; margin-top: 0.75rem; padding: 0.7rem 0.9rem; border: 1px solid var(--border); border-radius: 12px; background: var(--card); box-shadow: var(--shadow); }
+  .fbw .navbtn { display: inline-flex; align-items: center; gap: 0.35rem; border: 1px solid var(--border); background: var(--background); color: var(--foreground); border-radius: 8px; padding: 0.45rem 0.7rem; font-size: 0.83rem; font-weight: 500; cursor: pointer; }
+  .fbw .navbtn.primary { background: var(--player-accent); color: var(--primary-foreground); border-color: transparent; }
+  .fbw .ctrl { border: 1px solid var(--border); background: var(--background); color: var(--foreground); border-radius: 8px; width: 2.1rem; height: 2.1rem; cursor: pointer; font-size: 0.95rem; display: grid; place-items: center; }
+  .fbw .cap { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+  .fbw .cap .st { font-size: 0.7rem; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.04em; }
+  .fbw .cap .tx { font-size: 0.88rem; font-weight: 500; }
+  .fbw .dots-nav { display: flex; gap: 0.4rem; flex-wrap: wrap; max-width: 200px; }
+  .fbw .dotnav { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--border); border: none; padding: 0; cursor: pointer; transition: background 0.2s, transform 0.2s; }
+  .fbw .dotnav.on { background: var(--player-accent); transform: scale(1.3); }
+  .fbw .progress { height: 3px; background: var(--border); border-radius: 999px; overflow: hidden; margin-top: 0.55rem; }
+  .fbw .progress i { display: block; height: 100%; width: 0; background: var(--player-accent); }
+  .fbw .progress i.run { animation: fbw-fill var(--dur, 6000ms) linear forwards; }
+  @keyframes fbw-fill { to { width: 100%; } }
+
+  @media (max-width: 640px) {
+    .fbw .shell { grid-template-columns: 1fr; height: 560px; }
+    .fbw .sb { display: none; }
+    .fbw .inset { margin: 0.5rem; }
+    .fbw .cards3 { grid-template-columns: 1fr; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .fbw .page, .fbw .spot-on, .fbw .progress i { transition: none !important; animation: none !important; }
+  }
+</style>

--- a/apps/help/src/components/OnboardingWalkthrough.astro
+++ b/apps/help/src/components/OnboardingWalkthrough.astro
@@ -209,7 +209,7 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
   .oiw * { box-sizing: border-box; }
   .oiw svg { width: 1em; height: 1em; stroke: currentColor; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; flex-shrink: 0; display: inline-block; vertical-align: middle; }
 
-  .oiw .frame { display: flex; flex-direction: column; height: 620px; background: var(--background); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
+  .oiw .frame { display: flex; flex-direction: column; height: 680px; background: var(--background); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; box-shadow: var(--shadow); }
   .oiw .nav { height: 4rem; flex-shrink: 0; background: var(--background); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 0.6rem; padding: 0 1rem; }
   .oiw .logo, .oiw .wlogo { width: 2rem; height: 2rem; display: inline-flex; align-items: center; justify-content: center; padding: 0.15rem; }
   .oiw .logo svg, .oiw .wlogo svg { width: 100%; height: 100%; stroke: none; }
@@ -286,7 +286,7 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
   @keyframes oiw-fill { to { width: 100%; } }
 
   @media (max-width: 640px) {
-    .oiw .frame { height: 640px; }
+    .oiw .frame { height: 560px; }
     .oiw .ws-grid { grid-template-columns: 1fr; }
   }
   @media (prefers-reduced-motion: reduce) {

--- a/apps/help/src/content/docs/en/accept-an-invitation.mdx
+++ b/apps/help/src/content/docs/en/accept-an-invitation.mdx
@@ -4,7 +4,7 @@ highlight: invitation
 description: Get into the platform for the first time — accept the terms, find your pending invitations, and join the workspaces you've been invited to.
 category: getting-started
 order: 2
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import OnboardingWalkthrough from "@/components/OnboardingWalkthrough.astro"

--- a/apps/help/src/content/docs/en/add-a-conversation-agent.mdx
+++ b/apps/help/src/content/docs/en/add-a-conversation-agent.mdx
@@ -4,7 +4,7 @@ highlight: conversation
 description: Create a conversation agent that chats with users, grounded in your workspace's documents and resource libraries.
 category: guides-agents
 order: 1
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddConversationAgentWalkthrough from "@/components/AddConversationAgentWalkthrough.astro"
@@ -113,8 +113,9 @@ full walkthrough.
   large workspace.
 - Remember to **Save** each tab — changes on one tab aren't kept when you move to
   another without saving.
-- **Conversation categories**, **Orchestration** and **Embed** only appear when the
-  workspace has categories or those features are enabled — you may see fewer tabs.
+- **Conversation categories**, **Orchestration**, **Embed** and **MCP Servers** only
+  appear when the workspace has categories or those features are enabled — you may see
+  fewer tabs.
 
 ## Troubleshooting
 

--- a/apps/help/src/content/docs/en/add-a-form-agent.mdx
+++ b/apps/help/src/content/docs/en/add-a-form-agent.mdx
@@ -4,7 +4,7 @@ highlight: form
 description: Create a form agent that guides a user through filling out a form, collecting structured answers that match a schema you define.
 category: guides-agents
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddFormAgentWalkthrough from "@/components/AddFormAgentWalkthrough.astro"
@@ -73,7 +73,8 @@ Open the **Form** tab and build the fields the agent collects **visually** — n
 required. Click **Add field** and, for each field, set:
 
 - **Field name** — the key the answer is stored under (e.g. `full_name`).
-- **Type** — **Text**, **Number**, or **Yes / No**.
+- **Type** — **Text**, **Number**, **Yes / No**, **List**, or **Choice**. **Number**
+  offers an optional min/max range, and **Choice** lets you define the allowed values.
 - **Description** — the question or hint the agent uses to ask for this field.
 - **Required** — toggle on for mandatory answers.
 
@@ -111,8 +112,8 @@ full walkthrough.
 
 - **The Create button is disabled** — the **Name** must be at least 3 characters.
 - **I don't see the field type I need** — the visual editor covers **Text**,
-  **Number** and **Yes / No**; use **Advanced mode** (raw JSON) for lists or nested
-  objects.
+  **Number**, **Yes / No**, **List** and **Choice**; use **Advanced mode** (raw JSON)
+  for **nested objects**.
 - **The agent asks questions in the wrong order** — turn on **Ask questions in this
   order** and drag the fields into the sequence you want.
 - **My changes disappeared** — each tab saves separately; click **Save** before

--- a/apps/help/src/content/docs/en/add-a-user.mdx
+++ b/apps/help/src/content/docs/en/add-a-user.mdx
@@ -4,7 +4,7 @@ highlight: user
 description: Invite someone by email to use one of your agents, and manage that agent's members and pending invitations.
 category: guides-team
 order: 1
-updated: 2026-07-10
+updated: 2026-07-22
 ---
 
 import AgentMembersWalkthrough from "@/components/AgentMembersWalkthrough.astro"

--- a/apps/help/src/content/docs/en/add-an-admin.mdx
+++ b/apps/help/src/content/docs/en/add-an-admin.mdx
@@ -4,7 +4,7 @@ highlight: admin
 description: Invite people to your workspace by email so they can collaborate, and manage members and pending invitations.
 category: guides-team
 order: 2
-updated: 2026-07-09
+updated: 2026-07-22
 ---
 
 import MembersWalkthrough from "@/components/MembersWalkthrough.astro"

--- a/apps/help/src/content/docs/en/add-an-extraction-agent.mdx
+++ b/apps/help/src/content/docs/en/add-an-extraction-agent.mdx
@@ -4,7 +4,7 @@ highlight: extraction
 description: Create an extraction agent that reads an uploaded document and returns structured data matching a JSON schema you define.
 category: guides-agents
 order: 2
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddExtractionAgentWalkthrough from "@/components/AddExtractionAgentWalkthrough.astro"
@@ -74,7 +74,8 @@ Open the **Output** tab and build the fields to extract **visually** — no JSON
 required. Click **Add field** and, for each field, set:
 
 - **Field name** — the key it's stored under (e.g. `title`).
-- **Type** — **Text**, **Number**, or **Yes / No**.
+- **Type** — **Text**, **Number**, **Yes / No**, **List**, or **Choice**. **Number**
+  offers an optional min/max range, and **Choice** lets you define the allowed values.
 - **Description** — the hint the agent uses to decide what to put there.
 - **Required** — toggle on for fields the agent must fill.
 
@@ -105,15 +106,16 @@ full walkthrough.
   repeatable output rather than creative answers.
 - Mark only genuinely mandatory fields as **Required**; the agent returns `null`
   for a required value it can't find.
-- The visual editor offers **Text**, **Number** and **Yes / No** fields. For richer
-  shapes (lists, nested objects) switch to **Advanced mode** and edit the JSON.
+- The visual editor offers **Text**, **Number**, **Yes / No**, **List** and
+  **Choice** fields. For **nested objects**, switch to **Advanced mode** and edit the
+  JSON.
 
 ## Troubleshooting
 
 - **The Create button is disabled** — the **Name** must be at least 3 characters.
 - **I don't see the field type I need** — the visual editor covers **Text**,
-  **Number** and **Yes / No**; use **Advanced mode** (raw JSON) for lists or nested
-  objects.
+  **Number**, **Yes / No**, **List** and **Choice**; use **Advanced mode** (raw JSON)
+  for **nested objects**.
 - **My schema won't save in Advanced mode** — it must be a valid JSON object; the
   editor shows *Output JSON schema must be a valid JSON object* and keeps you in
   Advanced mode until you fix it.

--- a/apps/help/src/content/docs/en/agent-embed.mdx
+++ b/apps/help/src/content/docs/en/agent-embed.mdx
@@ -4,7 +4,7 @@ highlight: Embed
 description: Put a conversation agent on your own website as a chat widget — enable embedding, copy the script snippet, restrict which sites can load it, and match your branding.
 category: guides-agents
 order: 6
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import EmbedWalkthrough from "@/components/EmbedWalkthrough.astro"
@@ -17,8 +17,13 @@ to.
 Embedding is configured on the **Embed** tab of a **conversation agent's** editor, in
 **Studio**. It's an optional feature: the tab only appears when your workspace has
 embedding enabled and you're editing a **conversation** agent (extraction and form
-agents don't have it). In the editor's tab row it's the **last** tab, after
-[**Orchestration**](/en/agent-orchestration).
+agents don't have it). In the editor's tab row it's the last tab, after
+[**Orchestration**](/en/agent-orchestration) — unless the **MCP Servers** tab is
+enabled, which sits after it.
+
+> **Ask to have it enabled.** Embedding is turned on per workspace. If your
+> conversation agent's editor has no **Embed** tab, the feature isn't enabled for
+> your workspace yet — contact the Bayes team to request it.
 
 ## How embedding works
 
@@ -50,7 +55,8 @@ editor. You need permission to manage the agent.
 
 ### 2. Open the Embed tab
 
-In the editor's tab row, click **Embed** — it's the last tab. If you don't see it, the
+In the editor's tab row, click **Embed** — the last tab (unless the **MCP Servers**
+tab is enabled, which sits after it). If you don't see it, the
 tab is either not enabled for your workspace or you're not on a **conversation** agent
 (see Troubleshooting).
 

--- a/apps/help/src/content/docs/en/agent-orchestration.mdx
+++ b/apps/help/src/content/docs/en/agent-orchestration.mdx
@@ -4,7 +4,7 @@ highlight: Orchestration
 description: Turn a conversation agent into an orchestrator that delegates parts of a conversation to sub-agents — attach other agents as tools, describe when to use each, and enable or disable them.
 category: guides-agents
 order: 5
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import OrchestrationWalkthrough from "@/components/OrchestrationWalkthrough.astro"
@@ -19,6 +19,10 @@ agent's** editor, in **Studio**. It's an optional feature: the tab only appears 
 your workspace has orchestration enabled and you're editing a **conversation** agent
 (extraction and form agents don't have it). In the editor's tab row it sits after
 **Conversation categories** and before [**Embed**](/en/agent-embed).
+
+> **Ask to have it enabled.** Orchestration is turned on per workspace. If your
+> conversation agent's editor has no **Orchestration** tab, the feature isn't enabled
+> for your workspace yet — contact the Bayes team to request it.
 
 ## How orchestration works
 

--- a/apps/help/src/content/docs/en/agent-version-history.mdx
+++ b/apps/help/src/content/docs/en/agent-version-history.mdx
@@ -4,7 +4,7 @@ highlight: history
 description: Every time you save an agent, its settings are versioned — browse past versions, compare exactly what changed, and restore any earlier version in one click.
 category: guides-agents
 order: 7
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import VersionHistoryWalkthrough from "@/components/VersionHistoryWalkthrough.astro"
@@ -21,8 +21,8 @@ button in the top right of the agent editor — no matter which tab you're on.
 
 A version captures the agent's saved settings, and the comparison highlights exactly
 which of them changed between two versions, field by field — for example
-**Instructions**, **Greeting**, **Model**, **Temperature**, **Language**, the document
-**search** mode, and the **output schema**. Restoring never deletes anything: it
+**Instructions**, **Greeting**, **Model**, **Temperature**, **Locale**, the **Answer
+source** mode, and the **output schema**. Restoring never deletes anything: it
 copies an old version's settings into a **new** current version.
 
 ## The full flow at a glance

--- a/apps/help/src/content/docs/en/analytics.mdx
+++ b/apps/help/src/content/docs/en/analytics.mdx
@@ -4,7 +4,7 @@ highlight: Analytics
 description: Read your workspace's conversation analytics — daily conversations, average questions per session, and sessions by category — and filter by agent and date range.
 category: guides-eval
 order: 1
-updated: 2026-07-13
+updated: 2026-07-22
 ---
 
 import AnalyticsWalkthrough from "@/components/AnalyticsWalkthrough.astro"
@@ -17,6 +17,10 @@ engaged users are, and how sessions break down by category — that you can filt
 You open it from **Analytics** in the left sidebar of **Studio**. The dashboard
 covers the whole **workspace**; each conversation agent also has its own Analytics
 view, reached from the agent's page.
+
+> **Optional feature — ask to have it enabled.** Analytics is turned on per
+> workspace. If you don't see **Analytics** in the Studio sidebar, the feature isn't
+> enabled for your workspace yet — contact the Bayes team to request it.
 
 ## What the dashboard shows
 

--- a/apps/help/src/content/docs/en/apps-overview.mdx
+++ b/apps/help/src/content/docs/en/apps-overview.mdx
@@ -4,7 +4,7 @@ highlight: overview
 description: Understand the different apps you open from a workspace — App, Studio, Evaluation, Test and Review — what each is for, and why you may see only some of them.
 category: getting-started
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AppsOverviewWalkthrough from "@/components/AppsOverviewWalkthrough.astro"

--- a/apps/help/src/content/docs/en/chat-with-an-agent.mdx
+++ b/apps/help/src/content/docs/en/chat-with-an-agent.mdx
@@ -4,7 +4,7 @@ highlight: Chat
 description: Use the App to talk to the agents built for your workspace — pick an agent, start a chat, send messages, attach files or dictate, and use each answer's feedback, copy, and sources.
 category: getting-started
 order: 4
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AppChatWalkthrough from "@/components/AppChatWalkthrough.astro"

--- a/apps/help/src/content/docs/en/create-a-workspace.md
+++ b/apps/help/src/content/docs/en/create-a-workspace.md
@@ -1,29 +1,35 @@
 ---
 title: Create your first workspace
 highlight: workspace
-description: Learn how to create a workspace and organize your work.
+description: Create a workspace, rename it, and delete it.
 category: getting-started
 order: 5
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
-Workspaces are the main way to organize your work. Each workspace keeps its own
-resources and settings separate from your other workspaces.
+A **workspace** groups the agents, sources and settings for one body of work, kept
+separate from your other workspaces. Every workspace belongs to an **organization**.
 
 ## Create a workspace
 
-1. Open the workspace switcher in the top-left corner.
-2. Select **Create Workspace**.
-3. Give the workspace a clear, descriptive name.
-4. Confirm to create it.
+1. On the **home page**, find the organization you want the workspace in — each
+   organization lists its workspaces as cards.
+2. Click the **New Workspace** card (*Manage your conversational agents, form agents
+   and other types of agents.*).
+3. In the **Create Workspace** dialog, enter a clear, descriptive **name**.
+4. Click **Create**. Your new workspace opens automatically, ready for content.
 
-Your new workspace opens automatically, ready for you to start adding content.
+## Rename a workspace
 
-## Rename or delete a workspace
+1. Open the workspace and select **Admin** in the left sidebar (settings group).
+2. In the **General** section, edit the **Workspace name** field.
+3. Click **Save**.
 
-You can rename a workspace at any time from its settings page. Deleting a
-workspace is permanent and removes all of its contents, so make sure you no
-longer need anything inside it first.
+## Delete a workspace
+
+From the workspace **overview** (its agents page), use the **trash** control to open
+the **Delete Workspace** dialog. Deleting is **irreversible** — it removes the
+workspace and everything inside it — so make sure you no longer need anything first.
 
 ## Tips
 

--- a/apps/help/src/content/docs/en/documents.mdx
+++ b/apps/help/src/content/docs/en/documents.mdx
@@ -4,7 +4,7 @@ highlight: Documents
 description: Upload documents so their content becomes part of your agents' knowledge, and manage them with tags.
 category: guides-sources
 order: 1
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import DocumentsWalkthrough from "@/components/DocumentsWalkthrough.astro"
@@ -96,8 +96,13 @@ can be nested under a **parent tag**.
 Hover any tag to **edit** it (pencil) or **delete** it (trash). The reserved
 **`public-documents`** tag can't be edited or deleted.
 
-> The reserved tag **`public-documents`** is special: when a document carrying it
-> is surfaced in a conversation, the user is allowed to download it.
+> The reserved tag **`public-documents`** controls **who can download an uploaded
+> document**. Workspace admins and owners can always download any document from
+> Studio (the **⋮** menu above); a **regular member** can download a document only
+> when it carries `public-documents`. They do it from a **conversation**: under an
+> assistant reply they open the **Sources** panel and click **Download Document** on
+> the file. The Sources panel is itself an optional feature — if replies show no
+> **Sources** button, contact the Bayes team to enable it.
 
 ## Tips
 

--- a/apps/help/src/content/docs/en/evaluation-dashboard.mdx
+++ b/apps/help/src/content/docs/en/evaluation-dashboard.mdx
@@ -4,7 +4,7 @@ highlight: dashboard
 description: Test an extraction agent against a CSV dataset — upload your records, map the columns, run the agent, and read the match rate and per-record results.
 category: guides-eval
 order: 3
-updated: 2026-07-15
+updated: 2026-07-22
 ---
 
 import EvaluationDashboardWalkthrough from "@/components/EvaluationDashboardWalkthrough.astro"
@@ -17,6 +17,10 @@ per-record breakdown of where the agent's output matched, mismatched, or errored
 The **Evaluation** app is opened from your **workspace** card on the home page (the
 **Evaluation** button, with a flask icon). It's an optional feature, and today it
 covers **extraction agents** only.
+
+> **Ask to have it enabled.** The **Evaluation** app is turned on per workspace. If
+> you don't see the **Evaluation** button on your workspace card, the feature isn't
+> enabled for your workspace yet — contact the Bayes team to request it.
 
 > **Two different features share the word "Evaluation".** This guide covers the
 > **Evaluation dashboard** — the standalone app for bulk-testing an **extraction

--- a/apps/help/src/content/docs/en/evaluations.mdx
+++ b/apps/help/src/content/docs/en/evaluations.mdx
@@ -4,7 +4,7 @@ highlight: Evaluations
 description: Create input → expected-output test cases and run them against any agent to check its answers — each run adds a report with the agent's output, a score, and a status.
 category: guides-eval
 order: 2
-updated: 2026-07-15
+updated: 2026-07-22
 ---
 
 import EvaluationsWalkthrough from "@/components/EvaluationsWalkthrough.astro"
@@ -18,6 +18,10 @@ agents and settings side by side.
 You open **Evaluations** from its card on your **workspace overview** in **Studio**
 (the card reads *Test the performance of your agents*). It's an optional feature and
 belongs to the **workspace**.
+
+> **Ask to have it enabled.** Evaluations are turned on per workspace. If you don't
+> see the **Evaluations** card on your workspace overview, the feature isn't enabled
+> for your workspace yet — contact the Bayes team to request it.
 
 > **Two different features share the word "Evaluation".** This guide covers
 > **Evaluations** — lightweight input → expected-output test cases you run against any

--- a/apps/help/src/content/docs/en/frequently-asked-questions.md
+++ b/apps/help/src/content/docs/en/frequently-asked-questions.md
@@ -4,7 +4,7 @@ highlight: questions
 description: Quick answers to the questions we hear most often.
 category: faq
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
 ## How do I reset my password?
@@ -24,5 +24,5 @@ members of your workspace.
 
 ## Who do I contact for more help?
 
-Reach out to your workspace administrator, or contact support from within the
-app if the issue persists.
+Reach out to your workspace administrator, or contact the Bayes team if the issue
+persists.

--- a/apps/help/src/content/docs/en/manage-your-profile.md
+++ b/apps/help/src/content/docs/en/manage-your-profile.md
@@ -1,21 +1,29 @@
 ---
 title: Manage your profile
 highlight: profile
-description: Update your display name and language.
+description: Edit your name and switch the app language from the user menu.
 category: account
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
-Your profile controls your display name and the language the app uses for you.
+Your profile settings live in the **user menu** — the card at the **bottom of the
+left sidebar** showing your name and email. Click it to open the menu.
 
-## Update your details
+## Edit your name
 
-Open the user menu in the top-right corner and select **Edit profile**. From
-there you can change your display name and other personal details.
+1. Open the **user menu** (bottom of the left sidebar).
+2. Select **Edit profile**.
+3. In the **Edit profile** dialog, update the **Name** field.
+4. Click **Save**.
 
-## Change the language
+## Switch the language
 
-The app is available in several languages. Pick your preferred language from the
-user menu — the change applies immediately and is remembered next time you sign
-in.
+The same menu has a language toggle that switches between **English** and **French**.
+It reads **Switch to English** when the app is in French, and **Choisir le Français**
+when the app is in English. Selecting it changes the language immediately.
+
+## Also in the user menu
+
+- **Help Center** — opens this help center.
+- **Log out** — signs you out.

--- a/apps/help/src/content/docs/en/mcp-servers.mdx
+++ b/apps/help/src/content/docs/en/mcp-servers.mdx
@@ -1,0 +1,135 @@
+---
+title: MCP Servers
+highlight: MCP
+description: Connect external MCP tool servers to your workspace and enable them per agent, so an agent can call outside tools while it answers.
+category: guides-agents
+order: 8
+updated: 2026-07-22
+---
+
+import McpServersWalkthrough from "@/components/McpServersWalkthrough.astro"
+
+An **MCP server** is an external service that exposes **tools** an agent can call
+while it works — for example to look something up or trigger an action in another
+system. You connect a server once at the **workspace** level, then turn it on for the
+individual agents that should use it.
+
+MCP servers have two surfaces in **Studio**: a workspace-level **MCP Servers** page
+(its own item in the left sidebar, next to **Members** and **Admin**), where you
+connect and remove servers; and an **MCP Servers** tab in a **conversation agent's**
+editor, where you enable a connected server for that agent.
+
+> **Optional feature — ask to have it enabled.** MCP servers are turned on per
+> workspace. If you don't see **MCP Servers** in the Studio sidebar, the feature
+> isn't enabled for your workspace yet — contact the Bayes team to request it.
+
+## How MCP servers work
+
+- A server is connected to the **workspace** with a **Name**, a **URL**, and an
+  optional **API Key**. The key is stored encrypted and is never shown again after
+  you save it.
+- Connecting a server does **not** by itself give any agent access to it. You enable
+  each server **per agent** from the agent's **MCP Servers** tab — a server that is
+  off for an agent is invisible to it.
+- There is **no edit**: a server has only **connect** and **delete**. To change a
+  URL or key, delete the server and connect it again.
+- Deleting a server removes it for **every** agent that was using it — those agents
+  immediately lose access to its tools.
+
+## The full flow at a glance
+
+The walkthrough below replays every step in the real interface. Use **Prev / Next**
+to move at your own pace; each step highlights the button to click and the area to
+watch.
+
+<McpServersWalkthrough lang="en" />
+
+## Step by step
+
+### 1. Open MCP Servers
+
+In **Studio**, open the left sidebar and select **MCP Servers** (server icon). It
+sits in the settings group below **Sources**, alongside **Members** and **Admin**.
+
+### 2. Start connecting a server
+
+The page lists the servers already connected to the workspace, with a short
+description: **Manage external tool servers connected to this workspace.** When none
+exist yet, an empty state reads **No MCP servers configured yet. Add one to give your
+agents access to external tools.** Click **New Server** (top-right) to connect one.
+
+### 3. Fill in the server details
+
+The **Add MCP Server** dialog opens (**Connect an external MCP server to this
+workspace.**). Fill in:
+
+- **Name** — a label for the server (placeholder **Enter server name**). Required.
+- **URL** — the server's address, e.g. `https://mcp.example.com`. Required, and must
+  be a valid URL.
+- **API Key** — an optional authentication key (placeholder **Optional
+  authentication key**). It's write-only: stored encrypted and never displayed
+  again.
+
+Click **Create** to connect the server (or **Cancel** to close without saving).
+
+### 4. See the connected server
+
+The server appears as a **card** in the list, showing its **Name** and its **URL**.
+Repeat **New Server** for as many servers as you need.
+
+### 5. Remove a server
+
+Each card has a single action: the **trash icon** on its right. There is no edit or
+overflow menu — connect and delete are the only actions.
+
+### 6. Confirm the deletion
+
+Clicking the trash icon opens the **Delete MCP Server** confirmation: *Are you sure
+you want to delete “…”? Agents using this server will lose access to its tools.*
+Confirm with **Delete**, or **Cancel** to keep it.
+
+### 7. Open an agent to enable a server for it
+
+Connecting a server doesn't enable it anywhere yet. In **Studio**, open a
+**conversation agent** to edit it (from the sidebar **Agents** list or its card on
+the workspace overview).
+
+### 8. Open the MCP Servers tab
+
+In the agent editor, open the **MCP Servers** tab. It's the **last** tab, after
+[**Orchestration**](/en/agent-orchestration) and [**Embed**](/en/agent-embed), and
+it appears **only** once the workspace has at least one connected server.
+
+### 9. Toggle a server on for this agent
+
+The tab lists every server connected to the workspace, each with a **switch**.
+Toggle a server **on** to give this agent access to its tools; toggle it **off** to
+remove that access. The change takes effect immediately — there's no separate Save
+on this tab.
+
+### 10. Jump back to manage servers
+
+The tab header has a **Manage servers** link (external-link icon) that opens the
+workspace **MCP Servers** page in a new tab, so you can connect or remove servers
+without losing your place in the editor.
+
+## Tips
+
+- Give each server a clear **Name** — it's what you (and the per-agent switch list)
+  see, so it should say what the server does.
+- Keep the **API Key** handy elsewhere: because it's never shown again, the only way
+  to change it is to delete and reconnect the server.
+- Enable a server only for the agents that actually need it — a server left off for
+  an agent is invisible to it.
+
+## Troubleshooting
+
+- **There's no MCP Servers item in the sidebar** — the feature isn't enabled for your
+  workspace; contact the Bayes team to request it.
+- **An agent has no MCP Servers tab** — the tab only appears once the workspace has
+  at least one connected server. Connect one on the **MCP Servers** page first.
+- **Create is blocked** — the **URL** must be a valid address (for example starting
+  with `https://`), and the **Name** can't be empty.
+- **An agent stopped using a server's tools** — check the server is still **on** for
+  that agent in its **MCP Servers** tab, and that the server wasn't deleted on the
+  workspace page (deleting removes it for every agent).

--- a/apps/help/src/content/docs/en/message-feedback.mdx
+++ b/apps/help/src/content/docs/en/message-feedback.mdx
@@ -1,0 +1,80 @@
+---
+title: Message feedback
+highlight: feedback
+description: Read the problems users reported on an agent's messages — each report shows the exact message, its session and message IDs, and the reporter's comment.
+category: guides-eval
+order: 7
+updated: 2026-07-22
+---
+
+import MessageFeedbackWalkthrough from "@/components/MessageFeedbackWalkthrough.astro"
+
+While chatting, a user can flag a weak or wrong answer with **Report a problem with
+this message**. **Message feedback** is where you — as someone who manages the agent —
+read those reports, so you can spot recurring problems and improve the agent.
+
+Feedback is **per agent**: you open it from an agent's page in **Studio**, and it
+lists every report left on that agent's messages. It's visible only to people who can
+**manage** the agent (workspace owners and admins); it isn't behind a feature flag.
+
+## Where feedback comes from
+
+Reports are created by end users in a **conversation**, not in Studio. Under any
+assistant reply, a thumbs button opens **Report a problem with this message**; the
+user writes a free-text comment and clicks **Send**. Each comment becomes one entry on
+this page. See [Chat with an agent](/en/chat-with-an-agent) for the user's side.
+
+## The full flow at a glance
+
+The walkthrough below replays every step in the real interface. Use **Prev / Next**
+to move at your own pace; each step highlights the button to click and the area to
+watch.
+
+<MessageFeedbackWalkthrough lang="en" />
+
+## Step by step
+
+### 1. Open the Feedback card
+
+Open the agent from the **Agents** list in the left sidebar. On the agent's page, find
+the **Feedback** card — *Manage feedback on agent messages.* — and click its round
+**arrow** button to open it. (The card only appears if you can manage the agent.)
+
+### 2. Read the list of reports
+
+The **Feedback** page opens, titled **Feedback** with the agent's name and type
+underneath. It's a simple list — **newest first**, one entry per reported message.
+When there's nothing yet, you'll see the empty state instead (step 5).
+
+### 3. See the reported message
+
+The top card of each entry is the **exact agent message** that was reported, shown as
+it appeared to the user. Below it, a small line gives the **Session ID** and the
+**Message ID** so you can trace which conversation and message it came from.
+
+### 4. Read the report
+
+The card below it is the report itself: the **date** it was sent, then the reporter's
+free-text **comment**. There's no rating or category — just the message and the
+comment. The reporter's identity isn't shown, and there are no per-row actions.
+
+### 5. The empty state
+
+Until someone reports a message, the page shows **No feedback yet** — *No feedback on
+the agent's messages.*
+
+## Tips
+
+- Check feedback regularly: recurring comments about the same answer usually point to
+  an instruction, a source, or a model setting worth adjusting.
+- Use the **Session ID** and **Message ID** to locate the conversation the report came
+  from when you need the full context.
+
+## Troubleshooting
+
+- **There's no Feedback card on the agent's page** — the card and page are only
+  available to people who can **manage** the agent (owner/admin). Ask a workspace
+  admin if you need access.
+- **The page is empty** — no one has reported a message on this agent yet. Reports
+  come from the end-user **Report a problem with this message** action in a
+  conversation (see [Chat with an agent](/en/chat-with-an-agent)).

--- a/apps/help/src/content/docs/en/participate-as-a-tester.mdx
+++ b/apps/help/src/content/docs/en/participate-as-a-tester.mdx
@@ -4,7 +4,7 @@ highlight: tester
 description: You've been invited to test an agent in a review campaign — open the Test app, chat with the agent, rate each session and answer the questions, then submit the end-of-phase survey.
 category: guides-eval
 order: 5
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import TesterWalkthrough from "@/components/TesterWalkthrough.astro"

--- a/apps/help/src/content/docs/en/resource-libraries.mdx
+++ b/apps/help/src/content/docs/en/resource-libraries.mdx
@@ -4,7 +4,7 @@ highlight: libraries
 description: Create libraries of links and files your agents can surface to users during a conversation, and attach them to an agent.
 category: guides-sources
 order: 3
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import ResourceLibrariesWalkthrough from "@/components/ResourceLibrariesWalkthrough.astro"

--- a/apps/help/src/content/docs/en/review-as-a-reviewer.mdx
+++ b/apps/help/src/content/docs/en/review-as-a-reviewer.mdx
@@ -4,7 +4,7 @@ highlight: reviewer
 description: You've been invited as a reviewer in a review campaign — open the Reviewer app, read a tester's session, give your own independent (blind) rating, and consult the campaign report.
 category: guides-eval
 order: 6
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import ReviewerWalkthrough from "@/components/ReviewerWalkthrough.astro"

--- a/apps/help/src/content/docs/en/review-campaigns.mdx
+++ b/apps/help/src/content/docs/en/review-campaigns.mdx
@@ -4,7 +4,7 @@ highlight: campaigns
 description: Create a campaign to invite testers and reviewers to evaluate an agent, then read the aggregated results.
 category: guides-eval
 order: 4
-updated: 2026-07-09
+updated: 2026-07-22
 ---
 
 import ReviewCampaignsWalkthrough from "@/components/ReviewCampaignsWalkthrough.astro"
@@ -56,7 +56,10 @@ campaigns; the first time, it shows **No review campaigns yet**.
 2. In **General**, give the campaign a **Name** and pick the **Target agent** (the
    agent being evaluated). A **Description** is optional.
 3. Open the **Questions** tab and build the questionnaire (detailed below).
-4. Click **Create campaign** (top-right of the editor). It's saved as a **Draft**.
+4. Open the **Preview** tab to check what testers will see — a read-only preview of
+   the **After each session** feedback form and the **End-of-phase survey**, built
+   from your questions.
+5. Click **Create campaign** (top-right of the editor). It's saved as a **Draft**.
 
 ### 3. Build the questions
 

--- a/apps/help/src/content/docs/en/run-an-extraction.mdx
+++ b/apps/help/src/content/docs/en/run-an-extraction.mdx
@@ -4,7 +4,7 @@ highlight: extraction
 description: Run an extraction agent on a document — a single PDF or image, or a CSV batch — and read, download, and manage the extracted results.
 category: guides-agents
 order: 4
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import RunExtractionWalkthrough from "@/components/RunExtractionWalkthrough.astro"
@@ -29,7 +29,7 @@ a labelled dataset).
 - Open the extraction agent and start a **New Extraction**. Drop a file or pick one
   you've already uploaded (**PDF**, **image**, or **CSV**, one file at a time).
 - A **PDF/image** runs immediately and opens a **result page** with the extracted
-  JSON. A **CSV** opens a short dialog to set each column's role, then runs every row.
+  JSON. A **CSV** opens a short **page** to set each column's role, then runs every row.
 - Every run is saved to the **history** on the agent's page, tagged **PDF / Image** or
   **CSV**, so you can reopen or delete it later.
 
@@ -71,7 +71,7 @@ While it's still running you'll see *Processing... This may take a while...*
 
 ### 4. Configure and run a CSV batch
 
-For a CSV, the **Run CSV Extraction** dialog opens (*Run each record through the
+For a CSV, the **Run CSV Extraction** page opens (*Run each record through the
 agent*). In **Configure column roles**, set a role for each column:
 
 - **Input** — sent to the agent for that record.

--- a/apps/help/src/content/docs/en/web-sources.mdx
+++ b/apps/help/src/content/docs/en/web-sources.mdx
@@ -4,7 +4,7 @@ highlight: Web
 description: Crawl websites so their content becomes part of your agents' knowledge, and organize sources with tags.
 category: guides-sources
 order: 2
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import WebSourcesWalkthrough from "@/components/WebSourcesWalkthrough.astro"
@@ -16,13 +16,19 @@ workspace can draw on its pages to answer users.
 Web sources live under **Sources**, alongside [Documents](/en/documents) and [Resource libraries](/en/resource-libraries),
 and belong to the **workspace**.
 
+> **Optional feature — ask to have it enabled.** Web sources are turned on per
+> workspace. If you don't see **Web sources** under **Sources** in Studio, the
+> feature isn't enabled for your workspace yet — contact the Bayes team to request
+> it.
+
 ## How agents use web sources
 
 A crawled web source is indexed as knowledge in the workspace. Once its
 **Embedding Status** is **Ready**, agents can retrieve relevant pages from it to
-answer users. Use **tags** to organize your sources and control how they are used
-— for example, the reserved `public-documents` tag lets users download a source
-when it's surfaced in a conversation.
+answer users. Use **tags** to organize your sources and control how they are used.
+Note that, unlike an uploaded [document](/en/documents), a **crawled web source is
+never offered to users as a download** — its pages have no stored file — so the
+reserved `public-documents` tag has no download effect on a web source.
 
 ## The full flow at a glance
 
@@ -101,16 +107,18 @@ The tag then appears in the source's **Tags** column.
 3. Enter a **Name** and an optional **Description**, then click **Create**.
 4. From the tags panel you can **Edit** or **Delete** any tag at any time.
 
-> The reserved tag **`public-documents`** is special: when a document or source
-> carrying it is surfaced in a conversation, the user is allowed to download it.
+> The reserved **`public-documents`** tag only makes **uploaded
+> [Documents](/en/documents)** downloadable by users in a conversation. A crawled
+> web source can't be downloaded even when tagged, because its pages have no stored
+> file.
 
 ## Tips
 
 - Crawl the most relevant sections of a site — the whole site is indexed, so a
   focused, well-structured site gives the best answers.
 - **Recrawl** after the website changes so your agents stay up to date.
-- Use tags to keep large sets of sources organized and to control which ones are
-  downloadable by users.
+- Use tags to keep large sets of sources organized and to control how your agents
+  use them.
 
 ## Troubleshooting
 

--- a/apps/help/src/content/docs/en/welcome.md
+++ b/apps/help/src/content/docs/en/welcome.md
@@ -4,7 +4,7 @@ highlight: Welcome
 description: A quick overview of what you can do on the platform and where to find help.
 category: getting-started
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
 Welcome! This help center gathers guides, walkthroughs, and answers to common
@@ -25,4 +25,4 @@ categories from the home page. On desktop, press `/` to jump straight to search.
 ## Still need help?
 
 If you can't find what you're looking for, reach out to your workspace
-administrator or contact support from within the app.
+administrator or contact the Bayes team.

--- a/apps/help/src/content/docs/en/workspace-admin.mdx
+++ b/apps/help/src/content/docs/en/workspace-admin.mdx
@@ -4,7 +4,7 @@ highlight: workspace
 description: Use the Admin page to rename your workspace and manage its conversation categories — the labels that classify conversations and power the by-category analytics.
 category: guides-team
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import WorkspaceAdminWalkthrough from "@/components/WorkspaceAdminWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/accept-an-invitation.mdx
+++ b/apps/help/src/content/docs/fr/accept-an-invitation.mdx
@@ -4,7 +4,7 @@ highlight: invitation
 description: Accédez à la plateforme pour la première fois — acceptez les conditions, retrouvez vos invitations en attente, et rejoignez les espaces de travail auxquels vous êtes invité.
 category: getting-started
 order: 2
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import OnboardingWalkthrough from "@/components/OnboardingWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/add-a-conversation-agent.mdx
+++ b/apps/help/src/content/docs/fr/add-a-conversation-agent.mdx
@@ -4,7 +4,7 @@ highlight: conversationnel
 description: Créez un agent conversationnel qui discute avec les utilisateurs, en s'appuyant sur les documents et les bibliothèques de ressources de votre espace de travail.
 category: guides-agents
 order: 1
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddConversationAgentWalkthrough from "@/components/AddConversationAgentWalkthrough.astro"
@@ -123,9 +123,9 @@ guide complet.
   dans un grand espace de travail.
 - Pensez à **Enregistrer** chaque onglet — les modifications d'un onglet ne sont pas
   conservées si vous passez à un autre sans enregistrer.
-- **Catégories de conversation**, **Orchestration** et **Intégration** n'apparaissent
-  que si l'espace de travail a des catégories ou si ces fonctionnalités sont activées
-  — vous verrez peut-être moins d'onglets.
+- **Catégories de conversation**, **Orchestration**, **Intégration** et **Serveurs
+  MCP** n'apparaissent que si l'espace de travail a des catégories ou si ces
+  fonctionnalités sont activées — vous verrez peut-être moins d'onglets.
 
 ## Dépannage
 

--- a/apps/help/src/content/docs/fr/add-a-form-agent.mdx
+++ b/apps/help/src/content/docs/fr/add-a-form-agent.mdx
@@ -4,7 +4,7 @@ highlight: formulaire
 description: Créez un agent de formulaire qui guide un utilisateur pour remplir un formulaire, en collectant des réponses structurées conformes à un schéma que vous définissez.
 category: guides-agents
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddFormAgentWalkthrough from "@/components/AddFormAgentWalkthrough.astro"
@@ -83,7 +83,9 @@ définissez :
 
 - **Nom du champ** — la clé sous laquelle la réponse est stockée (par ex.
   `full_name`).
-- **Type** — **Texte**, **Nombre** ou **Oui / Non**.
+- **Type** — **Texte**, **Nombre**, **Oui / Non**, **Liste** ou **Choix**. **Nombre**
+  propose une plage min/max optionnelle, et **Choix** permet de définir les valeurs
+  autorisées.
 - **Description** — la question ou l'indice que l'agent utilise pour demander ce
   champ.
 - **Obligatoire** — activez-le pour les réponses obligatoires.
@@ -126,8 +128,8 @@ guide complet.
 - **Le bouton Créer est désactivé** — le **Nom** doit comporter au moins 3
   caractères.
 - **Je ne vois pas le type de champ dont j'ai besoin** — l'éditeur visuel couvre
-  **Texte**, **Nombre** et **Oui / Non** ; utilisez le **Mode avancé** (JSON brut)
-  pour des listes ou des objets imbriqués.
+  **Texte**, **Nombre**, **Oui / Non**, **Liste** et **Choix** ; utilisez le **Mode
+  avancé** (JSON brut) pour des **objets imbriqués**.
 - **L'agent pose les questions dans le mauvais ordre** — activez **Poser les questions
   dans cet ordre** et glissez les champs dans la séquence voulue.
 - **Mes modifications ont disparu** — chaque onglet s'enregistre séparément ; cliquez

--- a/apps/help/src/content/docs/fr/add-a-user.mdx
+++ b/apps/help/src/content/docs/fr/add-a-user.mdx
@@ -4,7 +4,7 @@ highlight: utilisateur
 description: Invitez une personne par email à utiliser l'un de vos agents, et gérez les membres et les invitations en attente de cet agent.
 category: guides-team
 order: 1
-updated: 2026-07-10
+updated: 2026-07-22
 ---
 
 import AgentMembersWalkthrough from "@/components/AgentMembersWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/add-an-admin.mdx
+++ b/apps/help/src/content/docs/fr/add-an-admin.mdx
@@ -4,7 +4,7 @@ highlight: administrateur
 description: Invitez des personnes dans votre espace de travail par email pour collaborer, et gérez les membres et les invitations en attente.
 category: guides-team
 order: 2
-updated: 2026-07-09
+updated: 2026-07-22
 ---
 
 import MembersWalkthrough from "@/components/MembersWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/add-an-extraction-agent.mdx
+++ b/apps/help/src/content/docs/fr/add-an-extraction-agent.mdx
@@ -4,7 +4,7 @@ highlight: extraction
 description: Créez un agent d'extraction qui lit un document téléversé et renvoie des données structurées conformes à un schéma JSON que vous définissez.
 category: guides-agents
 order: 2
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AddExtractionAgentWalkthrough from "@/components/AddExtractionAgentWalkthrough.astro"
@@ -79,7 +79,9 @@ Ouvrez l'onglet **Sortie** et construisez les champs à extraire **visuellement*
 sans JSON. Cliquez sur **Ajouter un champ** et, pour chaque champ, définissez :
 
 - **Nom du champ** — la clé sous laquelle il est stocké (par ex. `title`).
-- **Type** — **Texte**, **Nombre** ou **Oui / Non**.
+- **Type** — **Texte**, **Nombre**, **Oui / Non**, **Liste** ou **Choix**. **Nombre**
+  propose une plage min/max optionnelle, et **Choix** permet de définir les valeurs
+  autorisées.
 - **Description** — l'indice que l'agent utilise pour décider quoi y mettre.
 - **Obligatoire** — activez-le pour les champs que l'agent doit remplir.
 
@@ -112,17 +114,17 @@ guide complet.
   voulez une sortie fidèle et reproductible plutôt que des réponses créatives.
 - Ne marquez comme **Obligatoire** que les champs réellement requis ; l'agent
   renvoie `null` pour une valeur obligatoire qu'il ne trouve pas.
-- L'éditeur visuel propose des champs **Texte**, **Nombre** et **Oui / Non**. Pour
-  des formes plus riches (listes, objets imbriqués), passez en **Mode avancé** et
-  éditez le JSON.
+- L'éditeur visuel propose des champs **Texte**, **Nombre**, **Oui / Non**, **Liste**
+  et **Choix**. Pour des **objets imbriqués**, passez en **Mode avancé** et éditez le
+  JSON.
 
 ## Dépannage
 
 - **Le bouton Créer est désactivé** — le **Nom** doit comporter au moins 3
   caractères.
 - **Je ne vois pas le type de champ dont j'ai besoin** — l'éditeur visuel couvre
-  **Texte**, **Nombre** et **Oui / Non** ; utilisez le **Mode avancé** (JSON brut)
-  pour des listes ou des objets imbriqués.
+  **Texte**, **Nombre**, **Oui / Non**, **Liste** et **Choix** ; utilisez le **Mode
+  avancé** (JSON brut) pour des **objets imbriqués**.
 - **Mon schéma ne s'enregistre pas en Mode avancé** — il doit être un objet JSON
   valide ; l'éditeur affiche *Le schéma JSON de sortie doit être un objet JSON valide*
   et vous maintient en Mode avancé jusqu'à correction.

--- a/apps/help/src/content/docs/fr/agent-embed.mdx
+++ b/apps/help/src/content/docs/fr/agent-embed.mdx
@@ -4,7 +4,7 @@ highlight: Intégration
 description: Placez un agent conversationnel sur votre propre site comme widget de chat — activez l'intégration, copiez l'extrait de script, restreignez les sites autorisés, et adaptez la marque.
 category: guides-agents
 order: 6
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import EmbedWalkthrough from "@/components/EmbedWalkthrough.astro"
@@ -18,8 +18,14 @@ L'intégration se configure sur l'onglet **Intégration** de l'éditeur d'un **a
 conversationnel**, dans **Studio**. C'est une fonctionnalité optionnelle : l'onglet
 n'apparaît que si l'intégration est activée pour votre espace de travail et que vous
 modifiez un agent **conversationnel** (les agents d'extraction et de formulaire ne
-l'ont pas). Dans la barre d'onglets de l'éditeur, c'est le **dernier** onglet, après
-[**Orchestration**](/fr/agent-orchestration).
+l'ont pas). Dans la barre d'onglets de l'éditeur, c'est le dernier onglet, après
+[**Orchestration**](/fr/agent-orchestration) — sauf si l'onglet **Serveurs MCP** est
+activé, qui se place après lui.
+
+> **À faire activer.** L'intégration s'active espace de travail par espace de
+> travail. Si l'éditeur de votre agent conversationnel n'a pas d'onglet
+> **Intégration**, c'est que la fonctionnalité n'est pas encore activée — contactez
+> l'équipe Bayes pour en faire la demande.
 
 ## Comment fonctionne l'intégration
 
@@ -53,8 +59,9 @@ l'agent.
 
 ### 2. Ouvrir l'onglet Intégration
 
-Dans la barre d'onglets de l'éditeur, cliquez sur **Intégration** — c'est le dernier
-onglet. Si vous ne le voyez pas, l'onglet n'est pas activé pour votre espace de
+Dans la barre d'onglets de l'éditeur, cliquez sur **Intégration** — le dernier onglet
+(sauf si l'onglet **Serveurs MCP** est activé, qui se place après lui). Si vous ne le
+voyez pas, l'onglet n'est pas activé pour votre espace de
 travail, ou vous n'êtes pas sur un agent **conversationnel** (voir Dépannage).
 
 ### 3. Activer l'intégration

--- a/apps/help/src/content/docs/fr/agent-orchestration.mdx
+++ b/apps/help/src/content/docs/fr/agent-orchestration.mdx
@@ -4,7 +4,7 @@ highlight: Orchestration
 description: Transformez un agent conversationnel en orchestrateur qui délègue des parties de la conversation à des sous-agents — rattachez d'autres agents comme outils, décrivez quand utiliser chacun, et activez-les ou désactivez-les.
 category: guides-agents
 order: 5
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import OrchestrationWalkthrough from "@/components/OrchestrationWalkthrough.astro"
@@ -21,6 +21,11 @@ n'apparaît que si l'orchestration est activée pour votre espace de travail et 
 modifiez un agent **conversationnel** (les agents d'extraction et de formulaire ne
 l'ont pas). Dans la barre d'onglets de l'éditeur, il se situe après **Catégories de
 conversation** et avant [**Intégration**](/fr/agent-embed).
+
+> **À faire activer.** L'orchestration s'active espace de travail par espace de
+> travail. Si l'éditeur de votre agent conversationnel n'a pas d'onglet
+> **Orchestration**, c'est que la fonctionnalité n'est pas encore activée — contactez
+> l'équipe Bayes pour en faire la demande.
 
 ## Comment fonctionne l'orchestration
 

--- a/apps/help/src/content/docs/fr/agent-version-history.mdx
+++ b/apps/help/src/content/docs/fr/agent-version-history.mdx
@@ -4,7 +4,7 @@ highlight: Historique
 description: À chaque enregistrement d'un agent, ses paramètres sont versionnés — parcourez les versions passées, comparez précisément ce qui a changé, et restaurez n'importe quelle version antérieure en un clic.
 category: guides-agents
 order: 7
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import VersionHistoryWalkthrough from "@/components/VersionHistoryWalkthrough.astro"
@@ -24,7 +24,7 @@ l'onglet ouvert.
 Une version capture les paramètres enregistrés de l'agent, et la comparaison met en
 évidence précisément lesquels ont changé entre deux versions, champ par champ — par
 exemple les **Instructions**, le **Message d'accueil**, le **Modèle**, la
-**Température**, la **Langue**, le mode de **recherche** documentaire, et le **schéma
+**Température**, la **Langue**, la **Source de réponse**, et le **schéma
 de sortie**. Restaurer ne supprime jamais rien : cela copie les paramètres d'une
 ancienne version dans une **nouvelle** version actuelle.
 

--- a/apps/help/src/content/docs/fr/analytics.mdx
+++ b/apps/help/src/content/docs/fr/analytics.mdx
@@ -4,7 +4,7 @@ highlight: Analytique
 description: Consultez les analyses de conversation de votre espace de travail — conversations par jour, questions moyennes par session, sessions par catégorie — et filtrez par agent et par plage de dates.
 category: guides-eval
 order: 1
-updated: 2026-07-13
+updated: 2026-07-22
 ---
 
 import AnalyticsWalkthrough from "@/components/AnalyticsWalkthrough.astro"
@@ -18,6 +18,11 @@ comment les sessions se répartissent par catégorie — que vous pouvez filtrer
 Vous l'ouvrez depuis **Analytique** dans la barre latérale gauche de **Studio**. Le
 tableau de bord couvre tout l'**espace de travail** ; chaque agent conversationnel
 possède aussi sa propre vue Analytique, accessible depuis la page de l'agent.
+
+> **Fonctionnalité optionnelle — à faire activer.** L'analytique s'active espace de
+> travail par espace de travail. Si vous ne voyez pas **Analytique** dans la barre
+> latérale de Studio, c'est que la fonctionnalité n'est pas encore activée pour votre
+> espace de travail — contactez l'équipe Bayes pour en faire la demande.
 
 ## Ce que montre le tableau de bord
 

--- a/apps/help/src/content/docs/fr/apps-overview.mdx
+++ b/apps/help/src/content/docs/fr/apps-overview.mdx
@@ -4,7 +4,7 @@ highlight: applications
 description: Comprenez les différentes applications que vous ouvrez depuis un espace de travail — Application, Studio, Évaluation, Test et Révision — à quoi sert chacune, et pourquoi vous n'en voyez parfois que certaines.
 category: getting-started
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AppsOverviewWalkthrough from "@/components/AppsOverviewWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/chat-with-an-agent.mdx
+++ b/apps/help/src/content/docs/fr/chat-with-an-agent.mdx
@@ -4,7 +4,7 @@ highlight: Discuter
 description: Utilisez l'Application pour parler aux agents créés pour votre espace de travail — choisissez un agent, démarrez une discussion, envoyez des messages, joignez des fichiers ou dictez, et utilisez le retour, la copie et les sources de chaque réponse.
 category: getting-started
 order: 4
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import AppChatWalkthrough from "@/components/AppChatWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/create-a-workspace.md
+++ b/apps/help/src/content/docs/fr/create-a-workspace.md
@@ -1,34 +1,43 @@
 ---
 title: Créez votre premier espace de travail
 highlight: espace de travail
-description: Découvrez comment créer un espace de travail et organiser votre travail.
+description: Créez un espace de travail, renommez-le et supprimez-le.
 category: getting-started
 order: 5
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
-Les espaces de travail sont le principal moyen d'organiser votre travail. Chaque
-espace de travail conserve ses propres ressources et paramètres, séparés de vos
-autres espaces de travail.
+Un **espace de travail** regroupe les agents, sources et paramètres d'un même travail,
+séparés de vos autres espaces de travail. Chaque espace de travail appartient à une
+**organisation**.
 
 ## Créer un espace de travail
 
-1. Ouvrez le sélecteur d'espace de travail en haut à gauche.
-2. Sélectionnez **Créer un espace de travail**.
-3. Donnez à l'espace de travail un nom clair et descriptif.
-4. Confirmez pour le créer.
+1. Sur la **page d'accueil**, repérez l'organisation dans laquelle créer l'espace de
+   travail — chaque organisation liste ses espaces de travail sous forme de cartes.
+2. Cliquez sur la carte **Nouvel espace de travail** (*Gérez vos agents
+   conversationnels, agents de formulaire et autres types d'agents.*).
+3. Dans la boîte de dialogue **Créer un espace de travail**, saisissez un **nom** clair
+   et descriptif.
+4. Cliquez sur **Créer**. Votre nouvel espace de travail s'ouvre automatiquement, prêt
+   à accueillir votre contenu.
 
-Votre nouvel espace de travail s'ouvre automatiquement, prêt à accueillir votre
-contenu.
+## Renommer un espace de travail
 
-## Renommer ou supprimer un espace de travail
+1. Ouvrez l'espace de travail et sélectionnez **Admin** dans la barre latérale gauche
+   (groupe des paramètres).
+2. Dans la section **Général**, modifiez le champ **Nom de l'espace de travail**.
+3. Cliquez sur **Enregistrer**.
 
-Vous pouvez renommer un espace de travail à tout moment depuis sa page de
-paramètres. La suppression d'un espace de travail est définitive et efface tout
-son contenu : assurez-vous de ne plus avoir besoin de rien à l'intérieur.
+## Supprimer un espace de travail
+
+Depuis la **vue d'ensemble** de l'espace de travail (sa page d'agents), utilisez le
+contrôle **corbeille** pour ouvrir la boîte de dialogue **Supprimer l'espace de
+travail**. La suppression est **irréversible** — elle efface l'espace de travail et
+tout son contenu — assurez-vous donc de ne plus avoir besoin de rien.
 
 ## Conseils
 
 - Adoptez une convention de nommage que vos coéquipiers reconnaîtront.
-- Séparez les travaux sans rapport dans des espaces de travail distincts pour
-  rester organisé.
+- Séparez les travaux sans rapport dans des espaces de travail distincts pour rester
+  organisé.

--- a/apps/help/src/content/docs/fr/documents.mdx
+++ b/apps/help/src/content/docs/fr/documents.mdx
@@ -4,7 +4,7 @@ highlight: Documents
 description: Téléversez des documents pour intégrer leur contenu aux connaissances de vos agents, et gérez-les avec des étiquettes.
 category: guides-sources
 order: 1
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import DocumentsWalkthrough from "@/components/DocumentsWalkthrough.astro"
@@ -101,9 +101,15 @@ Survolez une étiquette pour la **modifier** (crayon) ou la **supprimer**
 (corbeille). L'étiquette réservée **`public-documents`** ne peut être ni modifiée
 ni supprimée.
 
-> L'étiquette réservée **`public-documents`** est spéciale : lorsqu'un document qui
-> la porte est proposé dans une conversation, l'utilisateur est autorisé à le
-> télécharger.
+> L'étiquette réservée **`public-documents`** détermine **qui peut télécharger un
+> document téléversé**. Les administrateurs et propriétaires de l'espace de travail
+> peuvent toujours télécharger n'importe quel document depuis Studio (le menu **⋮**
+> ci-dessus) ; un **membre** ordinaire ne peut télécharger un document que s'il porte
+> `public-documents`. Il le fait depuis une **conversation** : sous une réponse de
+> l'assistant, il ouvre le panneau **Sources** et clique sur **Télécharger le
+> document** sur le fichier. Le panneau Sources est lui-même une fonctionnalité
+> optionnelle — si les réponses n'affichent pas de bouton **Sources**, contactez
+> l'équipe Bayes pour l'activer.
 
 ## Conseils
 

--- a/apps/help/src/content/docs/fr/evaluation-dashboard.mdx
+++ b/apps/help/src/content/docs/fr/evaluation-dashboard.mdx
@@ -4,7 +4,7 @@ highlight: Tableau de bord
 description: Testez un agent d'extraction sur un dataset CSV — téléversez vos enregistrements, mappez les colonnes, lancez l'agent, et lisez le taux de correspondance et les résultats par enregistrement.
 category: guides-eval
 order: 3
-updated: 2026-07-15
+updated: 2026-07-22
 ---
 
 import EvaluationDashboardWalkthrough from "@/components/EvaluationDashboardWalkthrough.astro"
@@ -19,6 +19,11 @@ L'application **Évaluation** s'ouvre depuis la carte de votre **espace de trava
 sur la page d'accueil (le bouton **Évaluation**, avec une icône de fiole). C'est une
 fonctionnalité optionnelle, et elle couvre aujourd'hui uniquement les **agents
 d'extraction**.
+
+> **À faire activer.** L'application **Évaluation** s'active espace de travail par
+> espace de travail. Si vous ne voyez pas le bouton **Évaluation** sur la carte de
+> votre espace de travail, c'est que la fonctionnalité n'est pas encore activée —
+> contactez l'équipe Bayes pour en faire la demande.
 
 > **Deux fonctionnalités différentes partagent le mot « Évaluation ».** Ce guide
 > couvre le **tableau de bord d'évaluation** — l'application autonome pour tester en

--- a/apps/help/src/content/docs/fr/evaluations.mdx
+++ b/apps/help/src/content/docs/fr/evaluations.mdx
@@ -4,7 +4,7 @@ highlight: Évaluations
 description: Créez des cas de test entrée → résultat attendu et lancez-les sur n'importe quel agent pour vérifier ses réponses — chaque exécution ajoute un rapport avec la sortie de l'agent, un score et un statut.
 category: guides-eval
 order: 2
-updated: 2026-07-15
+updated: 2026-07-22
 ---
 
 import EvaluationsWalkthrough from "@/components/EvaluationsWalkthrough.astro"
@@ -18,6 +18,11 @@ ajoute un **rapport** montrant ce que l'agent a réellement renvoyé, un **score
 Vous ouvrez les **Évaluations** depuis leur carte sur la **vue d'ensemble de votre
 espace de travail** dans **Studio** (la carte indique *Tester les performances de vos
 agents*). C'est une fonctionnalité optionnelle, rattachée à l'**espace de travail**.
+
+> **À faire activer.** Les évaluations s'activent espace de travail par espace de
+> travail. Si vous ne voyez pas la carte **Évaluations** sur la vue d'ensemble de
+> votre espace de travail, c'est que la fonctionnalité n'est pas encore activée —
+> contactez l'équipe Bayes pour en faire la demande.
 
 > **Deux fonctionnalités différentes partagent le mot « Évaluation ».** Ce guide
 > couvre les **Évaluations** — des cas de test légers entrée → résultat attendu que

--- a/apps/help/src/content/docs/fr/frequently-asked-questions.md
+++ b/apps/help/src/content/docs/fr/frequently-asked-questions.md
@@ -4,7 +4,7 @@ highlight: Questions
 description: Réponses rapides aux questions les plus fréquentes.
 category: faq
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
 ## Comment réinitialiser mon mot de passe ?
@@ -26,5 +26,5 @@ membres de votre espace de travail.
 
 ## Qui contacter pour plus d'aide ?
 
-Contactez l'administrateur de votre espace de travail, ou le support depuis
-l'application si le problème persiste.
+Contactez l'administrateur de votre espace de travail, ou l'équipe Bayes si le
+problème persiste.

--- a/apps/help/src/content/docs/fr/manage-your-profile.md
+++ b/apps/help/src/content/docs/fr/manage-your-profile.md
@@ -1,22 +1,30 @@
 ---
 title: Gérez votre profil
 highlight: profil
-description: Modifiez votre nom d'affichage et votre langue.
+description: Modifiez votre nom et changez la langue de l'application depuis le menu utilisateur.
 category: account
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
-Votre profil détermine votre nom d'affichage et la langue de l'application.
+Les paramètres de votre profil se trouvent dans le **menu utilisateur** — la carte en
+**bas de la barre latérale gauche** affichant votre nom et votre email. Cliquez dessus
+pour ouvrir le menu.
 
-## Mettre à jour vos informations
+## Modifier votre nom
 
-Ouvrez le menu utilisateur en haut à droite et sélectionnez **Modifier le
-profil**. Vous pouvez y changer votre nom d'affichage et d'autres informations
-personnelles.
+1. Ouvrez le **menu utilisateur** (en bas de la barre latérale gauche).
+2. Sélectionnez **Modifier le profil**.
+3. Dans la boîte de dialogue **Modifier le profil**, mettez à jour le champ **Nom**.
+4. Cliquez sur **Enregistrer**.
 
 ## Changer de langue
 
-L'application est disponible en plusieurs langues. Choisissez votre langue
-préférée depuis le menu utilisateur — le changement s'applique immédiatement et
-est mémorisé à votre prochaine connexion.
+Le même menu contient une bascule de langue entre **anglais** et **français**. Elle
+affiche **Switch to English** quand l'application est en français, et **Choisir le
+Français** quand elle est en anglais. La sélectionner change la langue immédiatement.
+
+## Également dans le menu utilisateur
+
+- **Centre d'aide** — ouvre ce centre d'aide.
+- **Se déconnecter** — vous déconnecte.

--- a/apps/help/src/content/docs/fr/mcp-servers.mdx
+++ b/apps/help/src/content/docs/fr/mcp-servers.mdx
@@ -1,0 +1,150 @@
+---
+title: Serveurs MCP
+highlight: MCP
+description: Connectez des serveurs d'outils MCP externes à votre espace de travail et activez-les par agent, pour qu'un agent puisse appeler des outils externes pendant qu'il répond.
+category: guides-agents
+order: 8
+updated: 2026-07-22
+---
+
+import McpServersWalkthrough from "@/components/McpServersWalkthrough.astro"
+
+Un **serveur MCP** est un service externe qui expose des **outils** qu'un agent peut
+appeler pendant qu'il travaille — par exemple pour rechercher une information ou
+déclencher une action dans un autre système. Vous connectez un serveur une seule fois
+au niveau de l'**espace de travail**, puis vous l'activez pour chacun des agents qui
+doivent l'utiliser.
+
+Les serveurs MCP ont deux surfaces dans **Studio** : une page **Serveurs MCP** au
+niveau de l'espace de travail (son propre élément dans la barre latérale gauche, à
+côté de **Membres** et **Admin**), où vous connectez et supprimez des serveurs ; et un
+onglet **Serveurs MCP** dans l'éditeur d'un **agent conversationnel**, où vous activez
+un serveur connecté pour cet agent.
+
+> **Fonctionnalité optionnelle — à faire activer.** Les serveurs MCP s'activent espace
+> de travail par espace de travail. Si vous ne voyez pas **Serveurs MCP** dans la
+> barre latérale de Studio, c'est que la fonctionnalité n'est pas encore activée pour
+> votre espace de travail — contactez l'équipe Bayes pour en faire la demande.
+
+## Comment fonctionnent les serveurs MCP
+
+- Un serveur est connecté à l'**espace de travail** avec un **Nom**, une **URL** et
+  une **Clé API** facultative. La clé est stockée chiffrée et n'est plus jamais
+  affichée après l'enregistrement.
+- Connecter un serveur ne donne **pas** à lui seul accès à un agent. Vous activez
+  chaque serveur **par agent** depuis l'onglet **Serveurs MCP** de l'agent — un
+  serveur désactivé pour un agent lui est invisible.
+- Il n'y a **pas de modification** : un serveur ne propose que **connecter** et
+  **supprimer**. Pour changer une URL ou une clé, supprimez le serveur et
+  reconnectez-le.
+- Supprimer un serveur le retire pour **tous** les agents qui l'utilisaient — ces
+  agents perdent aussitôt l'accès à ses outils.
+
+## Le parcours complet en un coup d'œil
+
+La démonstration ci-dessous rejoue chaque étape dans l'interface réelle. Utilisez
+**Précédent / Suivant** pour avancer à votre rythme ; chaque étape met en valeur le
+bouton à cliquer et la zone à observer.
+
+<McpServersWalkthrough lang="fr" />
+
+## Étape par étape
+
+### 1. Ouvrir Serveurs MCP
+
+Dans **Studio**, ouvrez la barre latérale de gauche et sélectionnez **Serveurs MCP**
+(icône serveur). Elle se trouve dans le groupe des paramètres, sous **Sources**, aux
+côtés de **Membres** et **Admin**.
+
+### 2. Commencer à connecter un serveur
+
+La page liste les serveurs déjà connectés à l'espace de travail, avec une courte
+description : **Gérer les serveurs d'outils externes connectés à cet espace de
+travail.** Quand il n'y en a aucun, un état vide indique **Aucun serveur MCP
+configuré. Ajoutez-en un pour donner à vos agents accès à des outils externes.**
+Cliquez sur **Nouveau serveur** (en haut à droite) pour en connecter un.
+
+### 3. Renseigner les détails du serveur
+
+La boîte de dialogue **Ajouter un serveur MCP** s'ouvre (**Connecter un serveur MCP
+externe à cet espace de travail.**). Renseignez :
+
+- **Nom** — un libellé pour le serveur (indication **Entrez le nom du serveur**).
+  Obligatoire.
+- **URL** — l'adresse du serveur, par ex. `https://mcp.example.com`. Obligatoire, et
+  doit être une URL valide.
+- **Clé API** — une clé d'authentification facultative (indication **Clé
+  d'authentification optionnelle**). En écriture seule : stockée chiffrée et jamais
+  réaffichée.
+
+Cliquez sur **Créer** pour connecter le serveur (ou sur **Annuler** pour fermer sans
+enregistrer).
+
+### 4. Voir le serveur connecté
+
+Le serveur apparaît sous forme de **carte** dans la liste, affichant son **Nom** et
+son **URL**. Répétez **Nouveau serveur** pour autant de serveurs que nécessaire.
+
+### 5. Supprimer un serveur
+
+Chaque carte a une seule action : l'**icône corbeille** à sa droite. Il n'y a ni
+modification ni menu d'options — connecter et supprimer sont les seules actions.
+
+### 6. Confirmer la suppression
+
+Cliquer sur l'icône corbeille ouvre la confirmation **Supprimer le serveur MCP** :
+*Êtes-vous sûr de vouloir supprimer « … » ? Les agents utilisant ce serveur perdront
+l'accès à ses outils.* Confirmez avec **Supprimer**, ou **Annuler** pour le
+conserver.
+
+### 7. Ouvrir un agent pour lui activer un serveur
+
+Connecter un serveur ne l'active encore nulle part. Dans **Studio**, ouvrez un **agent
+conversationnel** pour le modifier (depuis la liste **Agents** de la barre latérale ou
+sa carte sur la vue d'ensemble de l'espace de travail).
+
+### 8. Ouvrir l'onglet Serveurs MCP
+
+Dans l'éditeur de l'agent, ouvrez l'onglet **Serveurs MCP**. C'est le **dernier**
+onglet, après [**Orchestration**](/fr/agent-orchestration) et
+[**Intégration**](/fr/agent-embed), et il n'apparaît **que** lorsque l'espace de
+travail a au moins un serveur connecté.
+
+### 9. Activer un serveur pour cet agent
+
+L'onglet liste tous les serveurs connectés à l'espace de travail, chacun avec un
+**interrupteur**. Basculez un serveur **sur activé** pour donner à cet agent accès à
+ses outils ; basculez-le **sur désactivé** pour retirer cet accès. Le changement prend
+effet immédiatement — il n'y a pas de bouton Enregistrer distinct sur cet onglet.
+
+### 10. Revenir à la gestion des serveurs
+
+L'en-tête de l'onglet contient un lien **Gérer les serveurs** (icône lien externe) qui
+ouvre la page **Serveurs MCP** de l'espace de travail dans un nouvel onglet, pour
+connecter ou supprimer des serveurs sans perdre votre place dans l'éditeur.
+
+## Conseils
+
+- Donnez à chaque serveur un **Nom** clair — c'est ce que vous voyez (et ce
+  qu'affiche la liste d'interrupteurs par agent), il doit donc dire ce que fait le
+  serveur.
+- Gardez la **Clé API** ailleurs à portée de main : comme elle n'est jamais
+  réaffichée, la seule façon de la changer est de supprimer puis reconnecter le
+  serveur.
+- N'activez un serveur que pour les agents qui en ont réellement besoin — un serveur
+  laissé désactivé pour un agent lui est invisible.
+
+## Dépannage
+
+- **Aucun élément Serveurs MCP dans la barre latérale** — la fonctionnalité n'est pas
+  activée pour votre espace de travail ; contactez l'équipe Bayes pour en faire la
+  demande.
+- **Un agent n'a pas d'onglet Serveurs MCP** — l'onglet n'apparaît que lorsque
+  l'espace de travail a au moins un serveur connecté. Connectez-en un sur la page
+  **Serveurs MCP** d'abord.
+- **Créer est bloqué** — l'**URL** doit être une adresse valide (par exemple
+  commençant par `https://`), et le **Nom** ne peut pas être vide.
+- **Un agent n'utilise plus les outils d'un serveur** — vérifiez que le serveur est
+  toujours **activé** pour cet agent dans son onglet **Serveurs MCP**, et qu'il n'a
+  pas été supprimé sur la page de l'espace de travail (la suppression le retire pour
+  tous les agents).

--- a/apps/help/src/content/docs/fr/message-feedback.mdx
+++ b/apps/help/src/content/docs/fr/message-feedback.mdx
@@ -1,0 +1,90 @@
+---
+title: Retours utilisateurs
+highlight: Retours
+description: Consultez les problèmes signalés par les utilisateurs sur les messages d'un agent — chaque signalement montre le message exact, ses ID de session et de message, et le commentaire du rapporteur.
+category: guides-eval
+order: 7
+updated: 2026-07-22
+---
+
+import MessageFeedbackWalkthrough from "@/components/MessageFeedbackWalkthrough.astro"
+
+Pendant une conversation, un utilisateur peut signaler une réponse faible ou erronée
+avec **Signaler un problème avec ce message**. Les **Retours utilisateurs** sont
+l'endroit où vous — en tant que personne qui gère l'agent — lisez ces signalements,
+pour repérer les problèmes récurrents et améliorer l'agent.
+
+Les retours sont **par agent** : vous les ouvrez depuis la page d'un agent dans
+**Studio**, et ils listent chaque signalement laissé sur les messages de cet agent.
+Ils ne sont visibles que par les personnes qui peuvent **gérer** l'agent
+(propriétaires et administrateurs de l'espace de travail) ; ce n'est pas derrière un
+drapeau de fonctionnalité.
+
+## D'où viennent les retours
+
+Les signalements sont créés par les utilisateurs finaux dans une **conversation**, pas
+dans Studio. Sous n'importe quelle réponse de l'assistant, un bouton pouce ouvre
+**Signaler un problème avec ce message** ; l'utilisateur écrit un commentaire libre et
+clique sur **Envoyer**. Chaque commentaire devient une entrée sur cette page. Voir
+[Discuter avec un agent](/fr/chat-with-an-agent) pour le côté utilisateur.
+
+## Le parcours complet en un coup d'œil
+
+La démonstration ci-dessous rejoue chaque étape dans l'interface réelle. Utilisez
+**Précédent / Suivant** pour avancer à votre rythme ; chaque étape met en valeur le
+bouton à cliquer et la zone à observer.
+
+<MessageFeedbackWalkthrough lang="fr" />
+
+## Étape par étape
+
+### 1. Ouvrir la carte Retours utilisateurs
+
+Ouvrez l'agent depuis la liste **Agents** de la barre latérale gauche. Sur la page de
+l'agent, repérez la carte **Retours utilisateurs** — *Gérez les retours sur les
+messages de l'agent.* — et cliquez sur son bouton **flèche** rond pour l'ouvrir. (La
+carte n'apparaît que si vous pouvez gérer l'agent.)
+
+### 2. Lire la liste des signalements
+
+La page **Retours utilisateurs** s'ouvre, titrée **Retours utilisateurs** avec le nom
+et le type de l'agent en dessous. C'est une simple liste — **du plus récent au plus
+ancien**, une entrée par message signalé. Quand il n'y a encore rien, vous voyez
+l'état vide à la place (étape 5).
+
+### 3. Voir le message signalé
+
+La carte du haut de chaque entrée est le **message exact de l'agent** qui a été
+signalé, tel qu'il est apparu à l'utilisateur. En dessous, une petite ligne donne
+l'**ID de session** et l'**ID de message** pour retrouver de quelle conversation et de
+quel message il provient.
+
+### 4. Lire le signalement
+
+La carte en dessous est le signalement lui-même : la **date** d'envoi, puis le
+**commentaire** libre du rapporteur. Il n'y a ni note ni catégorie — juste le message
+et le commentaire. L'identité du rapporteur n'est pas affichée, et il n'y a aucune
+action par ligne.
+
+### 5. L'état vide
+
+Tant que personne n'a signalé de message, la page affiche **Pas encore de retours** —
+*Aucun avis sur les messages de l'agent.*
+
+## Conseils
+
+- Consultez les retours régulièrement : des commentaires récurrents sur la même
+  réponse pointent souvent vers une instruction, une source ou un réglage de modèle à
+  ajuster.
+- Servez-vous de l'**ID de session** et de l'**ID de message** pour retrouver la
+  conversation d'où vient le signalement quand vous avez besoin du contexte complet.
+
+## Dépannage
+
+- **Il n'y a pas de carte Retours utilisateurs sur la page de l'agent** — la carte et
+  la page ne sont accessibles qu'aux personnes qui peuvent **gérer** l'agent
+  (propriétaire/administrateur). Demandez à un administrateur de l'espace de travail si
+  vous avez besoin d'un accès.
+- **La page est vide** — personne n'a encore signalé de message sur cet agent. Les
+  signalements viennent de l'action utilisateur **Signaler un problème avec ce
+  message** dans une conversation (voir [Discuter avec un agent](/fr/chat-with-an-agent)).

--- a/apps/help/src/content/docs/fr/participate-as-a-tester.mdx
+++ b/apps/help/src/content/docs/fr/participate-as-a-tester.mdx
@@ -4,7 +4,7 @@ highlight: testeur
 description: Vous avez été invité à tester un agent dans une campagne d'évaluation — ouvrez l'app Test, discutez avec l'agent, notez chaque session et répondez aux questions, puis envoyez le questionnaire de fin de phase.
 category: guides-eval
 order: 5
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import TesterWalkthrough from "@/components/TesterWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/resource-libraries.mdx
+++ b/apps/help/src/content/docs/fr/resource-libraries.mdx
@@ -4,7 +4,7 @@ highlight: Bibliothèques
 description: Créez des bibliothèques de liens et de fichiers que vos agents peuvent proposer aux utilisateurs pendant une conversation, et rattachez-les à un agent.
 category: guides-sources
 order: 3
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import ResourceLibrariesWalkthrough from "@/components/ResourceLibrariesWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/review-as-a-reviewer.mdx
+++ b/apps/help/src/content/docs/fr/review-as-a-reviewer.mdx
@@ -4,7 +4,7 @@ highlight: relecteur
 description: Vous avez été invité comme relecteur dans une campagne d'évaluation — ouvrez l'app Relecteur, lisez la session d'un testeur, donnez votre propre note indépendante (à l'aveugle), et consultez le rapport de la campagne.
 category: guides-eval
 order: 6
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import ReviewerWalkthrough from "@/components/ReviewerWalkthrough.astro"

--- a/apps/help/src/content/docs/fr/review-campaigns.mdx
+++ b/apps/help/src/content/docs/fr/review-campaigns.mdx
@@ -4,7 +4,7 @@ highlight: Campagnes
 description: Créez une campagne pour inviter des testeurs et des relecteurs à évaluer un agent, puis consultez les résultats agrégés.
 category: guides-eval
 order: 4
-updated: 2026-07-09
+updated: 2026-07-22
 ---
 
 import ReviewCampaignsWalkthrough from "@/components/ReviewCampaignsWalkthrough.astro"
@@ -61,7 +61,10 @@ d'évaluation**. La page liste vos campagnes ; la première fois, elle affiche
    ciblé** (l'agent évalué). Une **Description** est facultative.
 3. Ouvrez l'onglet **Questions** et construisez le questionnaire (détaillé
    ci-dessous).
-4. Cliquez sur **Créer la campagne** (en haut à droite de l'éditeur). Elle est
+4. Ouvrez l'onglet **Aperçu** pour voir ce que verront les testeurs — un aperçu en
+   lecture seule du formulaire **Après chaque session** et du **Questionnaire de fin
+   de phase**, construit à partir de vos questions.
+5. Cliquez sur **Créer la campagne** (en haut à droite de l'éditeur). Elle est
    enregistrée en **Brouillon**.
 
 ### 3. Construire les questions

--- a/apps/help/src/content/docs/fr/run-an-extraction.mdx
+++ b/apps/help/src/content/docs/fr/run-an-extraction.mdx
@@ -4,7 +4,7 @@ highlight: extraction
 description: Lancez un agent d'extraction sur un document — un seul PDF ou image, ou un lot CSV — et lisez, téléchargez et gérez les résultats extraits.
 category: guides-agents
 order: 4
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import RunExtractionWalkthrough from "@/components/RunExtractionWalkthrough.astro"
@@ -31,7 +31,7 @@ précision sur un dataset annoté).
   fichier ou choisissez-en un déjà téléversé (**PDF**, **image** ou **CSV**, un
   fichier à la fois).
 - Un **PDF/image** s'exécute immédiatement et ouvre une **page de résultat** avec le
-  JSON extrait. Un **CSV** ouvre une courte boîte de dialogue pour définir le rôle de
+  JSON extrait. Un **CSV** ouvre une courte **page** pour définir le rôle de
   chaque colonne, puis exécute chaque ligne.
 - Chaque exécution est enregistrée dans l'**historique** sur la page de l'agent,
   étiquetée **PDF / Image** ou **CSV**, pour la rouvrir ou la supprimer plus tard.
@@ -76,7 +76,7 @@ temps...*
 
 ### 4. Configurer et lancer un lot CSV
 
-Pour un CSV, la boîte de dialogue **Lancer l'extraction CSV** s'ouvre (*Exécutez
+Pour un CSV, la page **Lancer l'extraction CSV** s'ouvre (*Exécutez
 chaque enregistrement via l'agent*). Dans **Configurer les rôles des colonnes**,
 attribuez un rôle à chaque colonne :
 

--- a/apps/help/src/content/docs/fr/web-sources.mdx
+++ b/apps/help/src/content/docs/fr/web-sources.mdx
@@ -4,7 +4,7 @@ highlight: web
 description: Explorez des sites web pour intégrer leur contenu aux connaissances de vos agents, et organisez les sources avec des étiquettes.
 category: guides-sources
 order: 2
-updated: 2026-07-20
+updated: 2026-07-22
 ---
 
 import WebSourcesWalkthrough from "@/components/WebSourcesWalkthrough.astro"
@@ -17,14 +17,21 @@ pages pour répondre aux utilisateurs.
 Les sites web se trouvent dans **Sources**, aux côtés des [Documents](/fr/documents) et des
 [Bibliothèques de ressources](/fr/resource-libraries), et appartiennent à l'**espace de travail**.
 
+> **Fonctionnalité optionnelle — à faire activer.** Les sites web s'activent espace
+> de travail par espace de travail. Si vous ne voyez pas **Sites web** sous
+> **Sources** dans Studio, c'est que la fonctionnalité n'est pas encore activée pour
+> votre espace de travail — contactez l'équipe Bayes pour en faire la demande.
+
 ## Comment les agents utilisent les sources web
 
 Une source web explorée est indexée comme connaissance dans l'espace de travail.
 Une fois son **statut des embeddings** à **Prêt**, les agents peuvent en récupérer
 les pages pertinentes pour répondre aux utilisateurs. Utilisez les **étiquettes**
-pour organiser vos sources et contrôler leur usage — par exemple, l'étiquette
-réservée `public-documents` autorise l'utilisateur à télécharger une source
-lorsqu'elle est proposée dans une conversation.
+pour organiser vos sources et contrôler leur usage. À noter : contrairement à un
+[document](/fr/documents) téléversé, une **source web explorée n'est jamais proposée
+au téléchargement** aux utilisateurs — ses pages n'ont pas de fichier stocké — donc
+l'étiquette réservée `public-documents` n'a aucun effet de téléchargement sur une
+source web.
 
 ## Le parcours complet en un coup d'œil
 
@@ -109,9 +116,10 @@ L'étiquette apparaît alors dans la colonne **Tags** de la source.
 4. Depuis ce panneau, vous pouvez **Modifier** ou **Supprimer** une étiquette à
    tout moment.
 
-> L'étiquette réservée **`public-documents`** est spéciale : lorsqu'un document ou
-> une source qui la porte est proposé dans une conversation, l'utilisateur est
-> autorisé à le télécharger.
+> L'étiquette réservée **`public-documents`** ne rend téléchargeables que les
+> **[Documents](/fr/documents) téléversés**, dans une conversation. Une source web
+> explorée ne peut pas être téléchargée même si elle porte l'étiquette, car ses
+> pages n'ont pas de fichier stocké.
 
 ## Conseils
 
@@ -119,7 +127,7 @@ L'étiquette apparaît alors dans la colonne **Tags** de la source.
   donc un site ciblé et bien structuré donne les meilleures réponses.
 - **Ré-explorez** après une modification du site pour que vos agents restent à jour.
 - Utilisez les étiquettes pour organiser de grands ensembles de sources et
-  contrôler celles que les utilisateurs peuvent télécharger.
+  contrôler la façon dont vos agents les utilisent.
 
 ## Dépannage
 

--- a/apps/help/src/content/docs/fr/welcome.md
+++ b/apps/help/src/content/docs/fr/welcome.md
@@ -4,7 +4,7 @@ highlight: Bienvenue
 description: Un aperçu rapide de ce que vous pouvez faire sur la plateforme et où trouver de l'aide.
 category: getting-started
 order: 1
-updated: 2026-07-08
+updated: 2026-07-22
 ---
 
 Bienvenue ! Ce centre d'aide rassemble des guides, des tutoriels et des réponses
@@ -26,4 +26,4 @@ sur `/` pour accéder directement à la recherche.
 ## Besoin d'aide supplémentaire ?
 
 Si vous ne trouvez pas ce que vous cherchez, contactez l'administrateur de votre
-espace de travail ou le support depuis l'application.
+espace de travail ou l'équipe Bayes.

--- a/apps/help/src/content/docs/fr/workspace-admin.mdx
+++ b/apps/help/src/content/docs/fr/workspace-admin.mdx
@@ -4,7 +4,7 @@ highlight: espace de travail
 description: Utilisez la page Admin pour renommer votre espace de travail et gérer ses catégories de conversation — les étiquettes qui classent les conversations et alimentent l'analytique par catégorie.
 category: guides-team
 order: 3
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 import WorkspaceAdminWalkthrough from "@/components/WorkspaceAdminWalkthrough.astro"


### PR DESCRIPTION
## Summary

Adds two new help-center guides and generalizes the "optional feature" callouts on guides gated behind a feature flag.

- **New guides**: *MCP Servers* and *Message feedback* (EN + FR), each with its animated walkthrough component (`McpServersWalkthrough.astro`, `MessageFeedbackWalkthrough.astro`).
- **Feature-flag callouts**: a blockquote callout (EN + FR) on guides whose feature is enabled per flag (analytics, evaluations, web-sources, agent-embed, orchestration, mcp…), telling the reader the feature is optional and how to get it enabled.
- **Content enrichment**: updates to several existing guides + refreshed `updated` dates.
- **Rules**: documented the feature-flag callout rule and the additive `##` section rule in `apps/help/CLAUDE.md`.

All changes stay confined to `apps/help`.

## Notes

The per-tenant theming work already landed via #557; this PR only contains the new documentation content, on a branch based off the up-to-date `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)