### PR TITLE
fix: exclude the live-regression harness from coverage stats

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -30,6 +30,11 @@ export const nestConfig = {
     "!**/*.module.ts",
     "!**/script/**",
     "!**/llm/providers/*.provider.ts",
+    // Live-provider regression harness: fixtures, scenarios and the manual
+    // measurement script. Their specs are excluded from CI (no LLM calls), so
+    // these sources can never be executed there — counting them as uncovered
+    // hides the real coverage of product code.
+    "!**/live-regressions/**",
   ],
   coverageDirectory: "../coverage",
   coverageReporters: ["json-summary", "text", "lcov"],


### PR DESCRIPTION
## Why

The nightly coverage cron (infra `coverage.yml` → `npm run test:coverage`) runs without `LIVE_PROVIDER_REGRESSIONS=1`, so the `*.live.spec.ts` files never execute — that is by design, no LLM calls in CI. But their **source** files were still collected by `collectCoverageFrom`, so ~1100 lines of test harness counted as 0% covered:

| File | lines |
|---|---|
| `live-regressions/fat-prompt.fixture.ts` | 399 |
| `live-regressions/measure-voluntary-rate.ts` (manual ts-node script, imported by nothing) | 214 |
| `live-regressions/turn-summary-scenario.ts` | 213 |
| `live-regressions/employee-handbook.fixture.ts` | 193 |
| `live-regressions/provider-cases.ts` | 76 |

## Effect

This accounts for the whole 1.7 point drop on the last report: 31393/40873 (76.8%) → 32410/43140 (75.1%), i.e. +2267 coverable lines of which only 45% covered. Remove those ~1100 zero-covered harness lines from the denominator and the same commit sits at **32410/42045 = 77.1%** — above the previous figure. The product code shipped in that window was better covered than the repo average.

## What

One exclusion in `apps/api/jest.config.ts`, consistent with the test-tooling patterns already there (`*.factory.ts`, `llm/providers/*.provider.ts`, `script/`). Nothing changes in infra — the cron uses the app repo's own jest config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)