### PR TITLE
fix(agent-settings): playground no longer throws for project admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Embedded agents now answer with the agent's published version: the widget on a customer site, the greeting of a new embed session, and the reviewer's session view all stopped picking up an unpublished draft as soon as an author saved a change in the agent editor; archived versions are skipped the same way
 - Evaluations: retrying an extraction run re-processes its records with the settings version the run was launched on, instead of the agent's newest version, which could be an unpublished draft
 - Fix some scanned PDF documents importing with no extracted text
+- Studio playground no longer crashes for project admins who don't manage the agent
+- Agent editor no longer crashes when the page is reloaded while the settings are still loading
 
 ### Security
 ## [26.07.3] - 2026-07-24

--- a/apps/api/src/domains/agents/settings/agent-settings.controller.ts
+++ b/apps/api/src/domains/agents/settings/agent-settings.controller.ts
@@ -39,7 +39,11 @@ export class AgentSettingsController {
 
   // History timeline of all revisions for the agent settings, including drafts and published revisions.
   @Get(AgentSettingsRoutes.getAll.path)
-  @CheckPolicy((policy) => policy.canUpdate())
+  // NOTE: Project admin with only agent member access can see the history
+  // canCreate(): boolean {
+  //   return this.canAccess() && this.isProjectAdminOrOwner()
+  // }
+  @CheckPolicy((policy) => policy.canCreate())
   async getAll(
     @Req() request: EndpointRequestWithAgent,
   ): Promise<typeof AgentSettingsRoutes.getAll.response> {

--- a/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.en.json
+++ b/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.en.json
@@ -151,7 +151,8 @@
       "restoreDialog": {
         "title": "Restore version {{revision}}?",
         "description": "The settings of version {{revision}} will be copied as a new version and become the current settings. No version is deleted."
-      }
+      },
+      "draft": "Draft"
     },
     "version": {
       "ariaLabel": "Settings version new messages run with",

--- a/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.fr.json
+++ b/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.fr.json
@@ -151,7 +151,8 @@
       "restoreDialog": {
         "title": "Restaurer la version {{revision}} ?",
         "description": "Les paramètres de la version {{revision}} seront copiés comme nouvelle version et deviendront les paramètres actuels. Aucune version n'est supprimée."
-      }
+      },
+      "draft": "Brouillon"
     },
     "version": {
       "ariaLabel": "Version des paramètres utilisée par les nouveaux messages",

--- a/apps/web/src/studio/features/agents/agent-settings/components/AgentRevisionBadge.tsx
+++ b/apps/web/src/studio/features/agents/agent-settings/components/AgentRevisionBadge.tsx
@@ -32,6 +32,7 @@ export function AgentRevisionBadge({
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const version = findVersion(versions, revision)
+  const isDraft = version?.isDraft ?? false
 
   return (
     <>
@@ -39,7 +40,7 @@ export function AgentRevisionBadge({
         <TooltipTrigger asChild>
           <Badge
             asChild
-            variant="secondary"
+            variant={isDraft ? "warning" : "secondary"}
             className="cursor-pointer hover:bg-secondary/70"
             aria-label={t("agentSettings:history.revisionBadgeAria", { revision })}
           >
@@ -49,7 +50,8 @@ export function AgentRevisionBadge({
               aria-expanded={open}
               onClick={() => setOpen(true)}
             >
-              {t("agentSettings:history.revisionBadge", { revision })}
+              {t("agentSettings:history.revisionBadge", { revision })}{" "}
+              {isDraft && `- ${t("agentSettings:history.draft")}`}
             </button>
           </Badge>
         </TooltipTrigger>

--- a/apps/web/src/studio/features/agents/agent-settings/components/AgentSettingsRestoreButton.tsx
+++ b/apps/web/src/studio/features/agents/agent-settings/components/AgentSettingsRestoreButton.tsx
@@ -4,6 +4,9 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ConfirmDialog } from "@/common/components/ConfirmDialog"
 import { restoreAgentSettings } from "@/common/features/agents/agent-settings/agent-settings.thunks"
+import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
+import { useAbility } from "@/common/hooks/use-ability"
+import { useValue } from "@/common/hooks/use-value"
 import { useAppDispatch } from "@/common/store/hooks"
 
 /** One-click restore: copies the selected revision's settings as a new (current) revision. */
@@ -16,6 +19,9 @@ export function AgentSettingsRestoreButton({
 }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  const agent = useValue(selectCurrentAgentData)
+  const { abilities } = useAbility()
+  const canManageAgent = abilities.canManageAgent({ agentId: agent.id })
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [isRestoring, setIsRestoring] = useState(false)
 
@@ -31,6 +37,7 @@ export function AgentSettingsRestoreButton({
     }
   }
 
+  if (!canManageAgent) return null
   return (
     <>
       <Button size="sm" disabled={disabled || isRestoring} onClick={() => setConfirmOpen(true)}>

--- a/apps/web/src/studio/routes/AgentEditorRoute.tsx
+++ b/apps/web/src/studio/routes/AgentEditorRoute.tsx
@@ -40,7 +40,11 @@ export function AgentEditorRoute() {
     )
   }
 
-  return <WithData />
+  return (
+    <AsyncRoute data={[agentSettings]}>
+      <WithData />
+    </AsyncRoute>
+  )
 }
 
 function WithOrchestrationData() {

--- a/apps/web/src/studio/routes/StudioAgentRoute.tsx
+++ b/apps/web/src/studio/routes/StudioAgentRoute.tsx
@@ -2,7 +2,6 @@ import { selectAgentSettingsDataByAgentId } from "@/common/features/agents/agent
 import { agentSettingsActions } from "@/common/features/agents/agent-settings/agent-settings.slice"
 import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
 import { DeprecatedModelBanner } from "@/common/features/agents/components/DeprecatedModelBanner"
-import { useAbility } from "@/common/hooks/use-ability"
 import { useMount } from "@/common/hooks/use-mount"
 import { useValue } from "@/common/hooks/use-value"
 import { useAppSelector } from "@/common/store/hooks"
@@ -22,11 +21,9 @@ import { useAppSelector } from "@/common/store/hooks"
  */
 export function StudioAgentRoute({ children }: { children: React.ReactNode }) {
   const agent = useValue(selectCurrentAgentData)
-  const { abilities } = useAbility()
 
   useMount({
     actions: agentSettingsActions,
-    condition: abilities.canManageAgent({ agentId: agent.id }),
     refreshOn: [agent.id],
   })
 

--- a/apps/web/src/studio/routes/StudioAgentRoute.tsx
+++ b/apps/web/src/studio/routes/StudioAgentRoute.tsx
@@ -4,21 +4,9 @@ import { selectCurrentAgentData } from "@/common/features/agents/agents.selector
 import { DeprecatedModelBanner } from "@/common/features/agents/components/DeprecatedModelBanner"
 import { useMount } from "@/common/hooks/use-mount"
 import { useValue } from "@/common/hooks/use-value"
+import { AsyncRoute } from "@/common/routes/AsyncRoute"
 import { useAppSelector } from "@/common/store/hooks"
 
-/**
- * Loads the agent settings history for the whole Studio agent subtree, so the playground
- * can label message and header revisions without waiting for the editor's sheet to open.
- *
- * Manager-only: the history endpoint requires the manage-agent policy, and a member who
- * cannot manage the agent sees no version indicators.
- *
- * Rendering is not gated on the history — the playground shows immediately and the
- * indicators appear once the fetch lands. The deprecated-model banner reads the same
- * history and lives here so every view under the agent carries it exactly once; an
- * absent model (fetch still in flight, or a member who cannot manage the agent) renders
- * nothing.
- */
 export function StudioAgentRoute({ children }: { children: React.ReactNode }) {
   const agent = useValue(selectCurrentAgentData)
 
@@ -32,9 +20,18 @@ export function StudioAgentRoute({ children }: { children: React.ReactNode }) {
   )
 
   return (
+    <AsyncRoute data={[agentSettings]}>
+      <WithData agentId={agent.id}>{children}</WithData>
+    </AsyncRoute>
+  )
+}
+
+function WithData({ children, agentId }: { children: React.ReactNode; agentId: string }) {
+  const agentSettings = useValue(selectAgentSettingsDataByAgentId({ agentId, includeDraft: true }))
+  return (
     <>
       <div className="px-6 pt-4 empty:hidden bg-white">
-        <DeprecatedModelBanner model={agentSettings.value?.model} />
+        <DeprecatedModelBanner model={agentSettings.model} />
       </div>
       {children}
     </>

--- a/apps/web/src/studio/routes/StudioAgentSessionRoute.tsx
+++ b/apps/web/src/studio/routes/StudioAgentSessionRoute.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/common/features/agents/agent-settings/agent-settings.selectors"
 import { selectCurrentAgentData } from "@/common/features/agents/agents.selectors"
 import { DeleteAgentSessionButton } from "@/common/features/agents/components/DeleteAgentSessionButton"
-import { useAbility } from "@/common/hooks/use-ability"
 import { useGetAgentRoute } from "@/common/hooks/use-get-path"
 import { useValue } from "@/common/hooks/use-value"
 import { useAppSelector } from "@/common/store/hooks"
@@ -46,9 +45,6 @@ export function StudioAgentSessionRoute({ agentSession }: { agentSession: AgentS
 
   const handleBack = () => navigate(agentRoute)
 
-  const { abilities } = useAbility()
-  const canManageAgent = abilities.canManageAgent({ agentId: agent.id })
-
   const versions = useValue(
     selectAgentSettingsHistoryDataByAgentId({ agentId: agent.id, includeDraft: true }),
   )
@@ -66,7 +62,6 @@ export function StudioAgentSessionRoute({ agentSession }: { agentSession: AgentS
     publishedSettings
 
   const renderMessageVersion = (message: AgentSessionMessage) => {
-    if (!canManageAgent) return null
     const revision = resolveMessageRevision(message, runningRevision)
     if (revision === undefined) return null
     return (
@@ -95,7 +90,7 @@ export function StudioAgentSessionRoute({ agentSession }: { agentSession: AgentS
         description={
           <div className="flex items-center gap-2 flex-wrap">
             {date}
-            {canManageAgent && runningRevision && (
+            {runningRevision && (
               <>
                 {" "}
                 •


### PR DESCRIPTION
## Summary

The Studio playground threw for a project admin who is not an agent manager, because the settings history endpoint and the frontend both assumed the manage-agent policy.

- Relax the settings history endpoint policy from `canUpdate` to `canCreate`, and stop gating the history fetch and revision badges on `canManageAgent`; the restore button is hidden instead when the user cannot manage the agent. Draft revisions are labelled on the version badge.
- Gate the agent editor and the Studio agent route on the settings load with `AsyncRoute`, so reloading the page no longer throws "Value for memoized is not available" while the settings history fetch is pending.

Fixes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)