### PR TITLE
docs: clean readme and citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: "Bayes Platform (AgentStudio)"
+title: "Bayes Platform"
 abstract: >-
   Open-source platform for building multi-agent AI systems for the public
   interest, developed by the nonprofit Bayes Impact.
@@ -12,7 +12,7 @@ authors:
   - name: "Bayes Impact"
     website: "https://www.bayesimpact.org"
 license: MIT
-repository-code: "https://github.com/bayesimpact/agent-studio"
+repository-code: "https://github.com/bayesimpact/bayes-platform"
 url: "https://www.bayesimpact.org"
 keywords:
   - artificial intelligence
@@ -20,8 +20,6 @@ keywords:
   - public services
   - open source
   - nonprofit
-# TODO: once a release DOI is minted (GitHub ↔ Zenodo integration) or a JOSS
-# software paper is published, set `version` + `date-released` per release, add
-# the `doi:` here, and add a `preferred-citation:` block pointing at that paper/DOI
-# so it becomes the canonical reference (see CITING.md). Until then, GitHub's
-# "Cite this repository" button uses the software metadata above.
+# Zenodo integration is enabled — a release DOI will be minted on the first
+# GitHub release. When that happens, add `doi:`, `version:`, and `date-released:`
+# fields here, and add a `preferred-citation:` block if a JOSS paper is published.

--- a/CITING.md
+++ b/CITING.md
@@ -14,24 +14,23 @@ just want the platform's role on the record.
 
 A one-line mention in your Methods/Tools section:
 
-> Agents were built using the open-source Bayes Platform (AgentStudio; Bayes Impact),
-> available at <https://github.com/bayesimpact/agent-studio>.
+> Agents were built using the open-source Bayes Platform (Bayes Impact),
+> available at <https://github.com/bayesimpact/bayes-platform>.
 
 BibTeX:
 
 ```bibtex
 @software{bayes_platform,
   author = {{Bayes Impact}},
-  title  = {{Bayes Platform (AgentStudio)}},
-  url    = {https://github.com/bayesimpact/agent-studio},
+  title  = {{Bayes Platform}},
+  url    = {https://github.com/bayesimpact/bayes-platform},
   note   = {Open-source platform for multi-agent AI systems for the public interest},
   year   = {2026}
 }
 ```
 
-<!-- TODO: once a release DOI / JOSS paper exists, this becomes the canonical
-     citation (DOI + the paper). GitHub's "Cite this repository" button (from
-     CITATION.cff) will then export it automatically. -->
+<!-- Zenodo integration is enabled — once the first GitHub release is created,
+     update the BibTeX above with the minted DOI. -->
 
 > 💡 GitHub shows a **"Cite this repository"** button on this repo (powered by
 > `CITATION.cff`) that exports APA/BibTeX — point colleagues there.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 Bayes Impact is a technology nonprofit organization building AI recommendation systems for the public interest.
 As part of this work, we curate public and community resource datasets and make them usable by AI agents.
 
-Product updates: https://bayesimpact.notion.site/bayes-platform-product-updates
-
-# AgentStudio
+# Bayes platform
 
 ![Security](https://github.com/bayesimpact/caseai-connect/actions/workflows/security.yml/badge.svg)
 
@@ -142,7 +140,7 @@ VITE_AUTH0_AUDIENCE=https://your-tenant.auth0.com/api/v2/
 
 **Optional — in-platform help chat:**
 
-Set these two variables to embed a floating help chat bubble inside the Studio. The bubble uses the AgentStudio embed widget, so the target agent must have its embed config enabled and `VITE_AGENT_EMBED_URL`'s origin listed in `allowedOrigins`.
+Set these two variables to embed a floating help chat bubble inside the Studio. The bubble uses the Bayes platform embed widget, so the target agent must have its embed config enabled and `VITE_AGENT_EMBED_URL`'s origin listed in `allowedOrigins`.
 
 | Variable | Description |
 |---|---|


### PR DESCRIPTION
## Summary
- Rename AgentStudio → Bayes Platform in README heading, CITATION.cff, and CITING.md
- Fix stale `agent-studio` repo URLs → `bayes-platform`
- Remove Notion product-updates link from README
- Update Zenodo/DOI TODOs now that integration is enabled

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)