### PR TITLE
fix: detect and recover tool calls the model verbalizes in the text channel

### DIFF
--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/surfaced-resources-registry.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/surfaced-resources-registry.ts
@@ -19,10 +19,10 @@ export type SurfaceableLibrary = {
  * as the retrieved-chunks registry (c1, c2...): real ids and links are
  * un-copyable by small models (a mangled character silently breaks the
  * card), and exposing them in the prompt lets a weak model RECITE the
- * referential into the user-visible text instead of calling the tool —
- * observed in production: raw internal link pasted in a chat answer, which
- * the front then rendered. With aliases, a recitation leaks nothing
- * renderable; the surfaceResources tool resolves aliases server-side.
+ * referential into the user-visible text instead of calling the tool — a raw
+ * internal link pasted in an answer, which the front then renders. With
+ * aliases, a recitation leaks nothing renderable; the surfaceResources tool
+ * resolves aliases server-side.
  *
  * Unlike chunks, resources are static for the whole request (they come from
  * the agent's libraries, not from a mid-turn retrieval): the registry is

--- a/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
+++ b/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
@@ -3,6 +3,7 @@ import { AgentModelToAgentProvider, AgentProvider } from "@caseai-connect/api-co
 import { Logger, NotImplementedException } from "@nestjs/common"
 import { trace } from "@opentelemetry/api"
 import {
+  asSchema,
   type FilePart,
   generateText,
   type JSONSchema7,
@@ -24,7 +25,11 @@ import { removeNullish } from "@/common/utils/remove-nullish"
 import { fireAndForgetStopCondition } from "@/external/llm/fire-and-forget-stop-condition"
 import { ResponseHelper } from "@/external/llm/response-helper"
 import { withStrictTools } from "@/external/llm/strict-tools"
-import { findLeakedToolCallNames, ThoughtTokensHelper } from "@/external/llm/thought-tokens-helper"
+import {
+  findLeakedToolCalls,
+  type LeakedToolCall,
+  ThoughtTokensHelper,
+} from "@/external/llm/thought-tokens-helper"
 
 // OTel attribute keys under which we publish the raw LLM request body and
 // response. The `ai.telemetry.metadata.` prefix is required so the AI SDK
@@ -72,21 +77,25 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
    * A model that VERBALIZES a tool call in the text channel instead of
    * emitting it (documented Gemini failure family) means the tool never
    * ran: the sanitizer hides the tag from the user, so without this log the
-   * failure is completely silent. Observed in production on a safety-alert
-   * tool — the alert was lost. Logged loudly so monitoring can catch it.
+   * failure would be completely silent. Logged loudly so monitoring can
+   * catch it — a tool with side effects must never fail unnoticed.
    */
   private readonly leakedToolCallLogger = new Logger("LeakedToolCall")
 
   private logLeakedToolCalls({
     originalText,
     config,
+    leakedToolCalls,
   }: {
     originalText: string
     config?: LLMConfig
+    leakedToolCalls?: LeakedToolCall[]
   }): void {
     try {
-      const leakedToolNames = findLeakedToolCallNames(originalText)
-      if (leakedToolNames.length === 0) return
+      const found = findLeakedToolCalls(originalText)
+      if (found.length === 0) return
+      const leakedToolNames = found.map((leakedCall) => leakedCall.name)
+      leakedToolCalls?.push(...found)
       const declaredToolNames = [
         ...Object.keys(config?.tools ?? {}),
         ...Object.keys(config?.endOfTurnTools ?? {}),
@@ -103,12 +112,22 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
   protected getLanguageModelWithRawCapture(args: {
     config: LLMConfig
     callOrigin: CallOrigin
+    /**
+     * Request-scoped sink for tool calls the model verbalized in the text
+     * channel. The sanitizer removes the tag before anything downstream sees
+     * it, so the raw leak has to be captured here, in the middleware.
+     */
+    leakedToolCalls?: LeakedToolCall[]
   }): LanguageModelV3 {
     const baseModel = this.getLanguageModel(args)
     // Bound for use inside the stream TransformStream, where `this` is the
     // transformer, not the provider.
     const logLeaked = ({ originalText }: { originalText: string }) =>
-      this.logLeakedToolCalls({ originalText, config: args.config })
+      this.logLeakedToolCalls({
+        originalText,
+        config: args.config,
+        leakedToolCalls: args.leakedToolCalls,
+      })
     return wrapLanguageModel({
       model: baseModel,
       middleware: {
@@ -133,7 +152,11 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
               if (strippedText !== originalText) {
                 activeSpan?.setAttribute(RAW_LLM_RESPONSE_STRIPPED_ATTR, strippedText)
               }
-              this.logLeakedToolCalls({ originalText, config: args.config })
+              this.logLeakedToolCalls({
+                originalText,
+                config: args.config,
+                leakedToolCalls: args.leakedToolCalls,
+              })
             }
           } catch {
             // never let telemetry capture break the generation
@@ -284,8 +307,13 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
     const systemMessage = messages.find((msg) => msg.role === "system")?.content
     const functionId = this.buildFunctionIdForStreamChatResponse(aiSDKMessages)
 
+    // Request-scoped: tool calls the model verbalized in the text channel
+    // instead of emitting them. Collected by the raw-capture middleware and
+    // recovered after the stream (see recoverLeakedToolCalls).
+    const leakedToolCalls: LeakedToolCall[] = []
+
     const agent = new ToolLoopAgent({
-      model: this.getLanguageModelWithRawCapture({ config, callOrigin }),
+      model: this.getLanguageModelWithRawCapture({ config, callOrigin, leakedToolCalls }),
       temperature: config.temperature,
       tools: this.supportsStrictTools() ? withStrictTools(config.tools) : config.tools,
       // Keep the default step safety net, but skip the follow-up generation
@@ -331,6 +359,15 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
       messages: fullMessages,
       streamResult,
     })
+
+    await this.recoverLeakedToolCalls({
+      config,
+      callOrigin,
+      metadata,
+      functionId,
+      leakedToolCalls,
+      streamResult,
+    })
   }
 
   /**
@@ -347,6 +384,113 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
    * Best-effort: the user already received the streamed answer, so a failure
    * here is logged but never breaks the stream.
    */
+  /**
+   * Recovers a tool call the model VERBALIZED in the text channel instead of
+   * emitting it (documented Gemini failure family). Without this, the call
+   * is simply lost: the sanitizer hides the tag from the user and nothing
+   * ran, which silently drops whatever the tool was meant to do.
+   *
+   * Recovery deliberately does NOT re-force a tool call: the model that
+   * leaked is the one that would be asked again, and the whole failure mode
+   * is "wrong channel". Instead it uses STRUCTURED OUTPUT (no tool channel
+   * involved, arguments grammar-constrained by the schema) to convert the
+   * leaked tag — which already carries the intended arguments in a
+   * malformed form — into valid input, validated by the tool's own schema
+   * before the tool executes.
+   *
+   * One attempt per tool, skipped when the tool already executed in the
+   * turn. Deduplicating repeated deliveries is the destination's job (e.g.
+   * the MCP server). Best-effort: the user already got their answer, so
+   * failures are logged loudly and never break the stream.
+   */
+  private async recoverLeakedToolCalls({
+    config,
+    callOrigin,
+    metadata,
+    functionId,
+    leakedToolCalls,
+    streamResult,
+  }: {
+    config: LLMConfig
+    callOrigin: CallOrigin
+    metadata: LLMMetadata
+    functionId: string
+    leakedToolCalls: LeakedToolCall[]
+    streamResult: {
+      steps: PromiseLike<Array<{ toolResults: Array<{ toolName: string; output: unknown }> }>>
+    }
+  }): Promise<void> {
+    if (leakedToolCalls.length === 0) return
+    const tools = config.tools
+    if (!tools) return
+
+    try {
+      const steps = await streamResult.steps
+      const executedToolNames = new Set(
+        steps.flatMap((step) => step.toolResults.map((toolResult) => toolResult.toolName)),
+      )
+
+      for (const leakedCall of leakedToolCalls) {
+        if (executedToolNames.has(leakedCall.name)) continue
+        const tool = tools[leakedCall.name]
+        if (!tool?.execute) {
+          this.leakedToolCallLogger.error(
+            `cannot recover leaked call to "${leakedCall.name}": tool not declared or not executable`,
+          )
+          continue
+        }
+
+        const recoveredInput = await generateText({
+          model: this.getLanguageModelWithRawCapture({ config, callOrigin }),
+          temperature: config.temperature,
+          messages: [
+            {
+              role: "user",
+              content: `A tool call was emitted as malformed text instead of a real tool call. Convert it into the tool's arguments, verbatim — copy every value exactly as written, invent nothing, and drop nothing.
+
+Malformed call:
+${leakedCall.raw}`,
+            },
+          ],
+          output: Output.object({ schema: tool.inputSchema }),
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              ...this.buildMetadata({ config, metadata }),
+              recoveredLeakedToolCall: leakedCall.name,
+            },
+          },
+          providerOptions: {
+            custom: this.buildCustomProviderOptions({ config, callOrigin, metadata }),
+          },
+        })
+
+        // The tool's own schema is the last gate before a side effect runs.
+        const validatedInput = await asSchema(tool.inputSchema).validate?.(recoveredInput.output)
+        const input = validatedInput?.success ? validatedInput.value : recoveredInput.output
+        if (validatedInput && !validatedInput.success) {
+          this.leakedToolCallLogger.error(
+            `recovered arguments for "${leakedCall.name}" failed the tool schema — not executed`,
+          )
+          continue
+        }
+
+        await tool.execute(input, {
+          toolCallId: `recovered-${leakedCall.name}`,
+          messages: [],
+        })
+        this.leakedToolCallLogger.warn(
+          `recovered the leaked call to "${leakedCall.name}" through structured output and executed it`,
+        )
+      }
+    } catch (error) {
+      this.leakedToolCallLogger.error(
+        `leaked tool call recovery failed: ${error instanceof Error ? error.message : error}`,
+      )
+    }
+  }
+
   private async runEndOfTurnTools({
     config,
     callOrigin,

--- a/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
+++ b/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
@@ -24,7 +24,7 @@ import { removeNullish } from "@/common/utils/remove-nullish"
 import { fireAndForgetStopCondition } from "@/external/llm/fire-and-forget-stop-condition"
 import { ResponseHelper } from "@/external/llm/response-helper"
 import { withStrictTools } from "@/external/llm/strict-tools"
-import { ThoughtTokensHelper } from "@/external/llm/thought-tokens-helper"
+import { findLeakedToolCallNames, ThoughtTokensHelper } from "@/external/llm/thought-tokens-helper"
 
 // OTel attribute keys under which we publish the raw LLM request body and
 // response. The `ai.telemetry.metadata.` prefix is required so the AI SDK
@@ -68,11 +68,47 @@ function extractTextFromStreamChunks(chunks: unknown[]): string {
 
 export abstract class AISDKLLMProviderBase implements LLMProvider {
   private readonly endOfTurnLogger = new Logger("EndOfTurnTools")
+  /**
+   * A model that VERBALIZES a tool call in the text channel instead of
+   * emitting it (documented Gemini failure family) means the tool never
+   * ran: the sanitizer hides the tag from the user, so without this log the
+   * failure is completely silent. Observed in production on a safety-alert
+   * tool — the alert was lost. Logged loudly so monitoring can catch it.
+   */
+  private readonly leakedToolCallLogger = new Logger("LeakedToolCall")
+
+  private logLeakedToolCalls({
+    originalText,
+    config,
+  }: {
+    originalText: string
+    config?: LLMConfig
+  }): void {
+    try {
+      const leakedToolNames = findLeakedToolCallNames(originalText)
+      if (leakedToolNames.length === 0) return
+      const declaredToolNames = [
+        ...Object.keys(config?.tools ?? {}),
+        ...Object.keys(config?.endOfTurnTools ?? {}),
+      ]
+      this.leakedToolCallLogger.error(
+        `model verbalized tool call(s) in the text channel instead of calling them — NOT executed: ${JSON.stringify(
+          leakedToolNames,
+        )} (declared: ${JSON.stringify(declaredToolNames)}, model: ${config?.model})`,
+      )
+    } catch {
+      // never let diagnostics break the generation
+    }
+  }
   protected getLanguageModelWithRawCapture(args: {
     config: LLMConfig
     callOrigin: CallOrigin
   }): LanguageModelV3 {
     const baseModel = this.getLanguageModel(args)
+    // Bound for use inside the stream TransformStream, where `this` is the
+    // transformer, not the provider.
+    const logLeaked = ({ originalText }: { originalText: string }) =>
+      this.logLeakedToolCalls({ originalText, config: args.config })
     return wrapLanguageModel({
       model: baseModel,
       middleware: {
@@ -97,6 +133,7 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
               if (strippedText !== originalText) {
                 activeSpan?.setAttribute(RAW_LLM_RESPONSE_STRIPPED_ATTR, strippedText)
               }
+              this.logLeakedToolCalls({ originalText, config: args.config })
             }
           } catch {
             // never let telemetry capture break the generation
@@ -201,6 +238,7 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
                     if (strippedText !== originalText) {
                       activeSpan?.setAttribute(RAW_LLM_RESPONSE_STRIPPED_ATTR, strippedText)
                     }
+                    logLeaked({ originalText })
                   }
                 } catch {
                   // never let telemetry capture break the stream

--- a/apps/api/src/external/llm/leaked-tool-call-recovery.spec.ts
+++ b/apps/api/src/external/llm/leaked-tool-call-recovery.spec.ts
@@ -1,0 +1,104 @@
+import { AgentModel } from "@caseai-connect/api-contracts"
+import { Test } from "@nestjs/testing"
+import { tool } from "ai"
+import { z } from "zod"
+import type { LLMConfig, LLMMetadata } from "@/common/interfaces/llm-provider.interface"
+import { AISDKMockProvider } from "@/external/llm/providers/ai-sdk-mock.provider"
+
+/**
+ * Gemini models (lite especially) sometimes verbalize a tool call as
+ * pseudo-XML in the TEXT channel instead of emitting a functionCall part.
+ * The tool then never runs, and the sanitizer hides the tag from the user —
+ * so a tool with side effects fails silently. Recovery converts the leaked
+ * tag into validated arguments through structured output, then executes.
+ */
+const LEAKED_CALL_TEXT =
+  "Voici votre réponse, votre demande est bien prise en compte.\n\n" +
+  "<call:default_api:notify_operator{severity:high," +
+  "summary:Escalation requested by the user.,reference:ABC-123}/>"
+
+describe("leaked tool call recovery", () => {
+  let provider: AISDKMockProvider
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [AISDKMockProvider],
+    }).compile()
+    provider = moduleRef.get(AISDKMockProvider)
+    provider.resetMock()
+  })
+
+  const metadata: LLMMetadata = {
+    traceId: "trace-1",
+    agentSessionId: "session-1",
+    currentTurn: 1,
+    organizationId: "org-1",
+    agentId: "agent-1",
+    revision: 1,
+    projectId: "project-1",
+    tags: [],
+  }
+
+  const buildConfig = ({ execute }: { execute: (input: unknown) => Promise<unknown> }): LLMConfig =>
+    ({
+      model: AgentModel._Mock,
+      temperature: 0,
+      tools: {
+        notify_operator: tool({
+          description: "Notify a human operator about this conversation.",
+          inputSchema: z.object({
+            severity: z.enum(["low", "medium", "high"]),
+            summary: z.string(),
+            reference: z.string(),
+          }),
+          execute: async (input) => execute(input),
+        }),
+      },
+    }) as LLMConfig
+
+  const streamAll = async (config: LLMConfig) => {
+    let text = ""
+    for await (const chunk of provider.streamChatResponse({
+      messages: [{ role: "user", content: "Je veux parler à quelqu'un." }],
+      config,
+      metadata,
+    })) {
+      text += chunk
+    }
+    return text
+  }
+
+  it("executes the tool the model verbalized in the text, with the leaked arguments", async () => {
+    const execute = jest.fn().mockResolvedValue({ ok: true })
+    // Generation 1: the answer carrying the leaked call. Generation 2: the
+    // structured-output recovery, which the mock answers with valid input.
+    provider.addTextTurn("agent-1", LEAKED_CALL_TEXT)
+    provider.addObjectTurn("agent-1", {
+      severity: "high",
+      summary: "Escalation requested by the user.",
+      reference: "ABC-123",
+    })
+
+    const text = await streamAll(buildConfig({ execute }))
+
+    // The user never sees the leaked tag.
+    expect(text).not.toContain("default_api")
+    expect(text).toContain("bien prise en compte")
+    // …and the tool actually ran, with the arguments the model intended.
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(execute).toHaveBeenCalledWith({
+      severity: "high",
+      summary: "Escalation requested by the user.",
+      reference: "ABC-123",
+    })
+  })
+
+  it("does not run recovery when no call leaked", async () => {
+    const execute = jest.fn()
+    provider.addTextTurn("agent-1", "Voici votre réponse, sans balise.")
+
+    await streamAll(buildConfig({ execute }))
+
+    expect(execute).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/external/llm/thought-tokens-helper.spec.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.spec.ts
@@ -1,13 +1,13 @@
 import { findLeakedToolCallNames, ThoughtTokensHelper } from "./thought-tokens-helper"
 
-// The exact leak observed in production (gemini-3.5-flash-lite verbalizing
-// its tool call as pseudo-XML in the user-visible text instead of emitting a
-// functionCall part).
+// A leak captured from gemini-3.5-flash-lite: the model verbalizes its tool
+// call as pseudo-XML in the user-visible text instead of emitting a
+// functionCall part.
 const LEAKED_PSEUDO_CALL =
   '<call:default_api:mandatory_tool xmlns:default_api="default_api" categoryNames:[greetings,QA],suggestedTitle:Règles de Warmachine et pays de pays/>'
 
 describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
-  it("removes the production pseudo-call tag from a complete text", () => {
+  it("removes a pseudo-call tag from a complete text", () => {
     const text = `C'est noté, tu habites en France !\n\n${LEAKED_PSEUDO_CALL}`
     const cleaned = ThoughtTokensHelper.removeThoughtTokens(text)
 
@@ -60,14 +60,12 @@ describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
 })
 
 describe("findLeakedToolCallNames", () => {
-  it("extracts the tool name from a leaked safety-alert call (production case)", () => {
-    // Real production leak: the alert never reached the MCP server.
+  it("extracts the tool name from the brace-argument variant", () => {
     const text =
-      "Prenez soin de vous.\n\n<call:default_api:report_danger{category:self_harm," +
-      "severity:critical,summary:L'utilisateur exprime l'intention de mourir.," +
-      "verbatim:je veux mourrir}/>"
+      "Voici votre réponse.\n\n<call:default_api:notify_operator{severity:high," +
+      "summary:Escalation requested by the user.,reference:ABC-123}/>"
 
-    expect(findLeakedToolCallNames(text)).toEqual(["report_danger"])
+    expect(findLeakedToolCallNames(text)).toEqual(["notify_operator"])
   })
 
   it("extracts the tool name from the attribute-style variant", () => {

--- a/apps/api/src/external/llm/thought-tokens-helper.spec.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.spec.ts
@@ -1,4 +1,4 @@
-import { ThoughtTokensHelper } from "./thought-tokens-helper"
+import { findLeakedToolCallNames, ThoughtTokensHelper } from "./thought-tokens-helper"
 
 // The exact leak observed in production (gemini-3.5-flash-lite verbalizing
 // its tool call as pseudo-XML in the user-visible text instead of emitting a
@@ -56,5 +56,31 @@ describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
     // still deliver the surrounding text once the hold-back cap is passed.
     expect(out).toContain("Début.")
     expect(out).toContain("fin du texte.")
+  })
+})
+
+describe("findLeakedToolCallNames", () => {
+  it("extracts the tool name from a leaked safety-alert call (production case)", () => {
+    // Real production leak: the alert never reached the MCP server.
+    const text =
+      "Prenez soin de vous.\n\n<call:default_api:report_danger{category:self_harm," +
+      "severity:critical,summary:L'utilisateur exprime l'intention de mourir.," +
+      "verbatim:je veux mourrir}/>"
+
+    expect(findLeakedToolCallNames(text)).toEqual(["report_danger"])
+  })
+
+  it("extracts the tool name from the attribute-style variant", () => {
+    expect(findLeakedToolCallNames(LEAKED_PSEUDO_CALL)).toEqual(["mandatory_tool"])
+  })
+
+  it("returns nothing for legitimate text, including angle brackets and markup", () => {
+    expect(findLeakedToolCallNames("2 < 3 and <b>bold</b> and a call: to action")).toEqual([])
+    expect(findLeakedToolCallNames("Voici ma réponse, sans balise.")).toEqual([])
+  })
+
+  it("deduplicates repeated leaks of the same tool", () => {
+    const text = `${LEAKED_PSEUDO_CALL} then again ${LEAKED_PSEUDO_CALL}`
+    expect(findLeakedToolCallNames(text)).toEqual(["mandatory_tool"])
   })
 })

--- a/apps/api/src/external/llm/thought-tokens-helper.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.ts
@@ -5,10 +5,10 @@
 const CHANNEL_KEYWORDS = "thought|analysis|reasoning|finalize|commentary|final"
 
 // Hallucinated tool-call syntax that Gemini models (lite especially) leak
-// into the TEXT stream instead of emitting a real functionCall — observed in
-// production: `<call:default_api:mandatory_tool xmlns:default_api=... />`.
-// `default_api` is an internal Gemini tool namespace; none of these tags can
-// ever be legitimate user-facing content.
+// into the TEXT stream instead of emitting a real functionCall, e.g.
+// `<call:default_api:some_tool xmlns:default_api=... />`. `default_api` is an
+// internal Gemini tool namespace; none of these tags can ever be legitimate
+// user-facing content.
 const PSEUDO_TOOL_CALL_RE = /<\/?(?:call|default_api)[:\s][^>]*\/?>/gi
 // An opener of that family that has no closing `>` yet (still streaming).
 const PSEUDO_TOOL_CALL_OPEN_RE = /<\/?(?:call|default_api)[:\s][^>]*$/i
@@ -46,25 +46,36 @@ function stripStrayChannelTokens(text: string): string {
 }
 
 /**
- * Names of the tools the model tried to call by VERBALIZING the call in the
- * text channel instead of emitting a real tool call. Extracted from the
- * leaked pseudo-XML (`<call:default_api:report_danger{...}/>`), so callers
- * can react — the call itself never reached the provider's tool channel and
- * the platform did NOT execute it.
+ * A tool call the model VERBALIZED in the text channel instead of emitting
+ * it (documented Gemini failure family): the call never reached the tool
+ * channel, so the platform did NOT execute it. `raw` keeps the whole leaked
+ * tag — it already carries the arguments the model intended, in a malformed
+ * form, which is what makes recovery possible.
  */
-export function findLeakedToolCallNames(text: string): string[] {
-  const names = new Set<string>()
+export type LeakedToolCall = {
+  name: string
+  raw: string
+}
+
+export function findLeakedToolCalls(text: string): LeakedToolCall[] {
+  const byName = new Map<string, LeakedToolCall>()
   // The leaked tag is malformed and comes in variants; the tool name is the
   // last `:`-separated segment of the tag opener, before its arguments
   // (`{...}`, ` attr=...`, or the closing `>`).
-  for (const match of text.matchAll(/<\/?(?:call|default_api)[:\s]([^>{(\s]+)/gi)) {
-    const segments = (match[1] ?? "").split(":").filter(Boolean)
+  for (const match of text.matchAll(PSEUDO_TOOL_CALL_RE)) {
+    const raw = match[0]
+    const opener = /<\/?(?:call|default_api)[:\s]([^>{(\s]+)/i.exec(raw)
+    const segments = (opener?.[1] ?? "").split(":").filter(Boolean)
     const name = segments.at(-1)
     if (name && name !== "default_api" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
-      names.add(name)
+      if (!byName.has(name)) byName.set(name, { name, raw })
     }
   }
-  return [...names]
+  return [...byName.values()]
+}
+
+export function findLeakedToolCallNames(text: string): string[] {
+  return findLeakedToolCalls(text).map((leakedCall) => leakedCall.name)
 }
 
 // biome-ignore lint/complexity/noStaticOnlyClass: helper

--- a/apps/api/src/external/llm/thought-tokens-helper.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.ts
@@ -45,6 +45,28 @@ function stripStrayChannelTokens(text: string): string {
     .replace(/<unused\d+>/g, "")
 }
 
+/**
+ * Names of the tools the model tried to call by VERBALIZING the call in the
+ * text channel instead of emitting a real tool call. Extracted from the
+ * leaked pseudo-XML (`<call:default_api:report_danger{...}/>`), so callers
+ * can react — the call itself never reached the provider's tool channel and
+ * the platform did NOT execute it.
+ */
+export function findLeakedToolCallNames(text: string): string[] {
+  const names = new Set<string>()
+  // The leaked tag is malformed and comes in variants; the tool name is the
+  // last `:`-separated segment of the tag opener, before its arguments
+  // (`{...}`, ` attr=...`, or the closing `>`).
+  for (const match of text.matchAll(/<\/?(?:call|default_api)[:\s]([^>{(\s]+)/gi)) {
+    const segments = (match[1] ?? "").split(":").filter(Boolean)
+    const name = segments.at(-1)
+    if (name && name !== "default_api" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+      names.add(name)
+    }
+  }
+  return [...names]
+}
+
 // biome-ignore lint/complexity/noStaticOnlyClass: helper
 export class ThoughtTokensHelper {
   /**


### PR DESCRIPTION
## Why

Gemini models (lite especially, on large prompts) sometimes write their tool call as pseudo-XML in the TEXT channel instead of emitting a functionCall part — a documented failure family (google-gemini/gemini-cli#22441, livekit/agents#5662):

```
<call:default_api:some_tool{severity:high,summary:...,reference:ABC-123}/>
```

The tool never runs. Our sanitizer removes the tag before the user sees it, so **a tool with side effects fails completely silently** — the only trace was an `llm.call.with.transformation` ERROR span.

## What

**Visibility**: `findLeakedToolCalls` extracts the attempted tool name and the raw tag (tolerating the malformed variants). The provider logs an ERROR (`LeakedToolCall`) on both the streaming and generate paths — attempted names, declared tools, model — stating explicitly that nothing was executed.

**Recovery**: after the stream, `recoverLeakedToolCalls` converts the leaked tag into real arguments and executes the tool. Design notes:

- It does **not** re-force a tool call: the model that leaked is the one that would be asked again, and the failure mode is precisely "wrong channel". Recovery uses **structured output** instead — no tool channel involved, arguments constrained by the schema.
- The leaked tag already carries the intended arguments (malformed), so the recovery generation only has to convert them — a far easier task than deciding and emitting a call.
- The tool's own schema validates the result before any side effect runs.
- Request-scoped collector (no state on the provider singleton, safe under concurrency), one attempt per tool, skipped when the tool already executed in the turn. Deduplicating repeated deliveries stays the destination's job (e.g. an MCP server).
- Best-effort: the user already received their answer, so every branch logs loudly (recovered / schema-rejected / tool not declared / failed) and never breaks the stream.

A guaranteed path for signals that must not depend on the model's channel choice is tracked separately in internal-issues#29.

## Tests

- Sanitizer: tag removal one-shot and split across stream deltas, name extraction on both tag variants, deduplication, and legitimate text with angle brackets producing nothing.
- Recovery: a leaked call in the answer ends with the tool executed with the intended arguments and no tag in the user-visible text; no recovery generation when nothing leaked.
- `src/external/llm` 42 passed; streaming + public-chat 129 passed (the 2 GCS-dependent document specs fail on main too); typecheck, biome, and `check:boundaries` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)