### PR TITLE
feat(extraction): show the settings version badge on CSV runs

### DIFF
--- a/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/agent-csv-extraction-runs.controller.ts
@@ -402,6 +402,7 @@ function toAgentCsvExtractionRunDto(run: AgentCsvExtractionRun): AgentCsvExtract
     id: run.id,
     agentId: run.agentSettings.agentId,
     agentSettingsId: run.agentSettingsId,
+    agentRevision: run.agentSettings.revision,
     csvDocumentId: run.csvDocumentId,
     columnSchema: run.columnSchema,
     status: run.status,

--- a/apps/api/src/domains/agents/csv-extraction-runs/e2e-tests/create-one.spec.ts
+++ b/apps/api/src/domains/agents/csv-extraction-runs/e2e-tests/create-one.spec.ts
@@ -146,6 +146,7 @@ describe("AgentCsvExtractionRuns - createOne", () => {
 
     expectResponse(response, 201)
     expect(response.body.data.agentSettingsId).toBe(draft.id)
+    expect(response.body.data.agentRevision).toBe(2)
   })
 
   it("pins the run to the published version when no revision is asked for", async () => {
@@ -156,6 +157,7 @@ describe("AgentCsvExtractionRuns - createOne", () => {
 
     expectResponse(response, 201)
     expect(response.body.data.agentSettingsId).toBe(context.agentSettings.id)
+    expect(response.body.data.agentRevision).toBe(context.agentSettings.revision)
   })
 
   it("returns 403 when a plain member asks for a revision", async () => {

--- a/apps/web/src/common/features/agents/components/ExtractionAgentSessionItem.tsx
+++ b/apps/web/src/common/features/agents/components/ExtractionAgentSessionItem.tsx
@@ -124,10 +124,16 @@ export function CsvExtractionSessionItem({
   agentSession,
   className,
   canDelete = true,
+  renderRevisionBadge,
 }: {
   agentSession: AgentCsvExtractionRun
   className?: string
   canDelete?: boolean
+  /**
+   * Labels the run with the agent settings version it ran with. A render prop because the badge
+   * reads the settings history from the store, which only Studio loads.
+   */
+  renderRevisionBadge?: (revision: number) => React.ReactNode
 }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -164,6 +170,7 @@ export function CsvExtractionSessionItem({
       <div className="flex gap-2">
         <GridCard.Badge variant="outline">CSV</GridCard.Badge>
         <GridCard.Badge variant={isSuccess ? "secondary" : "destructive"}>{badge}</GridCard.Badge>
+        {renderRevisionBadge?.(agentSession.agentRevision)}
       </div>
       <GridCard.Body>
         <GridCard.Title>{date}</GridCard.Title>

--- a/apps/web/src/common/features/agents/csv-extraction-runs/external/agent-csv-extraction-runs.api.ts
+++ b/apps/web/src/common/features/agents/csv-extraction-runs/external/agent-csv-extraction-runs.api.ts
@@ -112,6 +112,7 @@ function toAgentCsvExtractionRun(dto: AgentCsvExtractionRunDto): AgentCsvExtract
     id: dto.id,
     agentId: dto.agentId,
     agentSettingsId: dto.agentSettingsId,
+    agentRevision: dto.agentRevision,
     csvDocumentId: dto.csvDocumentId,
     columnSchema: dto.columnSchema,
     status: dto.status,

--- a/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
+++ b/apps/web/src/common/routes/agents/extraction/AgentCsvExtractionRunRoute.tsx
@@ -27,7 +27,14 @@ import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
 import { buildDuration, buildSince } from "@/common/utils/build-date"
 import { DocumentOpener } from "@/studio/features/documents/components/DocumentOpener"
 
-export function AgentCsvExtractionRunRoute() {
+/**
+ * `renderRevisionBadge` labels the run with the agent settings version it ran with. It is a
+ * render prop because the badge reads the settings history from the store, which only Studio
+ * loads — Desk mounts this route without it.
+ */
+type Props = { renderRevisionBadge?: (revision: number) => React.ReactNode }
+
+export function AgentCsvExtractionRunRoute({ renderRevisionBadge }: Props) {
   const runData = useAppSelector(selectCurrentCsvRunData)
   const runId = useAppSelector(selectCurrentCsvRunId)
   const { setOpen, open } = useSidebar()
@@ -46,12 +53,12 @@ export function AgentCsvExtractionRunRoute() {
   if (!runId) return <LoadingRoute />
   return (
     <AsyncRoute data={[runData]}>
-      <WithData />
+      <WithData renderRevisionBadge={renderRevisionBadge} />
     </AsyncRoute>
   )
 }
 
-function WithData() {
+function WithData({ renderRevisionBadge }: Props) {
   const navigate = useNavigate()
   const run = useValue(selectCurrentCsvRunData)
   const dispatch = useAppDispatch()
@@ -115,6 +122,7 @@ function WithData() {
                   {t("agentCsvExtractionRun:results.remaining", { count: run.summary.running })}
                 </Badge>
               )}
+              {renderRevisionBadge?.(run.agentRevision)}
             </div>
           </div>
         }

--- a/apps/web/src/studio/features/agents/components/AgentSessionList.tsx
+++ b/apps/web/src/studio/features/agents/components/AgentSessionList.tsx
@@ -193,6 +193,12 @@ function History({ agentSessions }: { agentSessions: ExtractionAgentSessions }) 
                   className={itemClassName}
                   key={item.session.id}
                   agentSession={item.session}
+                  renderRevisionBadge={(revision) => (
+                    <CurrentAgentRevisionBadge
+                      revision={revision}
+                      tooltipKey="runRevisionTooltip"
+                    />
+                  )}
                 />
               ) : (
                 <ExtractionSessionItem

--- a/apps/web/src/studio/routes/StudioRoutes.tsx
+++ b/apps/web/src/studio/routes/StudioRoutes.tsx
@@ -172,7 +172,16 @@ export const studioRoutes = {
               children: [
                 {
                   path: StudioRoutes.agentExtractionCsvRun.path,
-                  element: <AgentCsvExtractionRunRoute />,
+                  element: (
+                    <AgentCsvExtractionRunRoute
+                      renderRevisionBadge={(revision) => (
+                        <CurrentAgentRevisionBadge
+                          revision={revision}
+                          tooltipKey="runRevisionTooltip"
+                        />
+                      )}
+                    />
+                  ),
                 },
                 {
                   path: StudioRoutes.agentExtractionRun.path,

--- a/packages/api-contracts/src/agents/agent-csv-extraction-runs/agent-csv-extraction-runs.dto.ts
+++ b/packages/api-contracts/src/agents/agent-csv-extraction-runs/agent-csv-extraction-runs.dto.ts
@@ -42,6 +42,8 @@ export type AgentCsvExtractionRunDto = {
   id: string
   agentId: string
   agentSettingsId: string
+  /** Revision of the settings version the run is pinned to. */
+  agentRevision: number
   csvDocumentId: string
   columnSchema: AgentCsvExtractionRunColumnSchemaDto
   status: AgentCsvExtractionRunStatusDto


### PR DESCRIPTION
## Summary

CSV extraction runs are pinned to a settings version (since #642), but neither the history list nor the CSV results header showed which one — the `v2` badge only appeared on PDF / Image runs.

- `AgentCsvExtractionRunDto` now carries `agentRevision`, mapped from the already-loaded `agentSettings` relation.
- The CSV history card and the CSV results header render the existing `CurrentAgentRevisionBadge`, injected from the Studio routes via a `renderRevisionBadge` render prop — same pattern as PDF / Image runs, so Desk stays free of the Studio-only agent settings slice.
- `create-one` e2e asserts the pinned draft revision and the published-version default.

Gates: `biome:check` and `typecheck` clean; all 14 csv-extraction-runs suites (84 tests) pass.

Known gap, pre-existing: there is still no `AgentCsvExtractionRunRoute.stories.tsx`, which ADR 0010 requires for every registered route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)