### PR TITLE
fix(tester): stop feedback modal buttons stretching full-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - French UI: the "Add library" button on an agent's Resources tab is now translated
 - Markdown (`.md`) files can be uploaded as documents, like other plain-text formats
 - Extraction agents accept Markdown and plain-text documents, in addition to PDF, images and CSV
+- Tester feedback form: the submit and back buttons no longer stretch full-width, fixing the layout on smaller screens
 
 ### Security
 

--- a/apps/web/src/tester/features/review-campaigns/components/TesterFeedbackModal.tsx
+++ b/apps/web/src/tester/features/review-campaigns/components/TesterFeedbackModal.tsx
@@ -109,10 +109,10 @@ export function TesterFeedbackModal({ open, questions, onSubmit, onAbandon }: Pr
         </div>
 
         <DialogFooter className="p-6 pt-2 shrink-0 flex-col">
-          <Button type="button" disabled={!canSubmit} onClick={handleSubmit} className="w-full">
+          <Button type="button" disabled={!canSubmit} onClick={handleSubmit}>
             {t("testerCampaigns:feedbackModal.submit")}
           </Button>
-          <Button type="button" variant="ghost" onClick={onAbandon} className="w-full">
+          <Button type="button" variant="ghost" onClick={onAbandon}>
             {t("actions:back")}
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary
The submit and back buttons in the tester campaign feedback modal were forced to full width (`w-full`), causing a responsive layout issue on the campaign feedback form. Removing `w-full` lets the buttons size naturally.