### PR TITLE
chore: set up Claude Code worktrees (.worktreeinclude + gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ llm-logs/
 # Smart IDEs
 .cursorrules
 
+# Claude Code worktrees
+.claude/worktrees/
+
 *.venv*
 
 # Python

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,9 @@
+# Gitignored files copied into every new Claude Code worktree
+# (see https://code.claude.com/docs/en/worktrees)
+# Gitignore syntax: a bare pattern matches at any depth, so `.env` covers
+# apps/api/.env, apps/web/.env, infra/database/.env — and any future one
+.env
+.env.test
+# GCP credentials referenced by apps/api/.env — root dontsave/ only,
+# so infra/database/dontsave/pgdata is never copied
+dontsave/*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,15 @@ All commands should be run from the root directory using Turbo (via npm scripts)
 - Use semantic commit messages consistent with the repo history: `feat: ...`, `fix: ...`, `chore: ...`.
 - Use scoped variants only when they match existing history and add clarity.
 
+## Working in a Worktree (Claude Code)
+
+Claude Code worktrees live under `.claude/worktrees/`. Gitignored config (`.env`, `.env.test`, root `dontsave/*.json`) is copied in automatically via `.worktreeinclude`. In a fresh worktree:
+
+1. Run `npm ci` at the worktree root before anything else. Never `npm install` — it rewrites `package-lock.json` with cosmetic peer-flag churn that pollutes the diff.
+2. Postgres and Redis (`infra/database` compose stack) are shared with the main checkout through localhost ports. Do not start a second stack, and remember that schema/migration changes hit the shared database.
+3. Never start `npm run dev:workers-main` if workers already run in another checkout: two workers on the same Redis compete for the same BullMQ queues, and jobs may be processed by the other branch's code.
+4. Dev servers are usually unnecessary in a worktree — typecheck, lint, and tests run without them. To run a second live stack anyway, override the ports in the copied env files (`PORT`, `FRONT_PORT`, `VITE_API_URL`, `FRONTEND_URL`).
+
 ## Code Style
 
 ### Descriptive Variable Names in Loops


### PR DESCRIPTION
## What

- Add a root `.worktreeinclude` so Claude Code copies gitignored config into every new worktree: `.env` / `.env.test` (matches at any depth — `apps/api`, `apps/web`, `infra/database`) and root `dontsave/*.json` GCP credentials. The pattern is anchored so `infra/database/dontsave/pgdata` is never copied.
- Ignore `.claude/worktrees/`, the default location for Claude Code worktree checkouts.

## Why

Enables working with Claude agents in isolated git worktrees: fresh worktrees are clean checkouts, so without this the gitignored env files are missing and nothing runs.

## Verified

Smoke-tested end to end: created a worktree via Claude Code, confirmed all four env files were copied, dependencies install and `npx tsc --noEmit` pass in both `apps/api` and `apps/web`, then removed the worktree cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)