### PR TITLE
feat(backoffice): create organizations from the organizations panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Back-office administrators can create an organization directly from the organizations panel; the creating administrator becomes its owner
 
 ### Changed
 - Form agents are no longer a separate agent type: any conversation agent can now turn on "Form filling" from a new Tools tab, define the form fields with the visual schema editor (drag to set the order the agent asks its questions), and the agent fills the form from the user's answers during the chat; the collected values open from a "Show form state" button on the agent's replies; the agent creator still offers a "Form" choice, which now creates a conversation agent with form filling already enabled — existing form agents, with their sessions and settings history, are migrated to conversation agents with form filling enabled

--- a/apps/api/src/domains/backoffice/backoffice.controller.ts
+++ b/apps/api/src/domains/backoffice/backoffice.controller.ts
@@ -1,4 +1,9 @@
-import { BackofficeRoutes, type FeatureFlagKey, FeatureFlags } from "@caseai-connect/api-contracts"
+import {
+  BackofficeRoutes,
+  createBackofficeOrganizationSchema,
+  type FeatureFlagKey,
+  FeatureFlags,
+} from "@caseai-connect/api-contracts"
 import {
   BadRequestException,
   Body,
@@ -11,8 +16,10 @@ import {
   Query,
   Req,
   UseGuards,
+  UsePipes,
 } from "@nestjs/common"
 import type { EndpointRequest } from "@/common/context/request.interface"
+import { ZodValidationPipe } from "@/common/zod-validation-pipe"
 import { JwtAuthGuard } from "@/domains/auth/jwt-auth.guard"
 import { UserGuard } from "@/domains/users/user.guard"
 import { TrackActivity } from "../activities/track-activity.decorator"
@@ -231,6 +238,20 @@ export class BackofficeController {
     return {
       data: toBackofficeProjectDetailDto(result.project, result.members, result.agents),
     }
+  }
+
+  @Post(BackofficeRoutes.createOrganization.path)
+  @TrackActivity({ action: "backoffice.organization.create" })
+  @UsePipes(new ZodValidationPipe(createBackofficeOrganizationSchema))
+  async createOrganization(
+    @Req() request: EndpointRequest,
+    @Body() body: typeof BackofficeRoutes.createOrganization.request,
+  ): Promise<typeof BackofficeRoutes.createOrganization.response> {
+    const organization = await this.backofficeService.createOrganization({
+      actingUserId: request.user.id,
+      name: body.payload.name,
+    })
+    return { data: toBackofficeOrganizationDto(organization) }
   }
 
   @Post(BackofficeRoutes.addFeatureFlag.path)

--- a/apps/api/src/domains/backoffice/backoffice.service.ts
+++ b/apps/api/src/domains/backoffice/backoffice.service.ts
@@ -1,5 +1,10 @@
 import type { FeatureFlagKey } from "@caseai-connect/api-contracts"
-import { ForbiddenException, Injectable, NotFoundException } from "@nestjs/common"
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
 import { In, type Repository } from "typeorm"
 import type { AgentMembershipModel } from "@/domains/agents/memberships/agent-membership.model"
@@ -81,6 +86,29 @@ export class BackofficeService {
     private readonly agentMembershipsService: AgentMembershipsService,
     private readonly reviewCampaignMembershipsService: ReviewCampaignMembershipsService,
   ) {}
+
+  async createOrganization({
+    actingUserId,
+    name,
+  }: {
+    actingUserId: string
+    name: string
+  }): Promise<Organization> {
+    const trimmedName = name?.trim() ?? ""
+    if (trimmedName.length < 3) {
+      throw new BadRequestException("Organization name must be at least 3 characters long")
+    }
+
+    const organization = this.organizationRepository.create({ name: trimmedName })
+    const savedOrganization = await this.organizationRepository.save(organization)
+
+    await this.organizationMembershipsService.createOrganizationOwnerMembership({
+      userId: actingUserId,
+      organizationId: savedOrganization.id,
+    })
+
+    return savedOrganization
+  }
 
   async listOrganizations({
     canListAll,

--- a/apps/api/src/domains/backoffice/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/backoffice/e2e-tests/auth.spec.ts
@@ -132,6 +132,33 @@ describe("Backoffice - Auth", () => {
     })
   })
 
+  describe("BackofficeRoutes.createOrganization", () => {
+    const subject = async () =>
+      request({
+        route: BackofficeRoutes.createOrganization,
+        token: accessToken ?? undefined,
+        request: { payload: { name: "Sample Organization" } },
+      })
+
+    it("requires an authentication token", async () => {
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("rejects users whose email domain is not in BACKOFFICE_AUTHORIZED_DOMAIN", async () => {
+      await createOrganizationWithOwner(repositories, {
+        user: { auth0Id, email: mockAuth0EmailForSub(auth0Id) },
+      })
+      process.env.BACKOFFICE_AUTHORIZED_DOMAIN = "@other-domain.test"
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+    })
+
+    it("allows authorized users to create an organization", async () => {
+      await createAuthorizedUser()
+      expectResponse(await subject(), 201)
+    })
+  })
+
   describe("BackofficeRoutes.addFeatureFlag", () => {
     const subject = async (projectId: string) =>
       request({

--- a/apps/api/src/domains/backoffice/e2e-tests/create-organization.spec.ts
+++ b/apps/api/src/domains/backoffice/e2e-tests/create-organization.spec.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto"
+import { BackofficeRoutes } from "@caseai-connect/api-contracts"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { createOrganizationWithOwner } from "@/domains/organizations/organization.factory"
+import { mockAuth0EmailForSub, setupUserGuardForTesting } from "../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../test/request"
+import { BackofficeModule } from "../backoffice.module"
+
+describe("Backoffice - createOrganization", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let auth0Id = `auth0|${randomUUID()}`
+
+  const originalAuthorizedEmails = process.env.BACKOFFICE_AUTHORIZED_EMAILS
+  const originalAuthorizedDomain = process.env.BACKOFFICE_AUTHORIZED_DOMAIN
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [BackofficeModule],
+      applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    auth0Id = `auth0|${randomUUID()}`
+    delete process.env.BACKOFFICE_AUTHORIZED_DOMAIN
+    delete process.env.BACKOFFICE_AUTHORIZED_EMAILS
+  })
+
+  afterEach(() => {
+    if (originalAuthorizedEmails === undefined) {
+      delete process.env.BACKOFFICE_AUTHORIZED_EMAILS
+    } else {
+      process.env.BACKOFFICE_AUTHORIZED_EMAILS = originalAuthorizedEmails
+    }
+    if (originalAuthorizedDomain === undefined) {
+      delete process.env.BACKOFFICE_AUTHORIZED_DOMAIN
+    } else {
+      process.env.BACKOFFICE_AUTHORIZED_DOMAIN = originalAuthorizedDomain
+    }
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await app.close()
+  })
+
+  const createAuthorizedUser = async () => {
+    const email = mockAuth0EmailForSub(auth0Id)
+    const { user } = await createOrganizationWithOwner(repositories, {
+      user: { auth0Id, email },
+    })
+    process.env.BACKOFFICE_AUTHORIZED_DOMAIN = "@example.com"
+    process.env.BACKOFFICE_AUTHORIZED_EMAILS = email
+    return user
+  }
+
+  const subject = async (name: string) =>
+    request({
+      route: BackofficeRoutes.createOrganization,
+      token: "token",
+      request: { payload: { name } },
+    })
+
+  it("creates an organization and returns its dto", async () => {
+    await createAuthorizedUser()
+    const response = await subject("Sample Organization")
+    expectResponse(response, 201)
+    expect(response.body.data.name).toBe("Sample Organization")
+    const organization = await repositories.organizationRepository.findOne({
+      where: { id: response.body.data.id },
+    })
+    expect(organization).not.toBeNull()
+    expect(organization?.name).toBe("Sample Organization")
+  })
+
+  it("makes the acting backoffice user an owner of the created organization", async () => {
+    const user = await createAuthorizedUser()
+    const response = await subject("Sample Organization")
+    expectResponse(response, 201)
+    const membership = await repositories.userMembershipRepository.findOne({
+      where: {
+        userId: user.id,
+        resourceId: response.body.data.id,
+        resourceType: "organization",
+      },
+    })
+    expect(membership).not.toBeNull()
+    expect(membership?.role).toBe("owner")
+  })
+
+  it("trims the organization name", async () => {
+    await createAuthorizedUser()
+    const response = await subject("  Sample Organization  ")
+    expectResponse(response, 201)
+    expect(response.body.data.name).toBe("Sample Organization")
+  })
+
+  it("rejects names shorter than 3 characters", async () => {
+    await createAuthorizedUser()
+    const response = await subject("ab")
+    expectResponse(response, 400)
+  })
+
+  it("lists the created organization afterwards", async () => {
+    await createAuthorizedUser()
+    await subject("Sample Organization")
+    const response = await request({
+      route: BackofficeRoutes.listOrganizations,
+      token: "token",
+    })
+    expectResponse(response, 200)
+    const names = response.body.data.organizations.map(
+      (organization: { name: string }) => organization.name,
+    )
+    expect(names).toContain("Sample Organization")
+  })
+})

--- a/apps/web/src/backoffice/features/backoffice/backoffice.middleware.ts
+++ b/apps/web/src/backoffice/features/backoffice/backoffice.middleware.ts
@@ -50,6 +50,32 @@ function registerListeners() {
   })
 
   listenerMiddleware.startListening({
+    actionCreator: backofficeActions.createOrganization.fulfilled,
+    effect: async (_, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Organization created",
+          type: "success",
+        }),
+      )
+      listenerApi.dispatch(backofficeActions.listOrganizations({ page: 0, limit: 10 }))
+    },
+  })
+
+  listenerMiddleware.startListening({
+    actionCreator: backofficeActions.createOrganization.rejected,
+    effect: async (action, listenerApi) => {
+      listenerApi.dispatch(
+        notificationsActions.show({
+          title: "Failed to create organization",
+          description: action.error.message,
+          type: "error",
+        }),
+      )
+    },
+  })
+
+  listenerMiddleware.startListening({
     matcher: isAnyOf(
       backofficeActions.addFeatureFlag.fulfilled,
       backofficeActions.removeFeatureFlag.fulfilled,

--- a/apps/web/src/backoffice/features/backoffice/backoffice.spi.ts
+++ b/apps/web/src/backoffice/features/backoffice/backoffice.spi.ts
@@ -1,6 +1,7 @@
 import type { FeatureFlagKey } from "@caseai-connect/api-contracts"
 import type {
   BackofficeAgentDetail,
+  BackofficeOrganization,
   BackofficeOrganizationDetail,
   BackofficeProjectDetail,
   BackofficeUserDetail,
@@ -19,6 +20,7 @@ export interface IBackofficeSpi {
     search?: string
   }) => Promise<PaginatedBackofficeOrganizations>
   getOrganization: (organizationId: string) => Promise<BackofficeOrganizationDetail>
+  createOrganization: (params: { name: string }) => Promise<BackofficeOrganization>
   listAgents: (params: {
     page?: number
     limit?: number

--- a/apps/web/src/backoffice/features/backoffice/backoffice.thunks.ts
+++ b/apps/web/src/backoffice/features/backoffice/backoffice.thunks.ts
@@ -4,6 +4,7 @@ import type { RootState, ThunkExtraArg } from "@/common/store"
 
 import type {
   BackofficeAgentDetail,
+  BackofficeOrganization,
   BackofficeOrganizationDetail,
   BackofficeProjectDetail,
   BackofficeUserDetail,
@@ -24,6 +25,13 @@ const listOrganizations = createAsyncThunk<
 >("backoffice/fetchOrganizations", async (params, { extra: { services } }) => {
   return services.backoffice.listOrganizations(params ?? {})
 })
+
+const createOrganization = createAsyncThunk<BackofficeOrganization, { name: string }, ThunkConfig>(
+  "backoffice/createOrganization",
+  async (params, { extra: { services } }) => {
+    return services.backoffice.createOrganization(params)
+  },
+)
 
 const getOrganization = createAsyncThunk<BackofficeOrganizationDetail, string, ThunkConfig>(
   "backoffice/getOrganization",
@@ -111,6 +119,7 @@ const updateTermsDocuments = createAsyncThunk<
 export const backofficeThunks = {
   listOrganizations,
   getOrganization,
+  createOrganization,
   listAgents,
   getAgent,
   listProjects,

--- a/apps/web/src/backoffice/features/backoffice/components/OrganizationsPanel.tsx
+++ b/apps/web/src/backoffice/features/backoffice/components/OrganizationsPanel.tsx
@@ -1,4 +1,21 @@
+import { createBackofficeOrganizationSchema } from "@caseai-connect/api-contracts"
 import { Button } from "@caseai-connect/ui/shad/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@caseai-connect/ui/shad/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@caseai-connect/ui/shad/form"
+import { Input } from "@caseai-connect/ui/shad/input"
 import {
   Table,
   TableBody,
@@ -7,10 +24,13 @@ import {
   TableHeader,
   TableRow,
 } from "@caseai-connect/ui/shad/table"
+import { zodResolver } from "@hookform/resolvers/zod"
 import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table"
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
+import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
+import type { z } from "zod"
 import { BackofficeOrganizationRoutes } from "@/backoffice/routes/helpers"
 import { useMount } from "@/common/hooks/use-mount"
 import { useValue } from "@/common/hooks/use-value"
@@ -23,6 +43,8 @@ import {
 } from "../backoffice.selectors"
 import { backofficeActions } from "../backoffice.slice"
 import { SearchField } from "./BackofficeTable"
+
+type CreateOrganizationFormValues = z.infer<typeof createBackofficeOrganizationSchema>
 
 const DEFAULT_PAGE_SIZE = 10
 
@@ -110,12 +132,13 @@ function WithData() {
 
   return (
     <>
-      <div className="p-4 border-b">
+      <div className="p-4 border-b flex items-center gap-2">
         <SearchField
           value={searchInput}
           onChange={setSearchInput}
           placeholder="Search by name or UUID…"
         />
+        <CreateOrganizationDialog />
       </div>
       <Table>
         <TableHeader className="bg-muted/50">
@@ -188,6 +211,76 @@ function WithData() {
           </Button>
         </div>
       </div>
+    </>
+  )
+}
+
+function CreateOrganizationDialog() {
+  const dispatch = useAppDispatch()
+  const [open, setOpen] = useState(false)
+
+  const form = useForm<CreateOrganizationFormValues>({
+    resolver: zodResolver(createBackofficeOrganizationSchema),
+    defaultValues: { name: "" },
+  })
+
+  const close = () => {
+    setOpen(false)
+    form.reset({ name: "" })
+  }
+
+  const onValid = async ({ name }: CreateOrganizationFormValues) => {
+    try {
+      await dispatch(backofficeActions.createOrganization({ name })).unwrap()
+      close()
+    } catch {
+      // The middleware shows the error notification; keep the dialog open for a retry.
+    }
+  }
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <PlusIcon className="size-4" />
+        Create organization
+      </Button>
+      <Dialog open={open} onOpenChange={(isOpen) => !isOpen && close()}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Create organization</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onValid)} className="flex flex-col gap-2">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Organization name" autoFocus {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter className="mt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={close}
+                  disabled={form.formState.isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                  Create
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/apps/web/src/backoffice/features/backoffice/components/OrganizationsPanel.tsx
+++ b/apps/web/src/backoffice/features/backoffice/components/OrganizationsPanel.tsx
@@ -132,12 +132,14 @@ function WithData() {
 
   return (
     <>
-      <div className="p-4 border-b flex items-center gap-2">
-        <SearchField
-          value={searchInput}
-          onChange={setSearchInput}
-          placeholder="Search by name or UUID…"
-        />
+      <div className="p-4 border-b flex items-center justify-between gap-2">
+        <div className="flex-1">
+          <SearchField
+            value={searchInput}
+            onChange={setSearchInput}
+            placeholder="Search by name or UUID…"
+          />
+        </div>
         <CreateOrganizationDialog />
       </div>
       <Table>

--- a/apps/web/src/backoffice/features/backoffice/external/backoffice.api.ts
+++ b/apps/web/src/backoffice/features/backoffice/external/backoffice.api.ts
@@ -2,6 +2,7 @@ import { BackofficeRoutes } from "@caseai-connect/api-contracts"
 import { getAxiosInstance } from "@/external/axios"
 import {
   toBackofficeAgentDetail,
+  toBackofficeOrganization,
   toBackofficeOrganizationDetail,
   toBackofficeProjectDetail,
   toBackofficeUserDetail,
@@ -32,6 +33,14 @@ export default {
       BackofficeRoutes.getOrganization.getPath({ organizationId }),
     )
     return toBackofficeOrganizationDetail(response.data.data)
+  },
+  createOrganization: async ({ name }) => {
+    const axios = getAxiosInstance()
+    const response = await axios.post<typeof BackofficeRoutes.createOrganization.response>(
+      BackofficeRoutes.createOrganization.getPath(),
+      { payload: { name } } satisfies typeof BackofficeRoutes.createOrganization.request,
+    )
+    return toBackofficeOrganization(response.data.data)
   },
   listAgents: async ({ page, limit, search }) => {
     const axios = getAxiosInstance()

--- a/apps/web/src/stories/routes/backoffice/helpers.tsx
+++ b/apps/web/src/stories/routes/backoffice/helpers.tsx
@@ -181,6 +181,9 @@ export function buildMockBackofficeService(overrides: {
     async listOrganizations() {
       return organizations
     },
+    async createOrganization({ name }) {
+      return backofficeOrganizationFactory.build({ name })
+    },
     async getOrganization(organizationId) {
       const detail = organizationDetails[organizationId]
       if (!detail) {

--- a/packages/api-contracts/src/backoffice/backoffice.dto.ts
+++ b/packages/api-contracts/src/backoffice/backoffice.dto.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import type { AgentMembershipRoleDto } from "../agent-membership/agent-membership.dto"
 import type { FeatureFlagsDto } from "../feature-flags/feature-flags.dto"
 import type { TimeType } from "../generic"
@@ -26,6 +27,16 @@ export type PaginatedBackofficeOrganizationsDto = {
   page: number
   limit: number
 }
+
+export const createBackofficeOrganizationSchema = z
+  .object({
+    name: z.string().min(3).max(100).trim(),
+  })
+  .strict()
+
+export type CreateBackofficeOrganizationRequestDto = z.infer<
+  typeof createBackofficeOrganizationSchema
+>
 
 export type BackofficeOrganizationMemberDto = {
   userId: string

--- a/packages/api-contracts/src/backoffice/backoffice.routes.ts
+++ b/packages/api-contracts/src/backoffice/backoffice.routes.ts
@@ -4,8 +4,10 @@ import { defineRoute } from "../helpers"
 import type {
   BackofficeAgentDetailDto,
   BackofficeOrganizationDetailDto,
+  BackofficeOrganizationDto,
   BackofficeProjectDetailDto,
   BackofficeUserDetailDto,
+  CreateBackofficeOrganizationRequestDto,
   ListTermsDocumentsResponseDto,
   PaginatedBackofficeAgentsDto,
   PaginatedBackofficeOrganizationsDto,
@@ -22,6 +24,13 @@ export const BackofficeRoutes = {
   getOrganization: defineRoute<ResponseData<BackofficeOrganizationDetailDto>>({
     method: "get",
     path: "backoffice/organizations/:organizationId",
+  }),
+  createOrganization: defineRoute<
+    ResponseData<BackofficeOrganizationDto>,
+    RequestPayload<CreateBackofficeOrganizationRequestDto>
+  >({
+    method: "post",
+    path: "backoffice/organizations",
   }),
   listAgents: defineRoute<ResponseData<PaginatedBackofficeAgentsDto>>({
     method: "get",

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -35,6 +35,7 @@ export type * from "./analytics/analytics.dto"
 export { AgentAnalyticsRoutes, AnalyticsRoutes } from "./analytics/analytics.routes"
 // Backoffice
 export type * from "./backoffice/backoffice.dto"
+export { createBackofficeOrganizationSchema } from "./backoffice/backoffice.dto"
 export { BackofficeRoutes } from "./backoffice/backoffice.routes"
 // Document Tags
 export * from "./document-tags/document-tag.dto"


### PR DESCRIPTION
Implements **bayesimpact/bayes-platform#584** — https://github.com/bayesimpact/bayes-platform/issues/584

## Why

The back office lists organizations but cannot create one. Today the only paths are the onboarding screen (shown only to users with zero organizations, gated by `ORGANIZATION_CREATOR_EMAIL_DOMAIN` / `VITE_PREMIUM_EMAIL_DOMAIN`) and the `invite:organization-owners` CLI script. A backoffice-authorized admin should be able to do it from the panel.

## What

- **api-contracts**: `BackofficeRoutes.createOrganization` (POST `backoffice/organizations`) + `createBackofficeOrganizationSchema` (name 3–100 chars, trimmed), exported as a value from the package index.
- **api**: handler behind the standard backoffice guards (`JwtAuthGuard`, `UserGuard`, `BackofficeGuard`) with `ZodValidationPipe`; `BackofficeService.createOrganization` creates the organization and makes the acting admin its owner. Tracked as `backoffice.organization.create`.
- **web**: Create organization button + dialog on the organizations panel (react-hook-form + contract schema per the form architecture rules); success/error toasts and list refresh via the listener middleware; storybook mock service updated.
- **e2e**: new `create-organization.spec.ts` (creation, owner membership, trim, min-length 400, list-after-create) and `createOrganization` cases added to the backoffice `auth.spec.ts` (401 / 403 / 201).

## Checks

- `npm run biome:check` ✅
- `npm run typecheck` ✅
- backoffice e2e suite: 52/52 ✅
- `npm run check:boundaries` ✅ (no new cycles)
- Full API suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)