### PR TITLE
feat(mcp): forward conversation context to MCP servers as request headers

### DIFF
--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming-session.types.ts
@@ -15,6 +15,11 @@ export type PublicStreamingSessionProxy = {
   id: string
   traceId: string
   organizationId: string
+  /**
+   * Identifier the embedding page attached to this session (for France
+   * Travail: the "identifiant DE"). Forwarded to MCP servers as context.
+   */
+  externalVisitorId?: string | null
   messages: AgentMessage[]
 }
 

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts
@@ -155,6 +155,7 @@ export class StreamingService extends ServiceWithLLM {
     notifyClient,
     sessionState,
     sessionResult,
+    externalVisitorId,
   }: {
     connectScope: RequiredConnectScope
     publicSessionId: string
@@ -169,6 +170,8 @@ export class StreamingService extends ServiceWithLLM {
     sessionState: SessionStateTarget
     /** Current fillForm state from public_agent_session.result. */
     sessionResult: Record<string, unknown> | null
+    /** Identifier the embedding page attached to the session, if any. */
+    externalVisitorId?: string | null
   }): AsyncGenerator<StreamEvent, void, unknown> {
     await this.recoverAbortedStreams(publicSessionId)
 
@@ -208,6 +211,7 @@ export class StreamingService extends ServiceWithLLM {
       id: publicSessionId,
       traceId: publicSessionId,
       organizationId: connectScope.organizationId,
+      externalVisitorId,
       messages,
       result: sessionResult,
     }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
@@ -14,6 +14,7 @@ import { ProjectsService } from "@/domains/projects/projects.service"
 import { ServiceWithLLM } from "@/external/llm"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { McpClientService } from "@/external/mcp"
+import type { McpConversationContext } from "@/external/mcp/mcp-request-headers"
 import { generateMasterPrompt } from "./master-promts/generate-master-prompt"
 import type { AgentSessionScope, OnExecute } from "./streaming-session.types"
 import { type BuiltTools, buildSubAgentTools } from "./sub-agent-tools"
@@ -113,7 +114,11 @@ export class ToolsService extends ServiceWithLLM {
     sessionState?: SessionStateTarget
   }): Promise<BuiltTools> {
     const { agent } = agentSessionScope
-    const mcp = await this.buildMcpTools({ agent, onExecute })
+    const mcp = await this.buildMcpTools({
+      agent,
+      session: agentSessionScope.session,
+      onExecute,
+    })
 
     switch (agent.type) {
       case "conversation":
@@ -140,18 +145,28 @@ export class ToolsService extends ServiceWithLLM {
 
   private async buildMcpTools({
     agent,
+    session,
     onExecute,
   }: {
     agent: Agent
+    session: AgentSessionScope["session"]
     onExecute: OnExecute
   }): Promise<McpToolset> {
     const mcpCloseFns: (() => Promise<void>)[] = []
     const mcpTools: ToolSet = {}
     const mcpToolDescriptions: Record<string, string> = {}
 
+    // Forwarded to every MCP server as headers: deterministic context, so a
+    // server can attribute a call without the model having to carry it.
+    const context: McpConversationContext = {
+      agentId: agent.id,
+      sessionId: session.id,
+      externalVisitorId: "externalVisitorId" in session ? session.externalVisitorId : null,
+    }
+
     const serverConfigs = await this.mcpServersService.getEnabledServersForAgent(agent.id)
     for (const serverConfig of serverConfigs) {
-      const mcpSession = await this.mcpClientService.connect(serverConfig)
+      const mcpSession = await this.mcpClientService.connect({ ...serverConfig, context })
       mcpCloseFns.push(mcpSession.close)
       for (const [toolName, toolDef] of Object.entries(mcpSession.tools)) {
         const originalExecute = toolDef.execute

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/all.tools.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/all.tools.spec.ts
@@ -710,6 +710,14 @@ describe("Tools execution", () => {
     expect(searchResourcesExecute).toHaveBeenCalled()
     expect(agentCalls).toHaveLength(3)
     expect(agentCalls[1]?.prompt).toContain("resource-1")
+    // The conversation context reaches the MCP transport as plumbing, with no
+    // model involvement: a server can attribute the call.
+    expect(mockMcpClientService.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://mcp.test",
+        context: expect.objectContaining({ agentId: agent.id, sessionId: session.id }),
+      }),
+    )
   })
 
   it("ToolName.McpSmartSearch - should works", async () => {

--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
@@ -9,6 +9,13 @@ import { McpServer } from "./mcp-server.entity"
 export type McpServerConfig = {
   url: string
   apiKey?: string
+  /**
+   * Static headers sent on every call to this server. Stored in the encrypted
+   * config blob, so adding them needs no migration. Typical use: tagging the
+   * deployment a server is called from (`X-Deployment: recette`) when the same
+   * MCP server serves several agents.
+   */
+  headers?: Record<string, string>
 }
 
 @Injectable()

--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
@@ -10,10 +10,10 @@ export type McpServerConfig = {
   url: string
   apiKey?: string
   /**
-   * Static headers sent on every call to this server. Stored in the encrypted
-   * config blob, so adding them needs no migration. Typical use: tagging the
-   * deployment a server is called from (`X-Deployment: recette`) when the same
-   * MCP server serves several agents.
+   * Static headers sent on every call to this server, for whatever a given
+   * server expects beyond its auth (an API version, a tenant). Stored in the
+   * encrypted config blob, so adding them needs no migration. The conversation
+   * context is applied after them and cannot be overridden here.
    */
   headers?: Record<string, string>
 }

--- a/apps/api/src/domains/public-chat/public-chat.service.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.ts
@@ -85,6 +85,7 @@ export class PublicChatService {
         resultUpdater: this.publicAgentSessionsService,
       },
       sessionResult: publicSession.result ?? null,
+      externalVisitorId: publicSession.externalVisitorId,
     })
   }
 

--- a/apps/api/src/external/mcp/mcp-client.service.ts
+++ b/apps/api/src/external/mcp/mcp-client.service.ts
@@ -1,6 +1,10 @@
 import { createMCPClient, type MCPClient } from "@ai-sdk/mcp"
 import { Injectable, Logger } from "@nestjs/common"
 import type { ToolSet } from "ai"
+import {
+  buildMcpRequestHeaders,
+  type McpConversationContext,
+} from "@/external/mcp/mcp-request-headers"
 
 export type McpSession = {
   tools: ToolSet
@@ -11,20 +15,26 @@ export type McpSession = {
 export class McpClientService {
   private readonly logger = new Logger(McpClientService.name)
 
-  async connect(config: { url: string; apiKey?: string }): Promise<McpSession> {
+  async connect(config: {
+    url: string
+    apiKey?: string
+    /** Static headers from the server's configuration. */
+    headers?: Record<string, string>
+    /** Conversation the tools will be called for (forwarded as headers). */
+    context?: McpConversationContext
+  }): Promise<McpSession> {
     let client: MCPClient | undefined
     try {
+      const headers = buildMcpRequestHeaders({
+        apiKey: config.apiKey,
+        staticHeaders: config.headers,
+        context: config.context,
+      })
       client = await createMCPClient({
         transport: {
           type: "http",
           url: config.url,
-          ...(config.apiKey
-            ? {
-                headers: {
-                  Authorization: `Bearer ${config.apiKey}`,
-                },
-              }
-            : {}),
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
         },
         name: "caseai-connect",
         version: "1.0.0",

--- a/apps/api/src/external/mcp/mcp-request-headers.spec.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.spec.ts
@@ -27,12 +27,12 @@ describe("buildMcpRequestHeaders", () => {
   it("keeps the server's auth and its static headers", () => {
     const headers = buildMcpRequestHeaders({
       apiKey: "secret",
-      staticHeaders: { "X-Deployment": "recette" },
+      staticHeaders: { "X-Api-Version": "2" },
       context,
     })
 
     expect(headers.Authorization).toBe("Bearer secret")
-    expect(headers["X-Deployment"]).toBe("recette")
+    expect(headers["X-Api-Version"]).toBe("2")
   })
 
   it("does not let static headers spoof the conversation context", () => {

--- a/apps/api/src/external/mcp/mcp-request-headers.spec.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.spec.ts
@@ -1,0 +1,59 @@
+import { buildMcpRequestHeaders, MCP_CONTEXT_HEADERS } from "./mcp-request-headers"
+
+describe("buildMcpRequestHeaders", () => {
+  const context = {
+    agentId: "agent-1",
+    sessionId: "session-1",
+    externalVisitorId: "visitor-1",
+  }
+
+  it("forwards the conversation context on every call", () => {
+    const headers = buildMcpRequestHeaders({ context })
+
+    expect(headers[MCP_CONTEXT_HEADERS.agentId]).toBe("agent-1")
+    expect(headers[MCP_CONTEXT_HEADERS.sessionId]).toBe("session-1")
+    expect(headers[MCP_CONTEXT_HEADERS.externalVisitorId]).toBe("visitor-1")
+  })
+
+  it("omits the external visitor header when the session has none", () => {
+    const headers = buildMcpRequestHeaders({
+      context: { agentId: "agent-1", sessionId: "session-1", externalVisitorId: null },
+    })
+
+    expect(headers).not.toHaveProperty(MCP_CONTEXT_HEADERS.externalVisitorId)
+    expect(headers[MCP_CONTEXT_HEADERS.sessionId]).toBe("session-1")
+  })
+
+  it("keeps the server's auth and its static headers", () => {
+    const headers = buildMcpRequestHeaders({
+      apiKey: "secret",
+      staticHeaders: { "X-Deployment": "recette" },
+      context,
+    })
+
+    expect(headers.Authorization).toBe("Bearer secret")
+    expect(headers["X-Deployment"]).toBe("recette")
+  })
+
+  it("does not let static headers spoof the conversation context", () => {
+    const headers = buildMcpRequestHeaders({
+      staticHeaders: { [MCP_CONTEXT_HEADERS.agentId]: "someone-else" },
+      context,
+    })
+
+    expect(headers[MCP_CONTEXT_HEADERS.agentId]).toBe("agent-1")
+  })
+
+  it("drops empty header names and values, which would break the transport", () => {
+    const headers = buildMcpRequestHeaders({
+      staticHeaders: { "  ": "value", "X-Empty": "   ", "X-Kept": "  yes  " },
+    })
+
+    expect(Object.keys(headers)).toEqual(["X-Kept"])
+    expect(headers["X-Kept"]).toBe("yes")
+  })
+
+  it("sends nothing when there is no auth, no static header and no context", () => {
+    expect(buildMcpRequestHeaders({})).toEqual({})
+  })
+})

--- a/apps/api/src/external/mcp/mcp-request-headers.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.ts
@@ -26,11 +26,10 @@ export const MCP_CONTEXT_HEADERS = {
 } as const
 
 /**
- * Builds the headers of an MCP transport: the server's own auth, then the
- * per-server static headers from its configuration (how a deployment tags
- * itself, e.g. `X-Deployment: recette` on a test agent's server), then the
- * conversation context. Context wins over static headers so a configuration
- * cannot spoof it.
+ * Builds the headers of an MCP transport: the server's own auth, then any
+ * static headers from its configuration (whatever a given server expects on
+ * every call, e.g. `X-Api-Version`), then the conversation context. Context
+ * wins over static headers so a configuration cannot spoof it.
  */
 export function buildMcpRequestHeaders({
   apiKey,

--- a/apps/api/src/external/mcp/mcp-request-headers.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.ts
@@ -1,0 +1,64 @@
+/**
+ * Context the platform forwards to MCP servers on every tool call, as HTTP
+ * headers on the MCP transport. Deterministic plumbing: it never goes through
+ * the model, so an MCP server can rely on it (a value the model has to copy
+ * from its prompt is neither guaranteed nor trustworthy).
+ *
+ * Deliberately minimal — these headers reach third-party servers. Only what a
+ * server needs to attribute a call to a conversation and to a caller: no user
+ * name, no message content, no organization or project identifier.
+ */
+export type McpConversationContext = {
+  agentId: string
+  /** Session the call belongs to (conversation or public/embed session). */
+  sessionId: string
+  /**
+   * Identifier the embedding page attached to a public session (for France
+   * Travail: the "identifiant DE"). Absent on internal sessions.
+   */
+  externalVisitorId?: string | null
+}
+
+export const MCP_CONTEXT_HEADERS = {
+  agentId: "X-Bayes-Agent-Id",
+  sessionId: "X-Bayes-Session-Id",
+  externalVisitorId: "X-Bayes-External-Visitor-Id",
+} as const
+
+/**
+ * Builds the headers of an MCP transport: the server's own auth, then the
+ * per-server static headers from its configuration (how a deployment tags
+ * itself, e.g. `X-Deployment: recette` on a test agent's server), then the
+ * conversation context. Context wins over static headers so a configuration
+ * cannot spoof it.
+ */
+export function buildMcpRequestHeaders({
+  apiKey,
+  staticHeaders,
+  context,
+}: {
+  apiKey?: string
+  staticHeaders?: Record<string, string>
+  context?: McpConversationContext
+}): Record<string, string> {
+  const headers: Record<string, string> = {}
+
+  for (const [name, value] of Object.entries(staticHeaders ?? {})) {
+    const trimmedName = name.trim()
+    // A header with an empty name or value would make the transport throw.
+    if (trimmedName === "" || value.trim() === "") continue
+    headers[trimmedName] = value.trim()
+  }
+
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  if (context) {
+    headers[MCP_CONTEXT_HEADERS.agentId] = context.agentId
+    headers[MCP_CONTEXT_HEADERS.sessionId] = context.sessionId
+    if (context.externalVisitorId) {
+      headers[MCP_CONTEXT_HEADERS.externalVisitorId] = context.externalVisitorId
+    }
+  }
+
+  return headers
+}

--- a/packages/api-contracts/src/mcp-servers/mcp-servers.dto.ts
+++ b/packages/api-contracts/src/mcp-servers/mcp-servers.dto.ts
@@ -15,8 +15,8 @@ export const createMcpServerSchema = z.object({
   url: z.string().url(),
   apiKey: z.string().optional(),
   /**
-   * Static headers sent on every call to this server, e.g. tagging which
-   * deployment calls it when one server serves several agents.
+   * Static headers sent on every call to this server, for whatever it expects
+   * beyond its auth (an API version, a tenant).
    */
   headers: z.record(z.string().trim().min(1), z.string()).optional(),
 })

--- a/packages/api-contracts/src/mcp-servers/mcp-servers.dto.ts
+++ b/packages/api-contracts/src/mcp-servers/mcp-servers.dto.ts
@@ -14,6 +14,11 @@ export const createMcpServerSchema = z.object({
   name: z.string().trim().min(1).max(100),
   url: z.string().url(),
   apiKey: z.string().optional(),
+  /**
+   * Static headers sent on every call to this server, e.g. tagging which
+   * deployment calls it when one server serves several agents.
+   */
+  headers: z.record(z.string().trim().min(1), z.string()).optional(),
 })
 
 export type CreateMcpServerDto = z.infer<typeof createMcpServerSchema>


### PR DESCRIPTION
## Why

An MCP server had no reliable way to know **which agent, session or embedded visitor** a tool call came from. The only channel was a tool parameter the model had to fill from its prompt — which is neither guaranteed (the model can omit it, or emit the call in the wrong channel entirely) nor trustworthy (a copied string can be mangled or invented).

Concrete need: one MCP server serving two agents, a test one and a production one, has to tell them apart, and an alert it forwards has to carry the visitor identifier the embedding page provided. Both must be plumbing, not prompt engineering.

## What

**Conversation context, on every MCP call, for every server.** Built in code from the streaming scope and sent as headers on the MCP transport:

| Header | Value |
|---|---|
| `X-Bayes-Agent-Id` | the calling agent |
| `X-Bayes-Session-Id` | the conversation or embed session |
| `X-Bayes-External-Visitor-Id` | the identifier the embedding page attached to a public session (absent on internal sessions) |

The public session proxy now carries that visitor identifier so it can reach the transport. The embed controller already received and stored it, nothing changes there.

Context headers are applied after the server's own configuration, so a configuration cannot spoof them.

## What consumes it, and how a server tells its deployments apart

The MCP server decides, from the headers alone:

- **`X-Bayes-External-Visitor-Id` present** means an embedded session, so a real user is behind the call. Absent means playground, evaluation or app: the server can record the call without notifying anyone.
- **Environment** comes from the agent id. The server keeps the list of agent identifiers it considers production in its own configuration and matches `X-Bayes-Agent-Id` against it. Nothing to declare on the platform side, nothing a caller can claim, and an unlisted agent falls back to the test label rather than the other way round.

That resolution belongs to the server, not here: the platform sends facts, the server decides what they mean for it.

## Privacy

These headers reach third-party servers, so the set is deliberately minimal: no user name, no message content, no organization or project identifier. Adding a field means deciding it is acceptable for every MCP server the platform can be pointed at.

## Also in this PR

`McpServerConfig` gains an optional `headers` record, sent on every call to that server. It is a generic capability, no longer needed by the case above now that the environment comes from the agent id. It costs no migration (the config is an encrypted blob) and the Studio dialog does not expose it. Say the word and I drop it to keep the PR minimal.

## Tests

Header builder: context forwarded, visitor header omitted when absent, server auth and static headers preserved, static headers cannot override the context, empty names and values dropped (they would make the transport throw), nothing sent when there is nothing to send. Plus an e2e assertion that the context reaches `connect` through the real pipeline.

## Verified against a real server

The first consumer is deployed and tested end to end. Without the visitor header the call is recorded on the server and notifies nobody; with it, the notification goes out and carries the identifier. The tool that receives it no longer declares the identifier as a parameter at all, so it can only come from the transport.

`trivy` is red on expired ignore entries in `.trivyignore.yaml` (30/06), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
