### PR TITLE
docs(changelog): rewrite the Unreleased section in short STE entries

### DIFF
--- a/.claude/skills/end-feature/SKILL.md
+++ b/.claude/skills/end-feature/SKILL.md
@@ -26,7 +26,12 @@ Only if checked. Edit `CHANGELOG.md`, adding a line under `## [Unreleased]`:
 - New capability → `### Added`; modified behavior → `### Changed`; bug fix → `### Fixed`.
 - **Write for end users, not developers** — describe the visible outcome, not entities/services/migrations.
 - Prefix with `(beta)` if the feature is behind a flag or not yet exposed in the UI.
-- One short line (under 100 chars) per feature/fix.
+- **Write in STE (Simplified Technical English)**: short sentences (max 20 words), one fact per sentence, active voice.
+- **One sentence per entry.** Even a large feature gets one headline sentence naming the capability or the new status (e.g. "Agents now have a draft and a published version of their settings."), not the mechanics. No sub-bullets. Never chain clauses with ";", "—", or "so".
+- Name the capability, not the UI: no button placement, labels, colors, or click behavior. Keep dates and required user actions.
+- Merge entries that belong to the same change into one. Delete an entry whose information is already carried by another.
+- **Verify before writing**: check the actual commits/code for how a change works (runtime vs data migration, full vs partial scope). Scope claims exactly — write "New CSV extraction runs are personal." when existing data is unaffected.
+- Do not add an entry for a bug that was never in a released version. Check that the bug's cause was in the last release tag before listing a fix.
 
 ## 2. Create a branch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,38 +8,30 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
-- Agent settings drafts and publishing: saving any tab of the agent editor now updates a draft version instead of changing the agent directly, and a new Publish button makes the draft the version the agent runs with, with an optional name and description shown in the version history; extraction agents get the Publish button next to the History button of their inline editor; the Publish button is disabled while the editor has unsaved changes
-- Studio playground: each agent reply carries a version badge showing which settings version produced it; clicking a badge opens the version history preselected on that version
-- Studio playground: a version picker in the header chooses which settings version new messages run with, listing the draft and the published versions with their names and dates, as the version history does; a session defaults to the draft when the agent has one, so a draft can be tested without publishing it, and the picker turns amber and reads "Draft" so an unpublished version is never demoed by accident; the choice applies to new messages only, so one session can mix versions, and it is locked while a reply is streaming
-- Studio extraction agents: every run carries a version badge showing which settings version it ran with, on the run page and on each entry of the run history; clicking a badge opens the version history preselected on that version
-- Studio extraction agents: a version picker on the New Extraction screen and on the CSV column setup screen chooses which settings version a run uses, listing the draft and the published versions with their names and dates; a run defaults to the draft when the agent has one, so a draft can be tested against a document without publishing it, and the picker turns amber and reads "Draft" so an unpublished version is never run by accident
-- Back-office administrators can create an organization directly from the organizations panel; the creating administrator becomes its owner
-- Embedded (public) agent sessions now get a session title and categories from the agent's bookkeeping report, and support form filling — the collected values accumulate on the public session across turns; embed sessions also enter the conversations-by-category analytics, summed with regular conversations
-- Agents running a model that is being retired now show a banner on the agent and editor views, giving the retirement date and the model to move to; retiring models are labelled "(deprecated)" in the model pickers and stay selectable so you can compare before switching
+- Agents now have a draft and a published version of their settings.
+- Studio playground: each agent reply shows a version badge.
+- Studio playground: a version picker in the header selects the settings version for new messages.
+- Studio extraction agents: each run shows a version badge.
+- Studio extraction agents: a version picker selects the settings version for a run.
+- Back-office administrators can create an organization from the organizations panel.
+- Embedded (public) agent sessions get a session title and categories, support form filling, and count in the category analytics.
+- Agents that run a retiring model show a banner with the retirement date and the replacement model.
 
 ### Changed
-- Access control is moving to a unified roles-and-permissions model across the platform (WIP)
-- Back-office access is now controlled by the new roles-and-permissions system
-- Session bookkeeping is now guaranteed on every reply: conversation agents report their session title, categories, and cited sources through a single mandatory report, enforced by the platform when the model skips it — titles now appear even on agents without categories, and categories can no longer be invented outside the configured list (schema enforced at generation time on Gemini models)
-- Gemini models other than 3.6-flash are served from the EU endpoint again (EU data processing); only gemini-3.6-flash, unavailable in the EU region, uses the global endpoint
-- gemini-2.5-flash and gemini-2.5-pro are retired on 30 September 2026: new agents and evaluation judge runs now start on gemini-3.5-flash-lite, and existing agents on a 2.5 model should be moved over and re-tested before that date
-- The Gemini 3.x models are now available to every project, so the replacement models can be picked without an administrator enabling a flag first; gemini-3.6-flash is labelled "(non-EU)" in the model pickers because it is the one model served outside the EU region
-- Evaluations: the agent version picker in the conversation run dialog labels each version as draft, and marks the published version the agent runs with as "Current" with its date, so runs are no longer launched on an unpublished draft by accident
-- Form agents are no longer a separate agent type: any conversation agent can now turn on "Form filling" from a new Tools tab, define the form fields with the visual schema editor (drag to set the order the agent asks its questions), and the agent fills the form from the user's answers during the chat; the collected values open from a "Show form state" button on the agent's replies; the agent creator still offers a "Form" choice, which now creates a conversation agent with form filling already enabled — existing form agents, with their sessions and settings history, are migrated to conversation agents with form filling enabled
+- Access control moves to a unified roles-and-permissions model (WIP).
+- Conversation agents report the session title, categories, and cited sources in one mandatory report, enforced by the platform.
+- Gemini models use the EU endpoint again; only gemini-3.6-flash uses the global endpoint (not available in the EU region).
+- gemini-2.5-flash and gemini-2.5-pro retire on 30 September 2026.
+- The Gemini 3.x models are available to every project.
+- Form agents are now merged with conversation agents.
 
 ### Fixed
-- Model tool-call syntax (pseudo-XML fragments) no longer leaks into chat replies when the model mishandles its bookkeeping call
-- Agent prompts that referenced the old retrieval tool name are rewritten to the new one at deploy time, so hand-written instructions keep working
-- Agent editor: restoring a version from the history now updates the form fields immediately
-- Embedded agents now answer with the agent's published version: the widget on a customer site, the greeting of a new embed session, and the reviewer's session view all stopped picking up an unpublished draft as soon as an author saved a change in the agent editor; archived versions are skipped the same way
-- Evaluations: retrying an extraction run re-processes its records with the settings version the run was launched on, instead of the agent's newest version, which could be an unpublished draft
-- Fix some scanned PDF documents importing with no extracted text
-- Retrying a CSV extraction run re-runs the records with the settings version the run was started on, instead of silently switching to the latest published version
-- Studio playground no longer crashes for project admins who don't manage the agent
-- Agent editor no longer crashes when the page is reloaded while the settings are still loading
-- CSV extraction runs started in the Studio playground no longer show up in the Desk app, and vice versa
-- CSV extraction run lists are now personal: a member no longer sees runs started by colleagues
-- Studio no longer crashes when opening a project right after going back through onboarding
+- Agent editor: restoring a version updates the form fields immediately.
+- Scanned PDF documents now import with their extracted text.
+- Agent editor no longer crashes when the page reloads while the settings load.
+- CSV extraction runs from the Studio playground no longer show in the Desk app, and vice versa.
+- New CSV extraction runs are personal.
+- Studio no longer crashes when a project opens right after onboarding restarts.
 
 ### Security
 ## [26.07.3] - 2026-07-24


### PR DESCRIPTION
Closes #655

## What

- Rewrites the `## [Unreleased]` section of `CHANGELOG.md` in STE: one sentence per entry, capability over UI mechanics. The section drops from ~1100 to ~250 words.
- Merges same-change entries (RBAC, form agents, duplicate retry lines) and removes entries with no user value.
- Removes 5 "Fixed" entries for bugs that were never in a released version (causes verified against the v26.07.3 tag: bookkeeping tool leak, retrieval tool rename, draft-serving bugs, playground badges crash).
- Scopes partially-applying fixes exactly ("New CSV extraction runs are personal.").
- Updates the `end-feature` skill so future changelog entries follow the same rules, including "no entry for a bug that was never released".

## Review notes

Every rewritten entry was validated one by one. Two factual corrections came out of the review: the retrieval tool rename is a data migration (not a deploy-time rewrite), and the CSV run visibility bugs predate the RBAC work (both surfaces and the unfiltered getAll existed in v26.07.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)