### PR TITLE
fix(agent-settings): serve published settings on the embed and reviewer paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Model tool-call syntax (pseudo-XML fragments) no longer leaks into chat replies when the model mishandles its bookkeeping call
 - Agent prompts that referenced the old retrieval tool name are rewritten to the new one at deploy time, so hand-written instructions keep working
 - Agent editor: restoring a version from the history now updates the form fields immediately
+- Embedded agents now answer with the agent's published version: the widget on a customer site, the greeting of a new embed session, and the reviewer's session view all stopped picking up an unpublished draft as soon as an author saved a change in the agent editor; archived versions are skipped the same way
 - Fix some scanned PDF documents importing with no extracted text
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Agent prompts that referenced the old retrieval tool name are rewritten to the new one at deploy time, so hand-written instructions keep working
 - Agent editor: restoring a version from the history now updates the form fields immediately
 - Embedded agents now answer with the agent's published version: the widget on a customer site, the greeting of a new embed session, and the reviewer's session view all stopped picking up an unpublished draft as soon as an author saved a change in the agent editor; archived versions are skipped the same way
+- Evaluations: retrying an extraction run re-processes its records with the settings version the run was launched on, instead of the agent's newest version, which could be an unpublished draft
 - Fix some scanned PDF documents importing with no extracted text
 
 ### Security

--- a/apps/api/.dependency-cruiser-known-violations.json
+++ b/apps/api/.dependency-cruiser-known-violations.json
@@ -3592,15 +3592,6 @@
   {
     "type": "dependency",
     "from": "src/domains/public-chat/public-agent-sessions/public-agent-sessions.service.ts",
-    "to": "src/domains/agents/settings/agent-settings.entity.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-domain-entity-import"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domains/public-chat/public-agent-sessions/public-agent-sessions.service.ts",
     "to": "src/domains/agents/shared/agent-session-messages/agent-message.entity.ts",
     "rule": {
       "severity": "error",
@@ -3628,15 +3619,6 @@
   {
     "type": "dependency",
     "from": "src/domains/public-chat/public-chat.module.ts",
-    "to": "src/domains/agents/settings/agent-settings.entity.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-domain-entity-import"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domains/public-chat/public-chat.module.ts",
     "to": "src/domains/agents/shared/agent-session-messages/agent-message.entity.ts",
     "rule": {
       "severity": "error",
@@ -3647,15 +3629,6 @@
     "type": "dependency",
     "from": "src/domains/public-chat/public-chat.service.ts",
     "to": "src/domains/agents/agent.entity.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-domain-entity-import"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domains/public-chat/public-chat.service.ts",
-    "to": "src/domains/agents/settings/agent-settings.entity.ts",
     "rule": {
       "severity": "error",
       "name": "no-cross-domain-entity-import"
@@ -3836,15 +3809,6 @@
     "type": "dependency",
     "from": "src/domains/review-campaigns/reviewer/reviewer.service.ts",
     "to": "src/domains/agents/conversation-agent-sessions/conversation-agent-session.entity.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-domain-entity-import"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domains/review-campaigns/reviewer/reviewer.service.ts",
-    "to": "src/domains/agents/settings/agent-settings.entity.ts",
     "rule": {
       "severity": "error",
       "name": "no-cross-domain-entity-import"
@@ -4365,6 +4329,24 @@
   },
   {
     "type": "dependency",
+    "from": "src/domains/public-chat/public-agent-sessions/public-agent-sessions.service.ts",
+    "to": "src/domains/agents/settings/agent-settings.service.ts",
+    "rule": {
+      "severity": "warn",
+      "name": "no-cross-domain-service-reach"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domains/public-chat/public-chat.service.ts",
+    "to": "src/domains/agents/settings/agent-settings.service.ts",
+    "rule": {
+      "severity": "warn",
+      "name": "no-cross-domain-service-reach"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "src/domains/public-chat/public-chat.service.ts",
     "to": "src/domains/agents/shared/agent-session-messages/streaming/streaming.service.ts",
     "rule": {
@@ -4375,6 +4357,15 @@
   {
     "type": "dependency",
     "from": "src/domains/review-campaigns/review-campaigns.service.ts",
+    "to": "src/domains/agents/settings/agent-settings.service.ts",
+    "rule": {
+      "severity": "warn",
+      "name": "no-cross-domain-service-reach"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domains/review-campaigns/reviewer/reviewer.service.ts",
     "to": "src/domains/agents/settings/agent-settings.service.ts",
     "rule": {
       "severity": "warn",

--- a/apps/api/src/domains/agents/settings/agent.settings.factory.ts
+++ b/apps/api/src/domains/agents/settings/agent.settings.factory.ts
@@ -9,7 +9,15 @@ type AgentSettingsTransientParams = RequiredScopeTransientParams & {
   agent: Agent
 }
 
-class AgentSettingsFactory extends Factory<AgentSettings, AgentSettingsTransientParams> {}
+class AgentSettingsFactory extends Factory<AgentSettings, AgentSettingsTransientParams> {
+  draft() {
+    return this.params({ isDraft: true })
+  }
+
+  archived() {
+    return this.params({ isArchived: true })
+  }
+}
 
 export const agentSettingsFactory = AgentSettingsFactory.define(
   ({ sequence, params, transientParams }) => {
@@ -39,8 +47,8 @@ export const agentSettingsFactory = AgentSettingsFactory.define(
       projectId: transientParams.project.id,
       agentId: transientParams.agent.id,
       agent: transientParams.agent,
-      isDraft: false,
-      isArchived: false,
+      isDraft: params.isDraft ?? false,
+      isArchived: params.isArchived ?? false,
       createdAt: params.createdAt || now,
       updatedAt: params.updatedAt || now,
       deletedAt: params.deletedAt || null,

--- a/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/retry-one.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/retry-one.spec.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto"
+import { AgentModel, EvaluationExtractionRunsRoutes } from "@caseai-connect/api-contracts"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { ActivitiesModule } from "@/domains/activities/activities.module"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { setupUserGuardForTesting } from "../../../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../../../test/request"
+import { EvaluationsModule } from "../../../evaluations.module"
+import { EVALUATION_EXTRACTION_RUN_BATCH_SERVICE } from "../evaluation-extraction-run-batch.interface"
+import { EvaluationExtractionRunRecord } from "../records/evaluation-extraction-run-record.entity"
+import { evaluationExtractionRunRecordFactory } from "../records/evaluation-extraction-run-record.factory"
+import { createRunWithCsvDataset } from "./csv-dataset.helpers"
+
+describe("EvaluationExtractionRuns - retryOne", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let organizationId: string
+  let projectId: string
+  let evaluationExtractionRunId: string
+  let accessToken: string | undefined = "token"
+  let auth0Id = `auth0|${randomUUID()}`
+
+  const mockRetryRunRecords = jest.fn().mockResolvedValue(undefined)
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [EvaluationsModule, ActivitiesModule],
+      applyOverrides: (moduleBuilder) =>
+        setupUserGuardForTesting(moduleBuilder, () => auth0Id)
+          .overrideProvider(EVALUATION_EXTRACTION_RUN_BATCH_SERVICE)
+          .useValue({
+            enqueueExecuteRun: jest.fn().mockResolvedValue(undefined),
+            enqueueRunRecords: jest.fn().mockResolvedValue(undefined),
+            retryRunRecords: mockRetryRunRecords,
+            removePendingRunRecords: jest.fn().mockResolvedValue(undefined),
+          }),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    mockRetryRunRecords.mockClear()
+    accessToken = "token"
+    auth0Id = `auth0|${randomUUID()}`
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await app.close()
+  })
+
+  /** A run pinned to the published settings, with one record left to retry. */
+  const createContext = async () => {
+    const { user, organization, project, agent, agentSettings } = await createOrganizationWithAgent(
+      repositories,
+      {
+        user: { auth0Id },
+        agent: { type: "extraction" },
+        agentSettings: {
+          outputJsonSchema: { type: "object", properties: { answer: { type: "string" } } },
+          model: AgentModel._Mock,
+          instructions: "Published instructions",
+        },
+      },
+    )
+    organizationId = organization.id
+    projectId = project.id
+    auth0Id = user.auth0Id
+
+    const { datasetRecords, run } = await createRunWithCsvDataset({
+      getRepository: setup.getRepository,
+      organization,
+      project,
+      agent,
+      agentSettings,
+      keyMapping: [{ agentOutputKey: "answer", datasetColumnId: "col-answer", mode: "scored" }],
+    })
+    evaluationExtractionRunId = run.id
+
+    const [firstDatasetRecord] = datasetRecords
+    if (!firstDatasetRecord) throw new Error("expected a dataset record")
+    await setup.getRepository(EvaluationExtractionRunRecord).save(
+      evaluationExtractionRunRecordFactory
+        .transient({
+          organization,
+          project,
+          evaluationExtractionRun: run,
+          evaluationExtractionDatasetRecord: firstDatasetRecord,
+        })
+        .build({ status: "error" }),
+    )
+
+    return { organization, project, agent, agentSettings, run }
+  }
+
+  const subject = async () =>
+    request({
+      route: EvaluationExtractionRunsRoutes.retryOne,
+      pathParams: removeNullish({ organizationId, projectId, evaluationExtractionRunId }),
+      token: accessToken,
+    })
+
+  it("retries the records with the settings version the run is pinned to", async () => {
+    const { agentSettings } = await createContext()
+
+    const res = await subject()
+
+    expectResponse(res, 201)
+    expect(mockRetryRunRecords).toHaveBeenCalledTimes(1)
+    const [payloads] = mockRetryRunRecords.mock.calls[0]
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].agentWithSettings).toMatchObject({
+      revision: agentSettings.revision,
+      instructions: "Published instructions",
+    })
+  })
+
+  it("does not retry with a newer draft revision (#636)", async () => {
+    const { organization, project, agent, agentSettings } = await createContext()
+    await repositories.agentSettingsRepository.save(
+      agentSettingsFactory
+        .draft()
+        .transient({ organization, project, agent })
+        .build({ revision: agentSettings.revision + 1, instructions: "Draft instructions" }),
+    )
+
+    const res = await subject()
+
+    expectResponse(res, 201)
+    expect(mockRetryRunRecords).toHaveBeenCalledTimes(1)
+    const [payloads] = mockRetryRunRecords.mock.calls[0]
+    expect(payloads[0].agentWithSettings).toMatchObject({
+      revision: agentSettings.revision,
+      instructions: "Published instructions",
+    })
+  })
+})

--- a/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.service.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.service.ts
@@ -25,6 +25,7 @@ export class EvaluationExtractionRunsService {
   private readonly runRecordConnectRepository: ConnectRepository<EvaluationExtractionRunRecord>
   private readonly datasetConnectRepository: ConnectRepository<EvaluationExtractionDataset>
   private readonly agentConnectRepository: ConnectRepository<Agent>
+  private readonly agentSettingsConnectRepository: ConnectRepository<AgentSettings>
 
   constructor(
     @InjectRepository(EvaluationExtractionRun)
@@ -36,7 +37,7 @@ export class EvaluationExtractionRunsService {
     @InjectRepository(Agent)
     agentRepository: Repository<Agent>,
     @InjectRepository(AgentSettings)
-    private readonly agentSettingsRepository: Repository<AgentSettings>,
+    agentSettingsRepository: Repository<AgentSettings>,
     @Inject(EVALUATION_EXTRACTION_RUN_BATCH_SERVICE)
     private readonly batchService: EvaluationExtractionRunBatchService,
   ) {
@@ -53,6 +54,10 @@ export class EvaluationExtractionRunsService {
       "evaluationExtractionDataset",
     )
     this.agentConnectRepository = new ConnectRepository(agentRepository, "agent")
+    this.agentSettingsConnectRepository = new ConnectRepository(
+      agentSettingsRepository,
+      "agentSettings",
+    )
   }
 
   async createRun({
@@ -283,23 +288,28 @@ export class EvaluationExtractionRunsService {
     })
   }
 
-  private async getAgent({
+  private async getAgentForRun({
     connectScope,
-    agentId,
+    evaluationExtractionRun,
   }: {
     connectScope: RequiredConnectScope
-    agentId: string
+    evaluationExtractionRun: EvaluationExtractionRun
   }): Promise<{ agent: Agent; agentSettings: AgentSettings }> {
+    const { agentId, agentSettingsId } = evaluationExtractionRun
     const agent = await this.agentConnectRepository.getOneById(connectScope, agentId)
     if (!agent) {
       throw new NotFoundException(`Agent with id ${agentId} not found`)
     }
-    const agentSettings = await this.agentSettingsRepository.findOne({
-      where: { agentId },
-      order: { revision: "DESC" }, //findOne + order DESC to get last revision
-    })
+    // A retry continues an existing run, so it reuses the exact settings version the
+    // run is pinned to, the way the run starter does. Re-resolving the highest
+    // revision picked up the draft an author was editing, and could also switch a
+    // run to another version halfway through (#636).
+    const agentSettings = await this.agentSettingsConnectRepository.getOneById(
+      connectScope,
+      agentSettingsId,
+    )
     if (!agentSettings)
-      throw new NotFoundException(`AgentSettings for Agent with id ${agentId} not found`)
+      throw new NotFoundException(`AgentSettings with id ${agentSettingsId} not found`)
 
     return { agent, agentSettings }
   }
@@ -318,9 +328,9 @@ export class EvaluationExtractionRunsService {
     evaluationExtractionRun.status = "running"
     await this.runConnectRepository.saveOne(evaluationExtractionRun)
 
-    const { agent, agentSettings } = await this.getAgent({
+    const { agent, agentSettings } = await this.getAgentForRun({
       connectScope,
-      agentId: evaluationExtractionRun.agentId,
+      evaluationExtractionRun,
     })
 
     const unfinishedRecords = await this.runRecordConnectRepository.find(connectScope, {

--- a/apps/api/src/domains/public-chat/e2e-tests/create-session.spec.ts
+++ b/apps/api/src/domains/public-chat/e2e-tests/create-session.spec.ts
@@ -9,6 +9,8 @@ import {
   setupE2eTestDatabase,
   teardownE2eTestDatabase,
 } from "@/common/test/test-database"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
+import type { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
 import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
 import { sdk } from "@/external/llm/open-telemetry-init"
 import { agentEmbedConfigFactory } from "../agent-embed-configs/agent-embed-config.factory"
@@ -41,14 +43,17 @@ describe("PublicChat - createSession", () => {
     await app.close()
   })
 
-  const createContext = async () => {
-    const { organization, project, agent } = await createOrganizationWithAgent(repositories)
+  const createContext = async (params?: { agentSettings?: Partial<AgentSettings> }) => {
+    const { organization, project, agent, agentSettings } = await createOrganizationWithAgent(
+      repositories,
+      params?.agentSettings ? { agentSettings: params.agentSettings } : {},
+    )
     const embedConfig = agentEmbedConfigFactory
       .transient({ organization, project, agent })
       .build({ isEnabled: true })
     await repositories.agentEmbedConfigRepository.save(embedConfig)
     embedToken = embedConfig.embedToken
-    return { organization, project, agent, embedConfig }
+    return { organization, project, agent, agentSettings, embedConfig }
   }
 
   const subject = (payload?: { externalVisitorId?: string }) =>
@@ -119,6 +124,50 @@ describe("PublicChat - createSession", () => {
       where: { id: response.body.data.sessionId },
     })
     expect(savedSession?.externalVisitorId).toBeNull()
+  })
+
+  it("greets with the last published revision, not the newer draft (#636)", async () => {
+    const { organization, project, agent, agentSettings } = await createContext({
+      agentSettings: { greetingMessage: "Published greeting" },
+    })
+    await repositories.agentSettingsRepository.save(
+      agentSettingsFactory
+        .draft()
+        .transient({ organization, project, agent })
+        .build({ revision: agentSettings.revision + 1, greetingMessage: "Draft greeting" }),
+    )
+
+    const response = await subject()
+
+    expect(response.status).toBe(201)
+    const messages = await repositories.agentMessageRepository.find({
+      where: { sessionId: response.body.data.sessionId },
+    })
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.content).toBe("Published greeting")
+    expect(messages[0]?.agentSettingsId).toBe(agentSettings.id)
+  })
+
+  it("greets with the last non-archived revision (#636)", async () => {
+    const { organization, project, agent, agentSettings } = await createContext({
+      agentSettings: { greetingMessage: "Published greeting" },
+    })
+    await repositories.agentSettingsRepository.save(
+      agentSettingsFactory
+        .archived()
+        .transient({ organization, project, agent })
+        .build({ revision: agentSettings.revision + 1, greetingMessage: "Archived greeting" }),
+    )
+
+    const response = await subject()
+
+    expect(response.status).toBe(201)
+    const messages = await repositories.agentMessageRepository.find({
+      where: { sessionId: response.body.data.sessionId },
+    })
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.content).toBe("Published greeting")
+    expect(messages[0]?.agentSettingsId).toBe(agentSettings.id)
   })
 
   it("each session call returns a unique sessionToken", async () => {

--- a/apps/api/src/domains/public-chat/e2e-tests/stream-messages.spec.ts
+++ b/apps/api/src/domains/public-chat/e2e-tests/stream-messages.spec.ts
@@ -10,6 +10,7 @@ import {
   setupE2eTestDatabase,
   teardownE2eTestDatabase,
 } from "@/common/test/test-database"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
 import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
 import { sdk } from "@/external/llm/open-telemetry-init"
 import type { AISDKMockProvider } from "@/external/llm/providers/ai-sdk-mock.provider"
@@ -163,6 +164,28 @@ describe("PublicChat - streamMessages", () => {
       id: session.id,
     })
     expect(updatedSession.result).toEqual({ fullName: "Ada", city: "Paris" })
+  })
+
+  it("answers with the last published revision, not the newer draft (#636)", async () => {
+    const { organization, project, agent, agentSettings, session } = await createContext()
+    const draftSettings = await repositories.agentSettingsRepository.save(
+      agentSettingsFactory
+        .draft()
+        .transient({ organization, project, agent })
+        .build({ revision: agentSettings.revision + 1 }),
+    )
+
+    const response = await subject("Hello")
+    expect(response.status).toBe(200)
+
+    const messages = await repositories.agentMessageRepository.find({
+      where: { sessionId: session.id },
+    })
+    expect(messages.length).toBeGreaterThan(0)
+    for (const message of messages) {
+      expect(message.agentSettingsId).toBe(agentSettings.id)
+      expect(message.agentSettingsId).not.toBe(draftSettings.id)
+    }
   })
 
   it("should return error when empty content", async () => {

--- a/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-sessions.service.ts
+++ b/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-sessions.service.ts
@@ -4,7 +4,8 @@ import { InjectRepository } from "@nestjs/typeorm"
 import type { Repository } from "typeorm"
 import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
 import { AgentSessionCategory } from "@/domains/agents/session-categories/agent-session-category.entity"
-import { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { AgentSettingsService } from "@/domains/agents/settings/agent-settings.service"
 import { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 import type { AgentEmbedConfig } from "../agent-embed-configs/agent-embed-config.entity"
 import { PublicAgentSession } from "./public-agent-session.entity"
@@ -19,12 +20,11 @@ export class PublicAgentSessionsService {
     private readonly publicAgentSessionRepository: Repository<PublicAgentSession>,
     @InjectRepository(AgentMessage)
     private readonly agentMessageRepository: Repository<AgentMessage>,
-    @InjectRepository(AgentSettings)
-    private readonly agentSettingsRepository: Repository<AgentSettings>,
     @InjectRepository(PublicAgentSessionCategory)
     private readonly publicAgentSessionCategoryRepository: Repository<PublicAgentSessionCategory>,
     @InjectRepository(AgentSessionCategory)
     private readonly agentSessionCategoryRepository: Repository<AgentSessionCategory>,
+    private readonly agentSettingsService: AgentSettingsService,
   ) {}
 
   /**
@@ -124,14 +124,15 @@ export class PublicAgentSessionsService {
     const sessionToken = crypto.randomUUID()
     const sessionTokenHash = crypto.createHash("sha256").update(sessionToken).digest("hex")
 
-    const agentSettings = await this.agentSettingsRepository.findOne({
-      where: { agentId: embedConfig.agentId },
-      order: { revision: "DESC" }, //findOne + order DESC to get last revision
+    // The greeting and the session config come from the published settings, not from
+    // the draft an author is editing in the agent editor (#636).
+    const agentSettings = await this.agentSettingsService.getLast({
+      connectScope: {
+        organizationId: embedConfig.organizationId,
+        projectId: embedConfig.projectId,
+      },
+      agentId: embedConfig.agentId,
     })
-    if (!agentSettings)
-      throw new NotFoundException(
-        `AgentSettings for Agent with id ${embedConfig.agentId} not found`,
-      )
 
     const session = this.publicAgentSessionRepository.create({
       embedConfigId: embedConfig.id,

--- a/apps/api/src/domains/public-chat/public-chat.module.ts
+++ b/apps/api/src/domains/public-chat/public-chat.module.ts
@@ -2,7 +2,7 @@ import { Module } from "@nestjs/common"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { Agent } from "@/domains/agents/agent.entity"
 import { AgentSessionCategory } from "@/domains/agents/session-categories/agent-session-category.entity"
-import { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
+import { AgentSettingsModule } from "@/domains/agents/settings/agent-settings.module"
 import { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 import { StreamingModule } from "@/domains/agents/shared/agent-session-messages/streaming/streaming.module"
 import { AgentEmbedConfig } from "./agent-embed-configs/agent-embed-config.entity"
@@ -24,8 +24,8 @@ import { PublicChatService } from "./public-chat.service"
       AgentSessionCategory,
       AgentMessage,
       Agent,
-      AgentSettings,
     ]),
+    AgentSettingsModule,
     StreamingModule,
   ],
   providers: [

--- a/apps/api/src/domains/public-chat/public-chat.service.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.ts
@@ -8,7 +8,8 @@ import { Injectable, NotFoundException } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
 import type { Repository } from "typeorm"
 import { Agent } from "@/domains/agents/agent.entity"
-import { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { AgentSettingsService } from "@/domains/agents/settings/agent-settings.service"
 import type { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { StreamingService } from "@/domains/agents/shared/agent-session-messages/streaming/streaming.service"
@@ -24,8 +25,7 @@ export class PublicChatService {
   constructor(
     @InjectRepository(Agent)
     private readonly agentRepository: Repository<Agent>,
-    @InjectRepository(AgentSettings)
-    private readonly agentSettingsRepository: Repository<AgentSettings>,
+    private readonly agentSettingsService: AgentSettingsService,
     readonly agentEmbedConfigsService: AgentEmbedConfigsService,
     private readonly publicAgentSessionsService: PublicAgentSessionsService,
     private readonly streamingService: StreamingService,
@@ -60,19 +60,21 @@ export class PublicChatService {
     })
     if (!agent) throw new NotFoundException("Agent not found")
 
-    const agentSettings = await this.agentSettingsRepository.findOne({
-      where: { agentId: publicSession.agentId },
-      order: { revision: "DESC" }, //findOne + order DESC to get last revision
+    const connectScope = {
+      organizationId: publicSession.organizationId,
+      projectId: publicSession.projectId,
+    }
+    // Visitors must be answered by the published settings, never by the draft an
+    // author is editing in the agent editor (#636).
+    const agentSettings = await this.agentSettingsService.getLast({
+      connectScope,
+      agentId: publicSession.agentId,
     })
-    if (!agentSettings) throw new NotFoundException("AgentSettings for Agent not found")
 
     await this.publicAgentSessionsService.updateLastActivity(publicSession.id)
 
     yield* this.streamingService.streamPublicAgentResponse({
-      connectScope: {
-        organizationId: publicSession.organizationId,
-        projectId: publicSession.projectId,
-      },
+      connectScope,
       publicSessionId: publicSession.id,
       agent,
       agentSettings,

--- a/apps/api/src/domains/review-campaigns/reviewer/e2e-tests/get-session.spec.ts
+++ b/apps/api/src/domains/review-campaigns/reviewer/e2e-tests/get-session.spec.ts
@@ -180,7 +180,7 @@ describe("ReviewCampaigns - Reviewer session detail (blind redaction)", () => {
     reviewCampaignId = campaign.id
     sessionId = session.id
 
-    return { organization, project, agent, campaign, reviewer, tester, session }
+    return { organization, project, agent, agentSettings, campaign, reviewer, tester, session }
   }
 
   const subject = async () =>
@@ -435,6 +435,26 @@ describe("ReviewCampaigns - Reviewer session detail (blind redaction)", () => {
 
   it("returns formResult: null when fillForm is not enabled on the agent", async () => {
     await seedCampaignAndSession()
+    const response = await subject()
+    expectResponse(response, 200)
+    expect(response.body.data.formResult).toBeNull()
+  })
+
+  it("reads the last published revision, not a newer draft (#636)", async () => {
+    const { organization, project, agent, agentSettings } = await seedCampaignAndSession()
+    // The draft enables fillForm; the published revision does not. The reviewer
+    // context must keep describing what the tester actually ran.
+    await repositories.agentSettingsRepository.save(
+      agentSettingsFactory
+        .draft()
+        .transient({ organization, project, agent })
+        .build({
+          revision: agentSettings.revision + 1,
+          fillFormEnabled: true,
+          outputJsonSchema: { type: "object", properties: { fullName: { type: "string" } } },
+        }),
+    )
+
     const response = await subject()
     expectResponse(response, 200)
     expect(response.body.data.formResult).toBeNull()

--- a/apps/api/src/domains/review-campaigns/reviewer/reviewer.service.ts
+++ b/apps/api/src/domains/review-campaigns/reviewer/reviewer.service.ts
@@ -10,7 +10,8 @@ import { In, type Repository } from "typeorm"
 import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
 import { Agent } from "@/domains/agents/agent.entity"
 import { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
-import { AgentSettings } from "@/domains/agents/settings/agent-settings.entity"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { AgentSettingsService } from "@/domains/agents/settings/agent-settings.service"
 import { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
 import type { ReviewCampaign } from "../review-campaign.entity"
 import type {
@@ -82,10 +83,9 @@ export class ReviewerService {
     private readonly agentMessageRepository: Repository<AgentMessage>,
     @InjectRepository(Agent)
     private readonly agentRepository: Repository<Agent>,
-    @InjectRepository(AgentSettings)
-    private readonly agentSettingsRepository: Repository<AgentSettings>,
     @InjectRepository(TesterSessionFeedback)
     private readonly testerFeedbackRepository: Repository<TesterSessionFeedback>,
+    private readonly agentSettingsService: AgentSettingsService,
   ) {}
 
   async listSessionsForCampaign({
@@ -175,19 +175,15 @@ export class ReviewerService {
     if (!agent) {
       throw new Error(`Agent ${campaign.agentId} not found for campaign ${campaign.id}`)
     }
-    const agentSettings = await this.agentSettingsRepository.findOne({
-      where: {
-        agentId: campaign.agentId,
+    // The reviewer context must describe the published settings, not the draft an
+    // author may be editing in the agent editor (#636).
+    const agentSettings = await this.agentSettingsService.getLast({
+      connectScope: {
         organizationId: campaign.organizationId,
         projectId: campaign.projectId,
       },
-      order: { revision: "DESC" }, //findOne + order DESC to get last revision
+      agentId: campaign.agentId,
     })
-    if (!agentSettings) {
-      throw new Error(
-        `AgentSettings for Agent ${campaign.agentId} not found for campaign ${campaign.id}`,
-      )
-    }
     // Loads everything we need in parallel. Redaction happens below based on
     // whether the caller has already reviewed.
     const [transcript, callerReview, allReviews, testerFeedback, session] = await Promise.all([

--- a/apps/api/src/scripts/requeue-evaluation-extraction-runs.ts
+++ b/apps/api/src/scripts/requeue-evaluation-extraction-runs.ts
@@ -131,10 +131,19 @@ async function bootstrapCli(): Promise<void> {
       if (!agent) {
         throw logger.warn(`Agent with id=${agentId} not found.`)
       }
+      // Pinned on purpose: a requeue re-processes records of an existing run, so it
+      // reuses the settings version that run was scored with. Resolving the highest
+      // revision instead would swap settings halfway through a run and could pick up
+      // the draft an author is editing (#636).
       const agentSettings = await agentSettingsRepository.findOne({
         where: { agentId, id: agentSettingsId },
       })
       if (!agentSettings) throw logger.warn(`AgentSettings for Agent with id=${agentId} not found`)
+      if (agentSettings.isDraft || agentSettings.isArchived) {
+        logger.warn(
+          `Run is pinned to revision ${agentSettings.revision} of agent id=${agentId}, which is ${agentSettings.isDraft ? "a draft" : "archived"}. Requeueing with it, as recorded on the run.`,
+        )
+      }
       return { agent, agentSettings }
     }
 


### PR DESCRIPTION
Closes #636

## What was wrong

Several services resolved agent settings by hand:

```ts
await this.agentSettingsRepository.findOne({
  where: { agentId },
  order: { revision: "DESC" }, //findOne + order DESC to get last revision
})
```

A draft is by construction the highest revision, so each of these ran the **draft** as soon as an author saved any change in the agent editor. An archived revision could surface the same way.

## The five call sites from the issue

| Call site | Resolution |
| --- | --- |
| `public-chat.service.ts` → `streamResponse` | `AgentSettingsService.getLast()` |
| `public-agent-sessions.service.ts` → `createSession` | `AgentSettingsService.getLast()` |
| `reviewer.service.ts` → `getSessionForReview` | `AgentSettingsService.getLast()` |
| `evaluation-extraction-runs.service.ts` → `getAgent` | loads the run's pinned `agentSettingsId` |
| `scripts/requeue-evaluation-extraction-runs.ts` → `getAgentWithSettings` | already loads the pinned id, keeps it, now warns when that version is a draft or archived |

### The three user-facing paths

The widget on a customer site, the greeting of a new embed session, and the reviewer's session view now go through `AgentSettingsService.getLast()`, which already filters `isDraft: false` and `isArchived: false`, so the rule stays in one place. Their direct `Repository<AgentSettings>` injections are removed, which is what allowed the pattern in the first place.

No agent loses its settings: `agents.service.ts` publishes revision 1 immediately after creating an agent, so every agent has at least one published revision.

### The two extraction paths

These are not "latest published" questions, they are "which version did this run use" questions, so the fix differs.

`retryRun` re-processed a run's unfinished records with the newest revision, while the initial execution (`evaluation-extraction-run-starter.service.ts:107`) honours `run.agentSettingsId`. So a retry both picked up the draft and could switch a run to a different published version halfway through. It now loads the pinned id, so both paths of a run agree on one version.

The requeue script was already loading the pinned id, which is what a requeue should do: swapping in the latest version would make the requeued records incomparable to the ones already scored. Refusing to requeue a run pinned to a draft would also fight #633, which wants a draft to be evaluatable on purpose. So the behaviour stands, with a comment recording why and a warning when the pinned version is a draft or archived.

The version selector in the run dialog and the pinning work on the create path stay with #633.

## Tests

Six tests, each failing before the fix and passing after:

- `public-chat/e2e-tests/create-session.spec.ts`: the greeting comes from the published revision, not from a newer draft, and not from a newer archived revision
- `public-chat/e2e-tests/stream-messages.spec.ts`: every message persisted by a stream carries the published `agentSettingsId`
- `review-campaigns/reviewer/e2e-tests/get-session.spec.ts`: a draft that enables form filling does not change the reviewer's `formResult`
- `evaluations/extraction/runs/e2e-tests/retry-one.spec.ts` (new): a retry enqueues the run's pinned revision, and a newer draft does not change that

`agentSettingsFactory` gets `draft()` and `archived()` traits, and its `isDraft` / `isArchived` defaults now read `params.X ?? false` like the other fields.

## Follow-up

The issue floats a lint rule or a narrower repository wrapper to stop the pattern coming back. Not done here. `grep -rn "revision.*DESC" apps/api/src` now returns only `agent-settings.service.ts` itself, so there is no live instance left to guard, and a rule that bans the shape outright would also ban the legitimate pinned lookups. Worth revisiting if it reappears.

## Checks

`npm run biome:check`, `npm run typecheck`, `apps/api npm run test:parallel` (2084 passed, 0 failed) and `apps/api npm run check:boundaries` all pass. The dependency-cruiser baseline is regenerated: three `no-cross-domain-service-reach` warnings appear (the same reach `tester.service.ts` already has) and four `no-cross-domain-entity-import` violations disappear.

## Before merging

Worth checking whether any embed session was already answered by a draft, as the issue notes. On production:

```sql
select s.agent_id, count(*) as messages, min(m.created_at) as first_seen, max(m.created_at) as last_seen
from agent_message m
join agent_settings s on s.id = m.agent_settings_id
join public_agent_session p on p.id = m.session_id
where s.is_draft = true
group by s.agent_id;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)