### PR TITLE
refactor(llm): drop dead tool-doc path from GemmaPromptHelper

### DIFF
--- a/apps/api/src/external/llm/providers/ai-sdk-gemma.provider.ts
+++ b/apps/api/src/external/llm/providers/ai-sdk-gemma.provider.ts
@@ -88,7 +88,10 @@ export class AISDKGemmaProvider extends AISDKLLMProviderBase {
     callOrigin: CallOrigin
   }): string {
     if (callOrigin === CallOrigin.streamChatResponse_withTools && config.tools) {
-      return GemmaPromptHelper.appendToolsToPrompt({ prompt: systemPrompt, tools: config.tools })
+      return GemmaPromptHelper.injectNullValueInstruction({
+        prompt: systemPrompt,
+        tools: config.tools,
+      })
     }
 
     return systemPrompt

--- a/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.spec.ts
+++ b/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.spec.ts
@@ -31,35 +31,36 @@ describe("GemmaPromptHelper", () => {
     },
   })
   const testTools = { test: testTool } as ToolSet
-  it("appendToolsToPrompt - returns prompt unchanged when marker is absent", async () => {
+  it("injectNullValueInstruction - returns prompt unchanged when marker is absent", async () => {
     const initialPrompt = "initial prompt"
-    const result = GemmaPromptHelper.appendToolsToPrompt({
+    const result = GemmaPromptHelper.injectNullValueInstruction({
       prompt: initialPrompt,
       tools: testTools,
     })
     expect(result).toBe(initialPrompt)
   })
-  it("appendToolsToPrompt - returns prompt unchanged when no tools", async () => {
+  it("injectNullValueInstruction - returns prompt unchanged when no tools", async () => {
     const prompt = `some text\n## Response language:\nAlways answer in English.`
-    const result = GemmaPromptHelper.appendToolsToPrompt({ prompt, tools: {} as ToolSet })
+    const result = GemmaPromptHelper.injectNullValueInstruction({
+      prompt,
+      tools: {} as ToolSet,
+    })
     expect(result).toBe(prompt)
   })
-  it("appendToolsToPrompt - injects CRITICAL instruction before language marker", async () => {
+  it("injectNullValueInstruction - injects CRITICAL instruction before language marker", async () => {
     const prompt = `some text\n## Response language:\nAlways answer in English.`
-    const result = GemmaPromptHelper.appendToolsToPrompt({ prompt, tools: testTools })
+    const result = GemmaPromptHelper.injectNullValueInstruction({ prompt, tools: testTools })
     expect(result).toContain("(CRITICAL)")
     expect(result).toContain("## Response language:\nAlways answer in")
     expect(result.indexOf("(CRITICAL)")).toBeLessThan(result.indexOf("## Response language:"))
   })
-  it("convertToolsToDocs", async () => {
-    const results = GemmaPromptHelper.convertToolsToDocs(testTools)
-    expect(results).toBeDefined()
-    expect(results?.length).toBe(1)
-    const result = results ? results[0] : ""
-    expect(result).toContain("test: A test tool")
-    expect(result).toContain(
-      "Parameters: { stringVal: string | null; boolVal: boolean | null; intVal: number | null; numberVal: number | null }",
-    )
+  it("injectNullValueInstruction - does not describe the tools in the prompt", async () => {
+    const prompt = `some text\n## Response language:\nAlways answer in English.`
+    const result = GemmaPromptHelper.injectNullValueInstruction({ prompt, tools: testTools })
+    // Gemma receives tool definitions through native function calling, never in
+    // the prompt. Guards against reintroducing the Mistral-style tool listing.
+    expect(result).not.toContain("A test tool")
+    expect(result).not.toContain("##TOOLS")
   })
   it("jsonSchemaToArgumentString", async () => {
     const schema1 = z.object({

--- a/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.ts
+++ b/apps/api/src/external/llm/providers/gemma/gemma-prompt-helper.ts
@@ -2,27 +2,28 @@ import type { ToolSet } from "ai"
 
 // biome-ignore lint/complexity/noStaticOnlyClass: helper
 export class GemmaPromptHelper {
-  static appendToolsToPrompt({ prompt, tools }: { prompt: string; tools: ToolSet }): string {
-    const toolDocs = GemmaPromptHelper.convertToolsToDocs(tools)
-    if (!toolDocs) return prompt
-    // FIXME: this is a hack to inject a critical instruction into the prompt. We should find a better way to do this.
+  /**
+   * Gemma calls tools natively through the OpenAI-compatible endpoint, so tool
+   * definitions are NOT described in the prompt (unlike Mistral and MedGemma).
+   * The only prompt adjustment it needs is this instruction about nullable
+   * argument fields, which Gemma otherwise fills with the string "null".
+   */
+  static injectNullValueInstruction({ prompt, tools }: { prompt: string; tools: ToolSet }): string {
+    // The instruction only concerns tool-call arguments, so it is pointless
+    // without tools.
+    if (Object.keys(tools ?? {}).length === 0) return prompt
+
+    // FIXME: anchoring on a prompt substring is fragile — the instruction is
+    // silently dropped if the master prompt stops emitting this exact heading.
     const marker = "## Response language:\nAlways answer in"
     const injection = `(CRITICAL) If a field value allows null, set the value to null when unknown. Set to null not to quoted "null"`
-    const injectedPrompt = prompt.includes(marker)
-      ? prompt.replace(marker, `${injection}\n${marker}`)
-      : prompt
-    return injectedPrompt
+    return prompt.includes(marker) ? prompt.replace(marker, `${injection}\n${marker}`) : prompt
   }
 
-  // FIXME: not used anymore
-  static convertToolsToDocs(tools: ToolSet) {
-    if (!tools || Object.entries(tools).length === 0) return undefined
-    return Object.entries(tools).map(
-      // biome-ignore lint/suspicious/noExplicitAny: custom unknown props
-      ([name, tool]: any) =>
-        `- ${name}: ${tool.description}\n  Parameters: ${GemmaPromptHelper.jsonSchemaToArgumentString(tool.inputSchema)}`,
-    )
-  }
+  /**
+   * Kept because the MedGemma provider renders tool docs in-prompt and reuses
+   * this — see ai-sdk-med-gemma.provider.ts. Not used for Gemma itself.
+   */
   // biome-ignore lint/suspicious/noExplicitAny: custom
   static jsonSchemaToArgumentString(schema: any): string {
     if (!schema) return "unknown"


### PR DESCRIPTION
Closes #593

## What

`GemmaPromptHelper.appendToolsToPrompt` built a list of tool docs via `convertToolsToDocs`, early-returned on it, then never used it. All it actually did was inject an unrelated instruction about nullable tool-argument fields. Gemma receives tool definitions through native function calling on the OpenAI-compatible endpoint, so nothing was ever appended to the prompt — the name was inherited from `MistralPromptHelper`, which does genuinely list tools in-prompt.

- Renamed to `injectNullValueInstruction`, which is what it does.
- Deleted `GemmaPromptHelper.convertToolsToDocs` (it carried a `FIXME: not used anymore`).
- Kept the "skip when there are no tools" behaviour, but stated it directly rather than having it fall out of an empty tool-docs list — the previous coupling meant an empty tool set silently skipped an instruction that has nothing to do with tool docs.

## Behaviour

Unchanged. The instruction is injected under exactly the same condition as before (tool set non-empty, and the prompt contains the response-language heading).

## Not removed

`jsonSchemaToArgumentString` looks dead from within this file but is not — `ai-sdk-med-gemma.provider.ts:78` reuses it, because MedGemma *does* render tool docs in-prompt for its JSON tool-call protocol. Added a doc comment so it is not mistaken for dead code again.

## Notes

The remaining `FIXME` is reworded rather than resolved: the injection still anchors on a substring of the master prompt (`## Response language:\nAlways answer in`) and is silently dropped if that heading ever changes. Out of scope here, but worth its own issue if it matters.

Added a regression test asserting the prompt does **not** contain tool descriptions, so the Mistral-style listing cannot creep back in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)