### PR TITLE
feat(eval-extraction): pick the agent settings version for a run, run history table, and run comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Studio extraction agents: a version picker selects the settings version for a run.
 - Extraction evaluations: a version picker selects the agent settings version for a run.
 - Extraction evaluations: each run shows the settings version it ran with.
+- Extraction evaluations: the run history is a table with one row per run.
+- Extraction evaluations: selected runs can be compared side by side.
 - Back-office administrators can create an organization from the organizations panel.
 - Embedded (public) agent sessions get a session title and categories, support form filling, and count in the category analytics.
 - Agents that run a retiring model show a banner with the retirement date and the replacement model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Studio playground: a version picker in the header selects the settings version for new messages.
 - Studio extraction agents: each run shows a version badge.
 - Studio extraction agents: a version picker selects the settings version for a run.
+- Extraction evaluations: a version picker selects the agent settings version for a run.
+- Extraction evaluations: each run shows the settings version it ran with.
 - Back-office administrators can create an organization from the organizations panel.
 - Embedded (public) agent sessions get a session title and categories, support form filling, and count in the category analytics.
 - Agents that run a retiring model show a banner with the retirement date and the replacement model.

--- a/apps/api/src/common/context/resolvers/evaluation-extraction-run-context.resolver.ts
+++ b/apps/api/src/common/context/resolvers/evaluation-extraction-run-context.resolver.ts
@@ -34,6 +34,8 @@ export class EvaluationExtractionRunContextResolver implements ContextResolver {
           organizationId: requestWithProject.organizationId,
           projectId: requestWithProject.project.id,
         },
+        // Controllers expose the pinned agent-settings revision on every run response.
+        relations: { agentSettings: true },
       })) ?? undefined
     if (!evaluationExtractionRun) throw new NotFoundException()
 

--- a/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/auth.spec.ts
@@ -96,6 +96,7 @@ describe("EvaluationExtractionRuns - Auth", () => {
       payload: {
         evaluationExtractionDatasetId: randomUUID(),
         agentId: randomUUID(),
+        agentSettingsRevision: null,
         keyMapping: [],
       },
     }

--- a/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/create-one.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/create-one.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@/common/test/test-transaction-manager"
 import { removeNullish } from "@/common/utils/remove-nullish"
 import { ActivitiesModule } from "@/domains/activities/activities.module"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
 import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
 import { setupUserGuardForTesting } from "../../../../../../test/e2e.helpers"
 import { expectResponse, type Requester, testRequester } from "../../../../../../test/request"
@@ -57,13 +58,16 @@ describe("EvaluationExtractionRuns - createOne", () => {
   })
 
   const createContext = async (agentType?: "conversation" | "extraction" | undefined) => {
-    const { user, organization, project, agent } = await createOrganizationWithAgent(repositories, {
-      agent: { type: agentType ?? "extraction" },
-      agentSettings: {
-        outputJsonSchema: { type: "object", properties: { age: { type: "string" } } },
-        model: AgentModel._Mock,
+    const { user, organization, project, agent, agentSettings } = await createOrganizationWithAgent(
+      repositories,
+      {
+        agent: { type: agentType ?? "extraction" },
+        agentSettings: {
+          outputJsonSchema: { type: "object", properties: { age: { type: "string" } } },
+          model: AgentModel._Mock,
+        },
       },
-    })
+    )
     organizationId = organization.id
     projectId = project.id
     auth0Id = user.auth0Id
@@ -73,7 +77,7 @@ describe("EvaluationExtractionRuns - createOne", () => {
       .build({ schemaMapping: {} })
     await setup.getRepository(EvaluationExtractionDataset).save(dataset)
 
-    return { organization, project, dataset, agent }
+    return { organization, project, dataset, agent, agentSettings }
   }
 
   const subject = async (payload?: typeof EvaluationExtractionRunsRoutes.createOne.request) =>
@@ -85,12 +89,13 @@ describe("EvaluationExtractionRuns - createOne", () => {
     })
 
   it("should create an evaluation run with valid data", async () => {
-    const { dataset, agent } = await createContext()
+    const { dataset, agent, agentSettings } = await createContext()
 
     const res = await subject({
       payload: {
         evaluationExtractionDatasetId: dataset.id,
         agentId: agent.id,
+        agentSettingsRevision: null,
         keyMapping: [{ agentOutputKey: "age", datasetColumnId: "col1", mode: "scored" }],
       },
     })
@@ -99,11 +104,114 @@ describe("EvaluationExtractionRuns - createOne", () => {
     expect(res.body.data.status).toBe("pending")
     expect(res.body.data.evaluationExtractionDatasetId).toBe(dataset.id)
     expect(res.body.data.agentId).toBe(agent.id)
+    expect(res.body.data.agentSettingsId).toBe(agentSettings.id)
+    expect(res.body.data.agentRevision).toBe(agentSettings.revision)
     expect(res.body.data.summary).toBeNull()
 
     const runs = await evaluationExtractionRunRepository.find()
     expect(runs).toHaveLength(1)
     await expectActivityCreated("evaluationExtractionRun.create")
+  })
+
+  it("should pin the latest published agent settings revision on the run when agentSettingsRevision is null", async () => {
+    const { organization, project, dataset, agent } = await createContext()
+    const newerSettings = agentSettingsFactory
+      .transient({ organization, project, agent })
+      .build({ revision: 2, instructions: "Newer helpful assistant instructions" })
+    await repositories.agentSettingsRepository.save(newerSettings)
+
+    const res = await subject({
+      payload: {
+        evaluationExtractionDatasetId: dataset.id,
+        agentId: agent.id,
+        agentSettingsRevision: null,
+        keyMapping: [{ agentOutputKey: "age", datasetColumnId: "col1", mode: "scored" }],
+      },
+    })
+
+    expectResponse(res, 201)
+    expect(res.body.data.agentRevision).toBe(2)
+    const runs = await evaluationExtractionRunRepository.find()
+    expect(runs[0]!.agentSettingsId).toBe(newerSettings.id)
+  })
+
+  it("should pin the requested agent settings revision on the run", async () => {
+    const { organization, project, dataset, agent, agentSettings } = await createContext()
+    const newerSettings = agentSettingsFactory
+      .transient({ organization, project, agent })
+      .build({ revision: 2, instructions: "Newer helpful assistant instructions" })
+    await repositories.agentSettingsRepository.save(newerSettings)
+
+    const res = await subject({
+      payload: {
+        evaluationExtractionDatasetId: dataset.id,
+        agentId: agent.id,
+        agentSettingsRevision: 1,
+        keyMapping: [{ agentOutputKey: "age", datasetColumnId: "col1", mode: "scored" }],
+      },
+    })
+
+    expectResponse(res, 201)
+    expect(res.body.data.agentRevision).toBe(1)
+    expect(res.body.data.agentSettingsId).toBe(agentSettings.id)
+    const runs = await evaluationExtractionRunRepository.find()
+    expect(runs[0]!.agentSettingsId).toBe(agentSettings.id)
+  })
+
+  it("should reject if the requested agent settings revision does not exist", async () => {
+    const { dataset, agent } = await createContext()
+
+    const res = await subject({
+      payload: {
+        evaluationExtractionDatasetId: dataset.id,
+        agentId: agent.id,
+        agentSettingsRevision: 999,
+        keyMapping: [],
+      },
+    })
+
+    expectResponse(res, 404)
+    const runs = await evaluationExtractionRunRepository.find()
+    expect(runs).toHaveLength(0)
+  })
+
+  it("should reject if the requested agent settings revision is archived", async () => {
+    const { organization, project, dataset, agent } = await createContext()
+    const archivedSettings = agentSettingsFactory
+      .transient({ organization, project, agent })
+      .build({ revision: 2, isArchived: true })
+    await repositories.agentSettingsRepository.save(archivedSettings)
+
+    const res = await subject({
+      payload: {
+        evaluationExtractionDatasetId: dataset.id,
+        agentId: agent.id,
+        agentSettingsRevision: 2,
+        keyMapping: [],
+      },
+    })
+
+    expectResponse(res, 422)
+    const runs = await evaluationExtractionRunRepository.find()
+    expect(runs).toHaveLength(0)
+  })
+
+  it("should reject if the requested agent settings revision is out of range", async () => {
+    const { dataset, agent } = await createContext()
+
+    const res = await subject({
+      payload: {
+        evaluationExtractionDatasetId: dataset.id,
+        agentId: agent.id,
+        // One past the Postgres int4 upper bound.
+        agentSettingsRevision: 2147483648,
+        keyMapping: [],
+      },
+    })
+
+    expectResponse(res, 422)
+    const runs = await evaluationExtractionRunRepository.find()
+    expect(runs).toHaveLength(0)
   })
 
   it("should reject if dataset does not exist", async () => {
@@ -113,6 +221,7 @@ describe("EvaluationExtractionRuns - createOne", () => {
       payload: {
         evaluationExtractionDatasetId: "00000000-0000-0000-0000-000000000000",
         agentId: agent.id,
+        agentSettingsRevision: null,
         keyMapping: [],
       },
     })
@@ -127,6 +236,7 @@ describe("EvaluationExtractionRuns - createOne", () => {
       payload: {
         evaluationExtractionDatasetId: dataset.id,
         agentId: "00000000-0000-0000-0000-000000000000",
+        agentSettingsRevision: null,
         keyMapping: [],
       },
     })
@@ -141,6 +251,7 @@ describe("EvaluationExtractionRuns - createOne", () => {
       payload: {
         evaluationExtractionDatasetId: dataset.id,
         agentId: agent.id,
+        agentSettingsRevision: null,
         keyMapping: [],
       },
     })

--- a/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/get-all.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/get-all.spec.ts
@@ -116,5 +116,7 @@ describe("EvaluationExtractionRuns - getAll", () => {
 
     expectResponse(res, 200)
     expect(res.body.data).toHaveLength(2)
+    expect(res.body.data[0]!.agentSettingsId).toBe(agentSettings.id)
+    expect(res.body.data[0]!.agentRevision).toBe(agentSettings.revision)
   })
 })

--- a/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/get-one.spec.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/e2e-tests/get-one.spec.ts
@@ -83,7 +83,7 @@ describe("EvaluationExtractionRuns - getOne", () => {
     await setup.getRepository(EvaluationExtractionRun).save(run)
     evaluationExtractionRunId = run.id
 
-    return { organization, project, dataset, agent, run }
+    return { organization, project, dataset, agent, agentSettings, run }
   }
 
   const subject = async () =>
@@ -94,7 +94,7 @@ describe("EvaluationExtractionRuns - getOne", () => {
     })
 
   it("should return the evaluation run", async () => {
-    const { run, dataset, agent } = await createContext()
+    const { run, dataset, agent, agentSettings } = await createContext()
 
     const res = await subject()
 
@@ -102,6 +102,8 @@ describe("EvaluationExtractionRuns - getOne", () => {
     expect(res.body.data.id).toBe(run.id)
     expect(res.body.data.evaluationExtractionDatasetId).toBe(dataset.id)
     expect(res.body.data.agentId).toBe(agent.id)
+    expect(res.body.data.agentSettingsId).toBe(agentSettings.id)
+    expect(res.body.data.agentRevision).toBe(agentSettings.revision)
     expect(res.body.data.status).toBe("pending")
   })
 

--- a/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.controller.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.controller.ts
@@ -10,10 +10,12 @@ import {
   Delete,
   Get,
   Logger,
+  NotFoundException,
   Post,
   Query,
   Req,
   Sse,
+  UnprocessableEntityException,
   UseGuards,
 } from "@nestjs/common"
 import type { Observable } from "rxjs"
@@ -25,6 +27,7 @@ import type {
 import { getRequiredConnectScope } from "@/common/context/request-context.helpers"
 import { AddContext, RequireContext } from "@/common/context/require-context.decorator"
 import { ResourceContextGuard } from "@/common/context/resource-context.guard"
+import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
 import { CheckPolicy } from "@/common/policies/check-policy.decorator"
 import { TrackActivity } from "@/domains/activities/track-activity.decorator"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
@@ -65,12 +68,14 @@ export class EvaluationExtractionRunsController {
     @Req() request: EndpointRequestWithProject,
     @Body() { payload }: typeof EvaluationExtractionRunsRoutes.createOne.request,
   ): Promise<typeof EvaluationExtractionRunsRoutes.createOne.response> {
-    const agentSettings = await this.agentSettingsService.getLast({
-      connectScope: getRequiredConnectScope(request),
+    const connectScope = getRequiredConnectScope(request)
+    const agentSettings = await this.resolveAgentSettings({
+      connectScope,
       agentId: payload.agentId,
+      agentSettingsRevision: payload.agentSettingsRevision,
     })
     const run = await this.evaluationExtractionRunsService.createRun({
-      connectScope: getRequiredConnectScope(request),
+      connectScope,
       fields: {
         evaluationExtractionDatasetId: payload.evaluationExtractionDatasetId,
         agentId: payload.agentId,
@@ -78,7 +83,50 @@ export class EvaluationExtractionRunsController {
         keyMapping: payload.keyMapping,
       },
     })
+    // The freshly created run has no relations loaded; attach the settings we
+    // just resolved so the response exposes the pinned revision.
+    run.agentSettings = agentSettings
     return { data: toEvaluationExtractionRunDto(run) }
+  }
+
+  private async resolveAgentSettings({
+    connectScope,
+    agentId,
+    agentSettingsRevision,
+  }: {
+    connectScope: RequiredConnectScope
+    agentId: string
+    agentSettingsRevision: number | null | undefined
+  }) {
+    if (typeof agentSettingsRevision !== "number") {
+      return this.agentSettingsService.getLast({ connectScope, agentId })
+    }
+    if (
+      !(
+        Number.isInteger(agentSettingsRevision) &&
+        agentSettingsRevision > 0 &&
+        // Postgres int4 upper bound: a larger value would error at query time.
+        agentSettingsRevision <= 2147483647
+      )
+    ) {
+      throw new UnprocessableEntityException("Settings version must be a positive integer")
+    }
+    const agentSettings = await this.agentSettingsService.get({
+      connectScope,
+      agentId,
+      revision: agentSettingsRevision,
+    })
+    if (!agentSettings) {
+      throw new NotFoundException(
+        `Revision ${agentSettingsRevision} not found for agent with id ${agentId}`,
+      )
+    }
+    if (agentSettings.isArchived) {
+      throw new UnprocessableEntityException(
+        `Revision ${agentSettingsRevision} is archived and cannot be run`,
+      )
+    }
+    return agentSettings
   }
 
   @Post(EvaluationExtractionRunsRoutes.executeOne.path)
@@ -257,6 +305,8 @@ function toEvaluationExtractionRunDto(run: EvaluationExtractionRun): EvaluationE
     id: run.id,
     evaluationExtractionDatasetId: run.evaluationExtractionDatasetId,
     agentId: run.agentId,
+    agentSettingsId: run.agentSettingsId,
+    agentRevision: run.agentSettings.revision,
     keyMapping: run.keyMapping,
     status: run.status,
     summary: run.summary,

--- a/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.service.ts
+++ b/apps/api/src/domains/evaluations/extraction/runs/evaluation-extraction-runs.service.ts
@@ -118,7 +118,10 @@ export class EvaluationExtractionRunsService {
     connectScope: RequiredConnectScope
     runId: string
   }): Promise<EvaluationExtractionRun | null> {
-    return this.runConnectRepository.getOneById(connectScope, runId)
+    // Run responses expose the pinned agent-settings revision.
+    return this.runConnectRepository.getOneById(connectScope, runId, {
+      relations: ["agentSettings"],
+    })
   }
 
   async markRunCancelled({
@@ -154,6 +157,8 @@ export class EvaluationExtractionRunsService {
     connectScope: RequiredConnectScope
   }): Promise<EvaluationExtractionRun[]> {
     const runs = await this.runConnectRepository.find(connectScope, {
+      // Run responses expose the pinned agent-settings revision.
+      relations: { agentSettings: true },
       order: { createdAt: "DESC" },
     })
     return runs

--- a/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.factory.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.factory.ts
@@ -1,0 +1,77 @@
+import { faker } from "@faker-js/faker"
+import { Factory } from "fishery"
+import type { Project } from "@/common/features/projects/projects.models"
+import type {
+  EvaluationExtractionDataset,
+  EvaluationExtractionDatasetSchemaColumn,
+} from "./evaluation-extraction-datasets.models"
+
+export const evaluationExtractionDatasetSchemaColumnFactory =
+  Factory.define<EvaluationExtractionDatasetSchemaColumn>(({ params, sequence }) => {
+    const originalName = params.originalName ?? `column_${sequence}`
+    return {
+      id: params.id ?? faker.string.uuid(),
+      finalName: params.finalName ?? originalName,
+      originalName,
+      index: params.index ?? sequence,
+      role: params.role ?? "target",
+    }
+  })
+
+function buildDefaultSchemaMapping(): Record<string, EvaluationExtractionDatasetSchemaColumn> {
+  const columns = [
+    evaluationExtractionDatasetSchemaColumnFactory.build({
+      finalName: "title",
+      originalName: "title",
+      index: 0,
+      role: "target",
+    }),
+    evaluationExtractionDatasetSchemaColumnFactory.build({
+      finalName: "summary",
+      originalName: "summary",
+      index: 1,
+      role: "target",
+    }),
+    evaluationExtractionDatasetSchemaColumnFactory.build({
+      finalName: "source",
+      originalName: "source",
+      index: 2,
+      role: "input",
+    }),
+  ]
+  return Object.fromEntries(columns.map((column) => [column.id, column]))
+}
+
+type EvaluationExtractionDatasetTransientParams = {
+  project: Project
+}
+
+class EvaluationExtractionDatasetFactory extends Factory<
+  EvaluationExtractionDataset,
+  EvaluationExtractionDatasetTransientParams
+> {}
+
+export const evaluationExtractionDatasetFactory = EvaluationExtractionDatasetFactory.define(
+  ({ params, transientParams }) => {
+    const { project } = transientParams
+    if (!project) {
+      throw new Error(
+        "Project must be provided in transient params to build an EvaluationExtractionDataset",
+      )
+    }
+
+    return {
+      id: params.id ?? faker.string.uuid(),
+      name: params.name ?? faker.commerce.productName(),
+      projectId: project.id,
+      documentIds: (params.documentIds as string[] | undefined) ?? [],
+      recordCount: params.recordCount ?? faker.number.int({ min: 1, max: 50 }),
+      schemaMapping:
+        (params.schemaMapping as
+          | Record<string, EvaluationExtractionDatasetSchemaColumn>
+          | undefined) ?? buildDefaultSchemaMapping(),
+      createdAt: params.createdAt ?? faker.date.past().getTime(),
+      updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
+    }
+  },
+)

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/AgentMetadataDialog.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/AgentMetadataDialog.tsx
@@ -10,22 +10,32 @@ import {
 import { ExternalLinkIcon, InfoIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { selectAgentSettingsDataByAgentId } from "@/common/features/agents/agent-settings/agent-settings.selectors"
+import { findVersion } from "@/common/features/agents/agent-settings/agent-settings.functions"
+import {
+  selectAgentSettingsDataByAgentId,
+  selectAgentSettingsHistoryDataByAgentId,
+} from "@/common/features/agents/agent-settings/agent-settings.selectors"
 import { selectAgentsData } from "@/common/features/agents/agents.selectors"
 import { selectCurrentOrganizationId } from "@/common/features/organizations/organizations.selectors"
 import { selectCurrentProjectId } from "@/common/features/projects/projects.selectors"
 import { useAbility } from "@/common/hooks/use-ability"
 import { useCurrentId, useValue } from "@/common/hooks/use-value"
+import { ADS } from "@/common/store/async-data-status"
+import { useAppSelector } from "@/common/store/hooks"
 import { StudioRoutes } from "@/studio/routes/helpers"
 
 export function AgentMetadataDialog({
   agentId,
+  revision,
   buttonProps = {
     variant: "outline",
     size: "sm",
   },
 }: {
   agentId: string
+  // Settings revision pinned on the run; when set, the dialog shows that
+  // version's settings instead of the agent's current ones.
+  revision?: number
   buttonProps?: React.ComponentProps<typeof Button>
 }) {
   const { t } = useTranslation()
@@ -38,7 +48,19 @@ export function AgentMetadataDialog({
     return agentsData.find((entry) => entry.id === agentId) ?? null
   }, [agentsData, agentId])
 
-  const agentSettings = useValue(selectAgentSettingsDataByAgentId({ agentId: agent?.id ?? "" }))
+  const currentAgentSettings = useValue(
+    selectAgentSettingsDataByAgentId({ agentId: agent?.id ?? "" }),
+  )
+  const historyData = useAppSelector(
+    selectAgentSettingsHistoryDataByAgentId({ agentId: agent?.id ?? "", includeDraft: true }),
+  )
+  // Falls back to the current settings when the pinned version is not in the
+  // history anymore (e.g. it was archived).
+  const pinnedAgentSettings =
+    revision !== undefined && ADS.isFulfilled(historyData)
+      ? findVersion(historyData.value, revision)
+      : undefined
+  const agentSettings = pinnedAgentSettings ?? currentAgentSettings
 
   const studioUrl = StudioRoutes.agent.build({ organizationId, projectId, agentId })
   const canAccessStudio = abilities.canAccessStudio({ projectId })
@@ -64,6 +86,12 @@ export function AgentMetadataDialog({
           <div className="flex flex-col gap-4">
             <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3 rounded-lg border p-4">
               <MetadataField label={t("evaluationExtractionRun:agent")} value={agent.name} />
+              {revision !== undefined && (
+                <MetadataField
+                  label={t("evaluationExtractionRun:version.label")}
+                  value={t("evaluationExtractionRun:version.revision", { revision })}
+                />
+              )}
               <MetadataField
                 label={t("evaluationExtractionRun:agentMetadata.model")}
                 value={agentSettings.model}

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunHistory.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunHistory.tsx
@@ -83,6 +83,9 @@ function RunItem({
       >
         <div className="flex items-center gap-3">
           <RunStatusBadge status={run.status} />
+          <span className="text-sm text-muted-foreground">
+            {t("evaluationExtractionRun:version.revision", { revision: run.agentRevision })}
+          </span>
           <span className="text-sm text-muted-foreground">{buildSince(run.updatedAt)}</span>
         </div>
         <div className="flex items-center gap-3">
@@ -109,6 +112,7 @@ function RunItem({
           <AgentMetadataDialog
             buttonProps={{ variant: "secondary", size: "sm" }}
             agentId={run.agentId}
+            revision={run.agentRevision}
           />
           <DeleteEvaluationExtractionRunButton
             buttonProps={{ variant: "secondary", size: "icon-sm" }}

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunHistory.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunHistory.tsx
@@ -1,16 +1,22 @@
 import { Button } from "@caseai-connect/ui/shad/button"
 import {
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@caseai-connect/ui/shad/card"
-import { cn } from "@caseai-connect/ui/utils"
-import { ArrowRightIcon } from "lucide-react"
+import { Checkbox } from "@caseai-connect/ui/shad/checkbox"
+import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table"
+import { ArrowRightIcon, GitCompareIcon } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
+import { selectAgentsData } from "@/common/features/agents/agents.selectors"
+import { useValue } from "@/common/hooks/use-value"
 import { buildSince } from "@/common/utils/build-date"
+import { shortRunId } from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.helpers"
 import type { EvaluationExtractionRun } from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.models"
 import { useEvaluationExtractionRunPath } from "@/eval/hooks/use-evaluation-extraction-run-path"
 import { DocumentOpener } from "@/studio/features/documents/components/DocumentOpener"
@@ -18,13 +24,175 @@ import { AgentMetadataDialog } from "./AgentMetadataDialog"
 import { DeleteEvaluationExtractionRunButton } from "./DeleteEvaluationExtractionRunButton"
 import { RunStatusBadge } from "./RunStatusBadge"
 
+function buildMatchRate(run: EvaluationExtractionRun): number | null {
+  if (!run.summary || run.summary.total === 0) return null
+  return Math.round((run.summary.perfectMatches / run.summary.total) * 100)
+}
+
 export function EvaluationExtractionRunHistory({ runs }: { runs: EvaluationExtractionRun[] }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { buildRunPath } = useEvaluationExtractionRunPath()
+  const { buildRunPath, buildComparePath } = useEvaluationExtractionRunPath()
+  const agents = useValue(selectAgentsData)
 
-  const handleOpen = (runId: string) => {
-    navigate(buildRunPath({ runId }))
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
+
+  const agentNameById = useMemo(
+    () => new Map(agents.map((agent) => [agent.id, agent.name])),
+    [agents],
+  )
+
+  const handleOpen = useCallback(
+    (runId: string) => {
+      navigate(buildRunPath({ runId }))
+    },
+    [navigate, buildRunPath],
+  )
+
+  const columns = useMemo<ColumnDef<EvaluationExtractionRun>[]>(
+    () => [
+      {
+        id: "select",
+        header: ({ table }) => (
+          <Checkbox
+            checked={
+              table.getIsAllRowsSelected()
+                ? true
+                : table.getIsSomeRowsSelected()
+                  ? "indeterminate"
+                  : false
+            }
+            onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
+            aria-label={t("actions:selectAll")}
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label={t("actions:select")}
+          />
+        ),
+        size: 40,
+      },
+      {
+        id: "id",
+        header: () => t("evaluationExtractionRun:history.columns.id"),
+        cell: ({ row }) => (
+          <span className="text-sm font-mono text-muted-foreground whitespace-nowrap">
+            {shortRunId(row.original.id)}
+          </span>
+        ),
+        size: 120,
+      },
+      {
+        id: "status",
+        header: () => t("evaluationExtractionRun:history.columns.status"),
+        cell: ({ row }) => <RunStatusBadge status={row.original.status} />,
+        size: 120,
+      },
+      {
+        id: "date",
+        header: () => t("evaluationExtractionRun:history.columns.date"),
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {buildSince(row.original.updatedAt)}
+          </span>
+        ),
+        size: 140,
+      },
+      {
+        id: "agent",
+        header: () => t("evaluationExtractionRun:history.columns.agent"),
+        cell: ({ row }) => {
+          const agentName = agentNameById.get(row.original.agentId)
+          if (!agentName) return <span className="text-muted-foreground">-</span>
+          return <span className="text-sm">{agentName}</span>
+        },
+        size: 180,
+      },
+      {
+        id: "version",
+        header: () => t("evaluationExtractionRun:history.columns.version"),
+        cell: ({ row }) => (
+          <span className="text-sm whitespace-nowrap">
+            {t("evaluationExtractionRun:version.revision", {
+              revision: row.original.agentRevision,
+            })}
+          </span>
+        ),
+        size: 90,
+      },
+      {
+        id: "matchRate",
+        header: () => t("evaluationExtractionRun:history.columns.matchRate"),
+        cell: ({ row }) => {
+          const matchRate = buildMatchRate(row.original)
+          if (matchRate === null) return <span className="text-muted-foreground">-</span>
+          return (
+            <span className="text-sm font-medium whitespace-nowrap">
+              {t("evaluationExtractionRun:history.matchRate", { matchRate })}
+            </span>
+          )
+        },
+        size: 120,
+      },
+      {
+        id: "records",
+        header: () => t("evaluationExtractionRun:history.columns.records"),
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {row.original.summary?.total ?? 0}
+          </span>
+        ),
+        size: 100,
+      },
+      {
+        id: "actions",
+        header: () => <></>,
+        cell: ({ row }) => (
+          <div className="flex items-center justify-end gap-2">
+            {row.original.csvExportDocumentId && (
+              <DocumentOpener
+                buttonProps={{ size: "sm" }}
+                documentId={row.original.csvExportDocumentId}
+              />
+            )}
+            <AgentMetadataDialog
+              buttonProps={{ variant: "secondary", size: "sm" }}
+              agentId={row.original.agentId}
+              revision={row.original.agentRevision}
+            />
+            <DeleteEvaluationExtractionRunButton
+              buttonProps={{ variant: "secondary", size: "icon-sm" }}
+              runId={row.original.id}
+            />
+            <Button onClick={() => handleOpen(row.original.id)} size="icon-sm">
+              <ArrowRightIcon className="size-4" />
+            </Button>
+          </div>
+        ),
+        size: 200,
+      },
+    ],
+    [t, agentNameById, handleOpen],
+  )
+
+  const table = useReactTable({
+    data: runs,
+    columns,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    enableRowSelection: true,
+    getRowId: (run) => run.id,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  const selectedRunIds = table.getSelectedRowModel().rows.map((row) => row.original.id)
+  const canCompare = selectedRunIds.length >= 2
+
+  const handleCompare = () => {
+    navigate(buildComparePath({ runIds: selectedRunIds }))
   }
 
   if (runs.length === 0) return null
@@ -36,94 +204,52 @@ export function EvaluationExtractionRunHistory({ runs }: { runs: EvaluationExtra
         <CardDescription>
           {t("evaluationExtractionRun:history.description", { count: runs.length })}
         </CardDescription>
+        <CardAction>
+          <Button variant="outline" size="sm" onClick={handleCompare} disabled={!canCompare}>
+            <GitCompareIcon className="size-4" />
+            {selectedRunIds.length > 0
+              ? t("evaluationExtractionRun:history.compareSelected", {
+                  count: selectedRunIds.length,
+                })
+              : t("evaluationExtractionRun:history.compare")}
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent>
-        <div className="rounded-lg border">
-          {runs.map((run, index) => (
-            <RunItem
-              key={run.id}
-              run={run}
-              isFirst={index === 0}
-              onOpen={() => handleOpen(run.id)}
-            />
-          ))}
+        <div className="rounded-lg border overflow-x-auto">
+          <table className="w-full caption-bottom text-sm">
+            <thead className="bg-muted/50 [&_tr]:border-b">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id} className="border-b transition-colors">
+                  {headerGroup.headers.map((header) => (
+                    <th
+                      key={header.id}
+                      className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium whitespace-nowrap"
+                      style={{ width: header.getSize() }}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className={`border-b transition-colors hover:bg-muted/50 ${row.index % 2 !== 0 ? "bg-muted/30" : ""}`}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="p-3 align-middle">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </CardContent>
     </Card>
-  )
-}
-
-function RunItem({
-  run,
-  isFirst,
-  onOpen,
-}: {
-  run: EvaluationExtractionRun
-  isFirst: boolean
-  onOpen: () => void
-}) {
-  const { t } = useTranslation()
-
-  const matchRate =
-    run.summary && run.summary.total > 0
-      ? Math.round((run.summary.perfectMatches / run.summary.total) * 100)
-      : null
-
-  return (
-    <div
-      className={cn(
-        "flex w-full items-center justify-between px-4 py-3 gap-6 hover:bg-muted/50 transition-colors",
-        { "border-t": !isFirst },
-      )}
-    >
-      <button
-        type="button"
-        className="flex flex-1 items-center gap-3 text-left flex-wrap"
-        onClick={onOpen}
-      >
-        <div className="flex items-center gap-3">
-          <RunStatusBadge status={run.status} />
-          <span className="text-sm text-muted-foreground">
-            {t("evaluationExtractionRun:version.revision", { revision: run.agentRevision })}
-          </span>
-          <span className="text-sm text-muted-foreground">{buildSince(run.updatedAt)}</span>
-        </div>
-        <div className="flex items-center gap-3">
-          {matchRate !== null && (
-            <span className="text-sm font-medium">
-              {t("evaluationExtractionRun:history.matchRate", { matchRate })}
-            </span>
-          )}
-          {run.summary && (
-            <span className="text-xs text-muted-foreground">
-              {t("evaluationExtractionRun:history.recordCount", {
-                count: run.summary.total,
-              })}
-            </span>
-          )}
-        </div>
-      </button>
-
-      <div className="flex items-center gap-6">
-        <div className="flex items-center gap-2 flex-wrap">
-          {run.csvExportDocumentId && (
-            <DocumentOpener buttonProps={{ size: "sm" }} documentId={run.csvExportDocumentId} />
-          )}
-          <AgentMetadataDialog
-            buttonProps={{ variant: "secondary", size: "sm" }}
-            agentId={run.agentId}
-            revision={run.agentRevision}
-          />
-          <DeleteEvaluationExtractionRunButton
-            buttonProps={{ variant: "secondary", size: "icon-sm" }}
-            runId={run.id}
-          />
-        </div>
-
-        <Button onClick={onOpen} size="icon-sm">
-          <ArrowRightIcon className="size-4" />
-        </Button>
-      </div>
-    </div>
   )
 }

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunsComparison.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/EvaluationExtractionRunsComparison.tsx
@@ -1,0 +1,395 @@
+import { Badge } from "@caseai-connect/ui/shad/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@caseai-connect/ui/shad/card"
+import { cn } from "@caseai-connect/ui/utils"
+import { type ReactNode, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import { TruncatedCell } from "@/common/components/shared/RecordTableParts"
+import { selectAgentsData } from "@/common/features/agents/agents.selectors"
+import { useValue } from "@/common/hooks/use-value"
+import { buildSince } from "@/common/utils/build-date"
+import { shortRunId } from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.helpers"
+import type {
+  EvaluationExtractionRun,
+  EvaluationExtractionRunRecord,
+  EvaluationExtractionRunRecordStatus,
+} from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.models"
+import { useEvaluationExtractionRunPath } from "@/eval/hooks/use-evaluation-extraction-run-path"
+import { RunStatusBadge } from "./RunStatusBadge"
+
+type Props = {
+  runs: EvaluationExtractionRun[]
+  recordsByRunId: Record<string, EvaluationExtractionRunRecord[]>
+}
+
+// Opens the run in a new tab so the comparison stays put behind it.
+function RunIdLink({ runId, className }: { runId: string; className?: string }) {
+  const { buildRunPath } = useEvaluationExtractionRunPath()
+  return (
+    <Link
+      to={buildRunPath({ runId })}
+      target="_blank"
+      rel="noreferrer"
+      className={cn("font-mono text-primary hover:underline", className)}
+    >
+      {shortRunId(runId)}
+    </Link>
+  )
+}
+
+function RecordStatusBadge({ status }: { status: EvaluationExtractionRunRecordStatus }) {
+  const { t } = useTranslation()
+  const variant =
+    status === "match"
+      ? "success"
+      : status === "mismatch"
+        ? "destructive"
+        : status === "cancelled"
+          ? "outline"
+          : "secondary"
+  return <Badge variant={variant}>{t(`evaluationExtractionRun:results.${status}`)}</Badge>
+}
+
+function buildMatchRate(run: EvaluationExtractionRun): number | null {
+  if (!run.summary || run.summary.total === 0) return null
+  return Math.round((run.summary.perfectMatches / run.summary.total) * 100)
+}
+
+export function EvaluationExtractionRunsComparison({ runs, recordsByRunId }: Props) {
+  const agents = useValue(selectAgentsData)
+
+  const agentNameById = useMemo(
+    () => new Map(agents.map((agent) => [agent.id, agent.name])),
+    [agents],
+  )
+
+  // Best match rate across runs; used to highlight the winning column.
+  const bestMatchRate = useMemo(() => {
+    const matchRates = runs
+      .map((run) => buildMatchRate(run))
+      .filter((matchRate): matchRate is number => matchRate !== null)
+    return matchRates.length > 0 ? Math.max(...matchRates) : null
+  }, [runs])
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SummaryComparison runs={runs} agentNameById={agentNameById} bestMatchRate={bestMatchRate} />
+      <RecordsComparison runs={runs} recordsByRunId={recordsByRunId} />
+    </div>
+  )
+}
+
+function RunColumnHeader({
+  run,
+  agentName,
+}: {
+  run: EvaluationExtractionRun
+  agentName: string | undefined
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="font-medium">{agentName ?? "-"}</span>
+      <RunIdLink runId={run.id} className="text-xs" />
+
+      <span className="text-xs text-muted-foreground whitespace-nowrap">
+        {t("evaluationExtractionRun:version.revision", { revision: run.agentRevision })}
+        {" · "}
+        {buildSince(run.updatedAt)}
+      </span>
+    </div>
+  )
+}
+
+function SummaryComparison({
+  runs,
+  agentNameById,
+  bestMatchRate,
+}: {
+  runs: EvaluationExtractionRun[]
+  agentNameById: Map<string, string>
+  bestMatchRate: number | null
+}) {
+  const { t } = useTranslation()
+
+  const rows: {
+    key: string
+    label: string
+    render: (run: EvaluationExtractionRun) => ReactNode
+  }[] = [
+    {
+      key: "status",
+      label: t("evaluationExtractionRun:comparison.metrics.status"),
+      render: (run) => <RunStatusBadge status={run.status} />,
+    },
+    {
+      key: "agent",
+      label: t("evaluationExtractionRun:comparison.metrics.agent"),
+      render: (run) => <span className="text-sm">{agentNameById.get(run.agentId) ?? "-"}</span>,
+    },
+    {
+      key: "version",
+      label: t("evaluationExtractionRun:comparison.metrics.version"),
+      render: (run) => (
+        <span className="text-sm whitespace-nowrap">
+          {t("evaluationExtractionRun:version.revision", { revision: run.agentRevision })}
+        </span>
+      ),
+    },
+    {
+      key: "matchRate",
+      label: t("evaluationExtractionRun:comparison.metrics.matchRate"),
+      render: (run) => {
+        const matchRate = buildMatchRate(run)
+        if (matchRate === null) return <span className="text-muted-foreground">-</span>
+        const isBest = bestMatchRate !== null && matchRate === bestMatchRate
+        return (
+          <span
+            className={cn(
+              "text-sm font-medium whitespace-nowrap",
+              isBest && "text-green-700 dark:text-green-400",
+            )}
+          >
+            {t("evaluationExtractionRun:history.matchRate", { matchRate })}
+          </span>
+        )
+      },
+    },
+    {
+      key: "perfectMatches",
+      label: t("evaluationExtractionRun:comparison.metrics.perfectMatches"),
+      render: (run) => <span className="text-sm">{run.summary?.perfectMatches ?? 0}</span>,
+    },
+    {
+      key: "mismatches",
+      label: t("evaluationExtractionRun:comparison.metrics.mismatches"),
+      render: (run) => <span className="text-sm">{run.summary?.mismatches ?? 0}</span>,
+    },
+    {
+      key: "errors",
+      label: t("evaluationExtractionRun:comparison.metrics.errors"),
+      render: (run) => <span className="text-sm">{run.summary?.errors ?? 0}</span>,
+    },
+    {
+      key: "total",
+      label: t("evaluationExtractionRun:comparison.metrics.total"),
+      render: (run) => <span className="text-sm">{run.summary?.total ?? 0}</span>,
+    },
+  ]
+
+  return (
+    <Card className="border-0 shadow-none">
+      <CardHeader>
+        <CardTitle>{t("evaluationExtractionRun:comparison.summary")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-lg border overflow-x-auto">
+          <table className="w-full caption-bottom text-sm">
+            <thead className="bg-muted/50 [&_tr]:border-b">
+              <tr className="border-b transition-colors">
+                <th className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium">
+                  {t("evaluationExtractionRun:comparison.metric")}
+                </th>
+                {runs.map((run) => (
+                  <th
+                    key={run.id}
+                    className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium"
+                  >
+                    <RunColumnHeader run={run} agentName={agentNameById.get(run.agentId)} />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, index) => (
+                <tr
+                  key={row.key}
+                  className={cn(
+                    "border-b transition-colors hover:bg-muted/50",
+                    index % 2 !== 0 && "bg-muted/30",
+                  )}
+                >
+                  <td className="p-3 align-middle font-medium text-muted-foreground whitespace-nowrap">
+                    {row.label}
+                  </td>
+                  {runs.map((run) => (
+                    <td key={run.id} className="p-3 align-middle">
+                      {row.render(run)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type RecordCell = {
+  status: EvaluationExtractionRunRecordStatus
+  // Scored fields that matched vs scored fields, when the record was compared.
+  matchedFields: number | null
+  scoredFields: number | null
+}
+
+type ComparisonRow = {
+  key: string
+  recordLabel: string
+  cellsByRunId: Record<string, RecordCell | null>
+}
+
+function buildRecordLabel(record: EvaluationExtractionRunRecord): string {
+  if (!record.datasetRecordData) return "-"
+  return Object.values(record.datasetRecordData)
+    .map((value) => String(value))
+    .join(" · ")
+}
+
+function buildRecordCell(record: EvaluationExtractionRunRecord): RecordCell {
+  if (!record.comparison) {
+    return { status: record.status, matchedFields: null, scoredFields: null }
+  }
+  const fieldResults = Object.values(record.comparison).filter(
+    (fieldResult) => fieldResult.status !== "fyi",
+  )
+  return {
+    status: record.status,
+    matchedFields: fieldResults.filter((fieldResult) => fieldResult.status === "match").length,
+    scoredFields: fieldResults.length,
+  }
+}
+
+function buildComparisonRows(
+  runs: EvaluationExtractionRun[],
+  recordsByRunId: Record<string, EvaluationExtractionRunRecord[]>,
+): ComparisonRow[] {
+  // Align records across runs by their source dataset-record id. Runs of the same
+  // dataset share those ids, so the reference is whichever run returned the most
+  // records; other runs are matched by id, falling back to positional index.
+  const reference = runs.reduce<EvaluationExtractionRunRecord[]>((longest, run) => {
+    const records = recordsByRunId[run.id] ?? []
+    return records.length > longest.length ? records : longest
+  }, [])
+
+  return reference.map((referenceRecord, index) => {
+    const datasetRecordId = referenceRecord.evaluationExtractionDatasetRecordId
+    const cellsByRunId: Record<string, RecordCell | null> = {}
+    for (const run of runs) {
+      const records = recordsByRunId[run.id] ?? []
+      const match = datasetRecordId
+        ? records.find((record) => record.evaluationExtractionDatasetRecordId === datasetRecordId)
+        : records[index]
+      cellsByRunId[run.id] = match ? buildRecordCell(match) : null
+    }
+    return {
+      key: datasetRecordId ?? `#${index}`,
+      recordLabel: buildRecordLabel(referenceRecord),
+      cellsByRunId,
+    }
+  })
+}
+
+function RecordsComparison({
+  runs,
+  recordsByRunId,
+}: {
+  runs: EvaluationExtractionRun[]
+  recordsByRunId: Record<string, EvaluationExtractionRunRecord[]>
+}) {
+  const { t } = useTranslation()
+  const rows = useMemo(() => buildComparisonRows(runs, recordsByRunId), [runs, recordsByRunId])
+
+  return (
+    <Card className="border-0 shadow-none">
+      <CardHeader>
+        <CardTitle>{t("evaluationExtractionRun:comparison.records")}</CardTitle>
+        <CardDescription>
+          {t("evaluationExtractionRun:comparison.recordsDescription", { count: rows.length })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-lg border overflow-x-auto">
+          <table className="w-full caption-bottom text-sm">
+            <thead className="bg-muted/50 [&_tr]:border-b">
+              <tr className="border-b transition-colors">
+                <th className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium">
+                  #
+                </th>
+                <th className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium">
+                  {t("evaluationExtractionRun:comparison.record")}
+                </th>
+                {runs.map((run) => (
+                  <th
+                    key={run.id}
+                    className="text-foreground h-auto px-3 py-2 text-left align-bottom font-medium whitespace-nowrap"
+                  >
+                    <RunIdLink runId={run.id} />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={2 + runs.length} className="h-24 text-center text-muted-foreground">
+                    {t("evaluationExtractionRun:results.noRecords")}
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row, index) => (
+                  <tr
+                    key={row.key}
+                    className={cn(
+                      "border-b transition-colors hover:bg-muted/50",
+                      index % 2 !== 0 && "bg-muted/30",
+                    )}
+                  >
+                    <td className="p-3 align-middle font-mono text-xs text-muted-foreground/60">
+                      {index + 1}
+                    </td>
+                    <td className="p-3 align-middle" style={{ maxWidth: 250 }}>
+                      <TruncatedCell value={row.recordLabel} />
+                    </td>
+                    {runs.map((run) => {
+                      const cell = row.cellsByRunId[run.id] ?? null
+                      if (!cell) {
+                        return (
+                          <td key={run.id} className="p-3 align-middle">
+                            <span className="text-muted-foreground">-</span>
+                          </td>
+                        )
+                      }
+                      return (
+                        <td key={run.id} className="p-3 align-middle">
+                          <div className="flex items-center gap-2 whitespace-nowrap">
+                            <RecordStatusBadge status={cell.status} />
+                            {cell.scoredFields !== null && cell.scoredFields > 0 && (
+                              <span className="text-xs text-muted-foreground">
+                                {t("evaluationExtractionRun:comparison.matchedFields", {
+                                  matched: cell.matchedFields,
+                                  scored: cell.scoredFields,
+                                })}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/eval/features/evaluation-extraction-runs/components/RunEvaluationExtractionDialog.tsx
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/components/RunEvaluationExtractionDialog.tsx
@@ -1,4 +1,7 @@
-import type { EvaluationExtractionRunKeyMappingEntryDto } from "@caseai-connect/api-contracts"
+import {
+  createEvaluationExtractionRunSchema,
+  type EvaluationExtractionRunKeyMappingEntryDto,
+} from "@caseai-connect/api-contracts"
 import { Button } from "@caseai-connect/ui/shad/button"
 import {
   Dialog,
@@ -9,6 +12,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@caseai-connect/ui/shad/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@caseai-connect/ui/shad/form"
 import { Label } from "@caseai-connect/ui/shad/label"
 import {
   Select,
@@ -17,19 +28,27 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@caseai-connect/ui/shad/select"
+import { zodResolver } from "@hookform/resolvers/zod"
 import { PlayIcon } from "lucide-react"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { type Control, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
+import { z } from "zod"
 import { Loader } from "@/common/components/Loader"
 import { RunScopeSelector } from "@/common/components/shared/RunScopeSelector"
+import {
+  findPublishedVersion,
+  findVersion,
+} from "@/common/features/agents/agent-settings/agent-settings.functions"
 import type { AgentSettings } from "@/common/features/agents/agent-settings/agent-settings.models"
-import { selectAgentSettingsDataByAgentId } from "@/common/features/agents/agent-settings/agent-settings.selectors"
+import { selectAgentSettingsHistoryDataByAgentId } from "@/common/features/agents/agent-settings/agent-settings.selectors"
 import type { Agent } from "@/common/features/agents/agents.models"
 import { selectAgentsData } from "@/common/features/agents/agents.selectors"
 import { useValue } from "@/common/hooks/use-value"
 import { ADS } from "@/common/store/async-data-status"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { buildDate } from "@/common/utils/build-date"
 import type {
   EvaluationExtractionDataset,
   EvaluationExtractionDatasetSchemaColumn,
@@ -42,6 +61,23 @@ type KeyMappingEntry = {
   agentOutputKey: string
   datasetColumnId: string
   mode: "scored" | "fyi"
+}
+
+type RunFormValues = {
+  agentId: string
+  // null = no explicit choice; the latest published revision is used once history loads.
+  selectedRevision: number | null
+  keyMapping: KeyMappingEntry[]
+  runScope: "all" | "limited"
+  limitedCount: number
+}
+
+const defaultRunFormValues: RunFormValues = {
+  agentId: "",
+  selectedRevision: null,
+  keyMapping: [],
+  runScope: "all",
+  limitedCount: 1,
 }
 
 function getAgentOutputKeys(agentSettings: AgentSettings): string[] {
@@ -110,87 +146,15 @@ function RunEvaluationExtractionForm({
   onRan: () => void
 }) {
   const { t } = useTranslation()
-  const agentsData = useValue(selectAgentsData)
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
-
-  const extractionAgents = useMemo(() => {
-    return agentsData.filter((agent) => agent.type === "extraction")
-  }, [agentsData])
-
-  return (
-    <div className="flex flex-col gap-4">
-      <AgentSelector
-        agents={extractionAgents}
-        selectedAgentId={selectedAgentId}
-        onAgentChange={setSelectedAgentId}
-      />
-
-      {selectedAgentId ? (
-        // Remounted on agent change so the run settings are rebuilt from the new agent's schema.
-        <AgentRunSettings
-          key={selectedAgentId}
-          selectedAgentId={selectedAgentId}
-          dataset={dataset}
-          onRan={onRan}
-        />
-      ) : (
-        <DialogFooter>
-          <Button disabled>{t("evaluationExtractionRun:run")}</Button>
-        </DialogFooter>
-      )}
-    </div>
-  )
-}
-
-/**
- * Gate: the agent settings are fetched per agent, so they can still be loading (or missing)
- * when an agent is picked. Only render the run settings once they are available.
- */
-function AgentRunSettings({
-  selectedAgentId,
-  dataset,
-  onRan,
-}: {
-  selectedAgentId: string | null
-  dataset: EvaluationExtractionDataset
-  onRan: () => void
-}) {
-  const { t } = useTranslation()
-  const agentSettingsData = useAppSelector(
-    selectAgentSettingsDataByAgentId({ agentId: selectedAgentId ?? "", includeDraft: true }),
-  )
-
-  if (ADS.isError(agentSettingsData)) {
-    return (
-      <p className="text-sm text-destructive">
-        {t("evaluationExtractionRun:agentSettingsUnavailable")}
-      </p>
-    )
-  }
-
-  if (!ADS.isFulfilled(agentSettingsData)) return <Loader />
-
-  return <AgentRunSettingsForm selectedAgentId={selectedAgentId} dataset={dataset} onRan={onRan} />
-}
-
-function AgentRunSettingsForm({
-  selectedAgentId,
-  dataset,
-  onRan,
-}: {
-  selectedAgentId: string | null
-  dataset: EvaluationExtractionDataset
-  onRan: () => void
-}) {
-  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const { buildRunPath } = useEvaluationExtractionRunPath()
   const isExecuting = useAppSelector(selectIsExecuting)
+  const agentsData = useValue(selectAgentsData)
 
-  const agentSettings = useValue(
-    selectAgentSettingsDataByAgentId({ agentId: selectedAgentId ?? "", includeDraft: true }),
-  )
+  const extractionAgents = useMemo(() => {
+    return agentsData.filter((agent) => agent.type === "extraction")
+  }, [agentsData])
 
   const targetColumns = useMemo(
     () =>
@@ -200,144 +164,313 @@ function AgentRunSettingsForm({
     [dataset.schemaMapping],
   )
 
-  const [keyMapping, setKeyMapping] = useState<KeyMappingEntry[]>(() =>
-    buildDefaultKeyMapping({ agentSettings, targetColumns }),
+  // Contract schema extended with the dialog-only fields and translated
+  // validation messages (ADR 0012).
+  const formSchema = useMemo(
+    () =>
+      createEvaluationExtractionRunSchema
+        .omit({ evaluationExtractionDatasetId: true, agentSettingsRevision: true })
+        .extend({
+          selectedRevision: z.number().int().nullable(),
+          runScope: z.enum(["all", "limited"]),
+          limitedCount: z.number().int().min(1),
+        })
+        .refine((values) => values.agentId.length > 0, {
+          path: ["agentId"],
+          message: t("evaluationExtractionRun:agentPlaceholder"),
+        })
+        .refine((values) => values.keyMapping.length > 0, {
+          path: ["keyMapping"],
+          message: t("evaluationExtractionRun:keyMapping.noOutputSchema"),
+        })
+        .refine(
+          (values) =>
+            values.keyMapping.every(
+              (entry) => entry.mode === "fyi" || entry.datasetColumnId !== "",
+            ),
+          {
+            path: ["keyMapping"],
+            message: t("evaluationExtractionRun:keyMapping.incomplete"),
+          },
+        ),
+    [t],
   )
-  const [recordLimit, setRecordLimit] = useState<number | null>(null)
 
-  const agentOutputKeys = useMemo(() => getAgentOutputKeys(agentSettings), [agentSettings])
+  const form = useForm<RunFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaultRunFormValues,
+  })
+  const { control, watch, setValue, getValues } = form
 
-  const handleColumnChange = useCallback((agentOutputKey: string, datasetColumnId: string) => {
-    setKeyMapping((previous) =>
-      previous.map((entry) =>
-        entry.agentOutputKey === agentOutputKey ? { ...entry, datasetColumnId } : entry,
-      ),
+  const selectedAgentId = watch("agentId")
+  const selectedRevision = watch("selectedRevision")
+  const runScope = watch("runScope")
+  const limitedCount = watch("limitedCount")
+  const keyMapping = watch("keyMapping")
+
+  const agentSettingsHistoryData = useAppSelector(
+    selectAgentSettingsHistoryDataByAgentId({ agentId: selectedAgentId, includeDraft: true }),
+  )
+  const history = ADS.isFulfilled(agentSettingsHistoryData)
+    ? agentSettingsHistoryData.value
+    : undefined
+
+  // The user's explicit pick, defaulting to the latest published revision — the
+  // version the server would pin if the payload carried none.
+  const effectiveRevision =
+    selectedRevision ?? (history ? (findPublishedVersion(history)?.revision ?? null) : null)
+  const selectedVersion =
+    history && effectiveRevision !== null ? findVersion(history, effectiveRevision) : undefined
+
+  // The key mapping derives from the chosen version's output schema, so it must be
+  // rebuilt whenever the effective version changes.
+  useEffect(() => {
+    setValue(
+      "keyMapping",
+      selectedVersion
+        ? buildDefaultKeyMapping({ agentSettings: selectedVersion, targetColumns })
+        : [],
     )
-  }, [])
+  }, [setValue, selectedVersion, targetColumns])
 
-  const handleModeChange = useCallback((agentOutputKey: string, mode: "scored" | "fyi") => {
-    setKeyMapping((previous) =>
-      previous.map((entry) =>
-        entry.agentOutputKey === agentOutputKey ? { ...entry, mode } : entry,
-      ),
+  const agentOutputKeys = useMemo(
+    () => (selectedVersion ? getAgentOutputKeys(selectedVersion) : []),
+    [selectedVersion],
+  )
+
+  const handleAgentChange = useCallback(() => {
+    setValue("selectedRevision", null)
+  }, [setValue])
+
+  const handleColumnChange = useCallback(
+    (agentOutputKey: string, datasetColumnId: string) => {
+      setValue(
+        "keyMapping",
+        getValues("keyMapping").map((entry) =>
+          entry.agentOutputKey === agentOutputKey ? { ...entry, datasetColumnId } : entry,
+        ),
+        { shouldValidate: true },
+      )
+    },
+    [setValue, getValues],
+  )
+
+  const handleModeChange = useCallback(
+    (agentOutputKey: string, mode: "scored" | "fyi") => {
+      setValue(
+        "keyMapping",
+        getValues("keyMapping").map((entry) =>
+          entry.agentOutputKey === agentOutputKey ? { ...entry, mode } : entry,
+        ),
+        { shouldValidate: true },
+      )
+    },
+    [setValue, getValues],
+  )
+
+  const handleLimitedCountChange = useCallback(
+    (value: string) => {
+      const parsed = Number.parseInt(value, 10)
+      if (!Number.isNaN(parsed)) {
+        setValue("limitedCount", Math.min(Math.max(1, parsed), dataset.recordCount))
+      }
+    },
+    [setValue, dataset.recordCount],
+  )
+
+  const handleRun = form.handleSubmit(async (values) => {
+    if (effectiveRevision === null) return
+    const validMapping: EvaluationExtractionRunKeyMappingEntryDto[] = values.keyMapping.map(
+      (entry) => ({
+        agentOutputKey: entry.agentOutputKey,
+        datasetColumnId: entry.datasetColumnId,
+        mode: entry.mode,
+      }),
     )
-  }, [])
-
-  const isValid = useMemo(() => {
-    if (!selectedAgentId) return false
-    if (keyMapping.length === 0) return false
-    return keyMapping.every((entry) => entry.mode === "fyi" || entry.datasetColumnId !== "")
-  }, [selectedAgentId, keyMapping])
-
-  const handleRun = async () => {
-    if (!selectedAgentId || !isValid) return
-    const validMapping: EvaluationExtractionRunKeyMappingEntryDto[] = keyMapping.map((entry) => ({
-      agentOutputKey: entry.agentOutputKey,
-      datasetColumnId: entry.datasetColumnId,
-      mode: entry.mode,
-    }))
 
     const result = await dispatch(
       evaluationExtractionRunsActions.createAndExecute({
         evaluationExtractionDatasetId: dataset.id,
-        agentId: selectedAgentId,
+        agentId: values.agentId,
+        agentSettingsRevision: effectiveRevision,
         keyMapping: validMapping,
-        recordLimit,
+        recordLimit: values.runScope === "limited" ? values.limitedCount : null,
       }),
     ).unwrap()
 
     onRan()
     navigate(buildRunPath({ runId: result.id }))
-  }
+  })
 
   return (
-    <>
-      {agentOutputKeys.length > 0 ? (
-        <KeyMappingEditor
-          agentOutputKeys={agentOutputKeys}
-          targetColumns={targetColumns}
-          keyMapping={keyMapping}
-          onColumnChange={handleColumnChange}
-          onModeChange={handleModeChange}
-        />
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          {t("evaluationExtractionRun:keyMapping.noOutputSchema")}
-        </p>
-      )}
+    <Form {...form}>
+      <form onSubmit={handleRun} className="flex flex-col gap-4">
+        <AgentField control={control} agents={extractionAgents} onAgentChange={handleAgentChange} />
 
-      <RunScopeField recordCount={dataset.recordCount} onRecordLimitChange={setRecordLimit} />
+        {selectedAgentId &&
+          (ADS.isError(agentSettingsHistoryData) ? (
+            <p className="text-sm text-destructive">
+              {t("evaluationExtractionRun:agentSettingsUnavailable")}
+            </p>
+          ) : !history ? (
+            <Loader />
+          ) : (
+            <>
+              <AgentVersionField
+                control={control}
+                history={history}
+                effectiveRevision={effectiveRevision}
+              />
 
-      <DialogFooter>
-        <Button onClick={handleRun} disabled={!isValid || isExecuting}>
-          {isExecuting ? t("evaluationExtractionRun:running") : t("evaluationExtractionRun:run")}
-        </Button>
-      </DialogFooter>
-    </>
+              {agentOutputKeys.length > 0 ? (
+                <FormField
+                  control={control}
+                  name="keyMapping"
+                  render={() => (
+                    <FormItem>
+                      <KeyMappingEditor
+                        agentOutputKeys={agentOutputKeys}
+                        targetColumns={targetColumns}
+                        keyMapping={keyMapping}
+                        onColumnChange={handleColumnChange}
+                        onModeChange={handleModeChange}
+                      />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  {t("evaluationExtractionRun:keyMapping.noOutputSchema")}
+                </p>
+              )}
+
+              <RunScopeSelector
+                recordCount={dataset.recordCount}
+                runScope={runScope}
+                limitedCount={limitedCount}
+                onRunScopeChange={(scope) => setValue("runScope", scope)}
+                onLimitedCountChange={handleLimitedCountChange}
+              />
+            </>
+          ))}
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            disabled={!selectedAgentId || form.formState.isSubmitting || isExecuting}
+          >
+            {isExecuting ? t("evaluationExtractionRun:running") : t("evaluationExtractionRun:run")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
   )
 }
 
-function RunScopeField({
-  recordCount,
-  onRecordLimitChange,
-}: {
-  recordCount: number
-  onRecordLimitChange: (recordLimit: number | null) => void
-}) {
-  const [runScope, setRunScope] = useState<"all" | "limited">("all")
-  const [limitedCount, setLimitedCount] = useState(1)
-
-  const handleRunScopeChange = (scope: "all" | "limited") => {
-    setRunScope(scope)
-    onRecordLimitChange(scope === "limited" ? limitedCount : null)
-  }
-
-  const handleLimitedCountChange = (value: string) => {
-    const parsed = Number.parseInt(value, 10)
-    if (Number.isNaN(parsed)) return
-    const clampedCount = Math.min(Math.max(1, parsed), recordCount)
-    setLimitedCount(clampedCount)
-    onRecordLimitChange(clampedCount)
-  }
-
-  return (
-    <RunScopeSelector
-      recordCount={recordCount}
-      runScope={runScope}
-      limitedCount={limitedCount}
-      onRunScopeChange={handleRunScopeChange}
-      onLimitedCountChange={handleLimitedCountChange}
-    />
-  )
-}
-
-function AgentSelector({
+function AgentField({
+  control,
   agents,
-  selectedAgentId,
   onAgentChange,
 }: {
+  control: Control<RunFormValues>
   agents: Agent[]
-  selectedAgentId: string | null
-  onAgentChange: (agentId: string) => void
+  onAgentChange: () => void
 }) {
   const { t } = useTranslation()
 
   return (
-    <div className="flex flex-col gap-2">
-      <Label>{t("evaluationExtractionRun:agent")}</Label>
-      <Select value={selectedAgentId ?? undefined} onValueChange={onAgentChange}>
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder={t("evaluationExtractionRun:agentPlaceholder")} />
-        </SelectTrigger>
-        <SelectContent>
-          {agents.map((agent) => (
-            <SelectItem key={agent.id} value={agent.id}>
-              {agent.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <FormField
+      control={control}
+      name="agentId"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{t("evaluationExtractionRun:agent")}</FormLabel>
+          <Select
+            value={field.value || undefined}
+            onValueChange={(agentId) => {
+              field.onChange(agentId)
+              onAgentChange()
+            }}
+          >
+            <FormControl>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t("evaluationExtractionRun:agentPlaceholder")} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {agents.map((agent) => (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function AgentVersionField({
+  control,
+  history,
+  effectiveRevision,
+}: {
+  control: Control<RunFormValues>
+  history: AgentSettings[]
+  effectiveRevision: number | null
+}) {
+  const { t } = useTranslation()
+
+  // The newest non-draft revision: the one the agent actually runs with.
+  const publishedRevision = findPublishedVersion(history)?.revision
+
+  const buildVersionDetail = (agentVersion: AgentSettings) => {
+    if (agentVersion.isDraft) return t("status:draft")
+    if (agentVersion.revision === publishedRevision)
+      return t("evaluationExtractionRun:version.current", {
+        date: buildDate(agentVersion.updatedAt),
+      })
+    return buildDate(agentVersion.updatedAt)
+  }
+
+  return (
+    <FormField
+      control={control}
+      name="selectedRevision"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{t("evaluationExtractionRun:version.label")}</FormLabel>
+          <Select
+            value={effectiveRevision !== null ? String(effectiveRevision) : undefined}
+            onValueChange={(value) => {
+              const parsed = Number.parseInt(value, 10)
+              if (!Number.isNaN(parsed)) field.onChange(parsed)
+            }}
+            disabled={history.length === 0}
+          >
+            <FormControl>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t("evaluationExtractionRun:version.placeholder")} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {history.map((agentVersion) => (
+                <SelectItem key={agentVersion.revision} value={String(agentVersion.revision)}>
+                  {t("evaluationExtractionRun:version.item", {
+                    revision: agentVersion.revision,
+                    detail: buildVersionDetail(agentVersion),
+                  })}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   )
 }
 

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.factory.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.factory.ts
@@ -1,0 +1,141 @@
+import { faker } from "@faker-js/faker"
+import { Factory } from "fishery"
+import type { Agent } from "@/common/features/agents/agents.models"
+import type { EvaluationExtractionDataset } from "../evaluation-extraction-datasets/evaluation-extraction-datasets.models"
+import type {
+  EvaluationExtractionRun,
+  EvaluationExtractionRunKeyMappingEntry,
+  EvaluationExtractionRunRecord,
+  EvaluationExtractionRunRecordFieldResult,
+  EvaluationExtractionRunSummary,
+} from "./evaluation-extraction-runs.models"
+
+export const evaluationExtractionRunSummaryFactory = Factory.define<EvaluationExtractionRunSummary>(
+  ({ params }) => {
+    const total = params.total ?? faker.number.int({ min: 1, max: 50 })
+    const errors = params.errors ?? 0
+    const running = params.running ?? 0
+    const mismatches = params.mismatches ?? 0
+    const perfectMatches =
+      params.perfectMatches ?? Math.max(total - errors - running - mismatches, 0)
+
+    return { total, perfectMatches, mismatches, errors, running }
+  },
+)
+
+type EvaluationExtractionRunTransientParams = {
+  dataset: EvaluationExtractionDataset
+  agent: Agent
+}
+
+class EvaluationExtractionRunFactory extends Factory<
+  EvaluationExtractionRun,
+  EvaluationExtractionRunTransientParams
+> {}
+
+export const evaluationExtractionRunFactory = EvaluationExtractionRunFactory.define(
+  ({ params, transientParams }) => {
+    const { dataset, agent } = transientParams
+    if (!dataset) {
+      throw new Error(
+        "Dataset must be provided in transient params to build an EvaluationExtractionRun",
+      )
+    }
+    if (!agent) {
+      throw new Error(
+        "Agent must be provided in transient params to build an EvaluationExtractionRun",
+      )
+    }
+
+    // Default mapping: every target column of the dataset scored against the
+    // agent output key of the same name.
+    const keyMapping =
+      (params.keyMapping as EvaluationExtractionRunKeyMappingEntry[] | undefined) ??
+      Object.values(dataset.schemaMapping)
+        .filter((column) => column.role === "target")
+        .map((column) => ({
+          agentOutputKey: column.finalName,
+          datasetColumnId: column.id,
+          mode: "scored" as const,
+        }))
+
+    return {
+      id: params.id ?? faker.string.uuid(),
+      evaluationExtractionDatasetId: dataset.id,
+      agentId: agent.id,
+      agentSettingsId: params.agentSettingsId ?? faker.string.uuid(),
+      agentRevision: params.agentRevision ?? faker.number.int({ min: 1, max: 20 }),
+      keyMapping,
+      status: params.status ?? "completed",
+      summary:
+        params.summary === null
+          ? null
+          : evaluationExtractionRunSummaryFactory.build(params.summary),
+      csvExportDocumentId: params.csvExportDocumentId ?? null,
+      projectId: dataset.projectId,
+      createdAt: params.createdAt ?? faker.date.past().getTime(),
+      updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
+    }
+  },
+)
+
+type EvaluationExtractionRunRecordTransientParams = {
+  run: EvaluationExtractionRun
+}
+
+class EvaluationExtractionRunRecordFactory extends Factory<
+  EvaluationExtractionRunRecord,
+  EvaluationExtractionRunRecordTransientParams
+> {}
+
+export const evaluationExtractionRunRecordFactory = EvaluationExtractionRunRecordFactory.define(
+  ({ params, transientParams }) => {
+    const { run } = transientParams
+    if (!run) {
+      throw new Error(
+        "Run must be provided in transient params to build an EvaluationExtractionRunRecord",
+      )
+    }
+
+    const status = params.status ?? "match"
+
+    // Default per-field comparison: one field per scored key-mapping entry,
+    // all matching unless the record itself is a mismatch.
+    const comparison =
+      params.comparison === null
+        ? null
+        : ((params.comparison as
+            | Record<string, EvaluationExtractionRunRecordFieldResult>
+            | undefined) ??
+          Object.fromEntries(
+            run.keyMapping
+              .filter((entry) => entry.mode === "scored")
+              .map((entry, index) => [
+                entry.agentOutputKey,
+                {
+                  agentValue: faker.lorem.word(),
+                  groundTruth: faker.lorem.word(),
+                  status: status === "mismatch" && index === 0 ? "mismatch" : "match",
+                } satisfies EvaluationExtractionRunRecordFieldResult,
+              ]),
+          ))
+
+    return {
+      id: params.id ?? faker.string.uuid(),
+      evaluationExtractionRunId: run.id,
+      evaluationExtractionDatasetRecordId:
+        params.evaluationExtractionDatasetRecordId ?? faker.string.uuid(),
+      status,
+      comparison,
+      agentRawOutput: (params.agentRawOutput as Record<string, unknown> | undefined) ?? null,
+      errorDetails: params.errorDetails ?? null,
+      datasetRecordData: (params.datasetRecordData as Record<string, unknown> | undefined) ?? {
+        title: faker.commerce.productName(),
+        summary: faker.lorem.sentence(),
+      },
+      traceUrl: params.traceUrl ?? null,
+      createdAt: params.createdAt ?? faker.date.past().getTime(),
+      updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
+    }
+  },
+)

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.helpers.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.helpers.ts
@@ -1,0 +1,6 @@
+// Last 6 chars of the run id (e.g. "894f5f5b-...-a3b4b3837502" -> "837502"): a short,
+// human-readable handle to tell runs apart when their agent/version match.
+// 6 hex chars keep collisions negligible for the handful of runs a dataset has.
+export function shortRunId(runId: string): string {
+  return runId.slice(-6)
+}

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.middleware.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.middleware.ts
@@ -3,6 +3,7 @@ import { notificationsActions } from "@/common/features/notifications/notificati
 import type { AppDispatch, RootState } from "@/common/store/types"
 import { evaluationExtractionDatasetsActions } from "../evaluation-extraction-datasets/evaluation-extraction-datasets.slice"
 import {
+  selectComparisonRunIds,
   selectCurrentRecordsQuery,
   selectCurrentRunId,
 } from "./evaluation-extraction-runs.selectors"
@@ -40,6 +41,21 @@ function registerListeners() {
     actionCreator: evaluationExtractionRunsActions.unmount,
     effect: async (_, listenerApi) => {
       listenerApi.dispatch(evaluationExtractionRunsActions.stopRunStatusStream())
+    },
+  })
+
+  // Compare page: fetch the records of the compared runs once the route has
+  // pushed the URL-driven run ids into the slice (setComparisonRunIds).
+  listenerMiddleware.startListening({
+    actionCreator: evaluationExtractionRunsActions.compareMount,
+    effect: async (_, listenerApi) => {
+      const runIds = selectComparisonRunIds(listenerApi.getState())
+      if (runIds.length === 0) return
+      listenerApi.dispatch(
+        evaluationExtractionRunsActions.getComparisonRecords({
+          evaluationExtractionRunIds: runIds,
+        }),
+      )
     },
   })
 

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.selectors.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.selectors.ts
@@ -11,6 +11,11 @@ export const selectCurrentRunData = (state: RootState) => state.extractionRuns.c
 
 export const selectCurrentRunRecords = (state: RootState) => state.extractionRuns.currentRunRecords
 
+export const selectExtractionRunsComparison = (state: RootState) =>
+  state.extractionRuns.comparisonRecords
+
+export const selectComparisonRunIds = (state: RootState) => state.extractionRuns.comparisonRunIds
+
 export const selectIsExecuting = (state: RootState) => state.extractionRuns.isExecuting
 
 export const selectIsCancelling = (state: RootState) => state.extractionRuns.isCancelling

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.slice.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.slice.ts
@@ -3,6 +3,7 @@ import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data
 import { currentIdsActions } from "@/eval/store/currentIds.slice"
 import type {
   EvaluationExtractionRun,
+  EvaluationExtractionRunRecord,
   EvaluationExtractionRunStatus,
   EvaluationExtractionRunSummary,
   PaginatedEvaluationExtractionRunRecords,
@@ -24,6 +25,9 @@ interface State {
   currentRun: AsyncData<EvaluationExtractionRun>
   currentRunRecords: AsyncData<PaginatedEvaluationExtractionRunRecords>
   currentRecordsQuery: RecordsQuery
+  // Run ids being compared (URL-driven, compare page) and their records keyed by run id.
+  comparisonRunIds: string[]
+  comparisonRecords: AsyncData<Record<string, EvaluationExtractionRunRecord[]>>
   isExecuting: boolean
   isRetrying: boolean
   isCancelling: boolean
@@ -32,12 +36,23 @@ interface State {
 
 const defaultRecordsQuery: RecordsQuery = { page: 0, limit: 10 }
 
+// Guards stale getComparisonRecords responses: only the response matching the
+// current comparison (same run ids, same order) may touch the state.
+function isCurrentComparison(
+  comparisonRunIds: string[],
+  requestArg: { evaluationExtractionRunIds: string[] },
+): boolean {
+  return comparisonRunIds.join(",") === requestArg.evaluationExtractionRunIds.join(",")
+}
+
 const initialState: State = {
   currentRunId: null,
   data: defaultAsyncData,
   currentRun: defaultAsyncData,
   currentRunRecords: defaultAsyncData,
   currentRecordsQuery: defaultRecordsQuery,
+  comparisonRunIds: [],
+  comparisonRecords: defaultAsyncData,
   isExecuting: false,
   isRetrying: false,
   isCancelling: false,
@@ -50,6 +65,19 @@ const slice = createSlice({
   reducers: {
     mount: () => {},
     unmount: () => {},
+    // Compare-page lifecycle (ADR 0009): the middleware fetches on compareMount;
+    // unmounting clears the comparison so a later visit never flashes stale data.
+    compareMount: () => {},
+    compareUnmount: (state) => {
+      state.comparisonRunIds = []
+      state.comparisonRecords = defaultAsyncData
+    },
+    // URL-driven, set by the compare route (same role as useSetCurrentIds).
+    setComparisonRunIds: (state, action: PayloadAction<string[]>) => {
+      if (state.comparisonRunIds.join(",") === action.payload.join(",")) return
+      state.comparisonRunIds = action.payload
+      state.comparisonRecords = defaultAsyncData
+    },
     reset: () => initialState,
     startRunStatusStream: (state) => {
       state.runStatusStream.isActive = true
@@ -150,6 +178,26 @@ const slice = createSlice({
         if (action.meta.arg.evaluationExtractionRunId !== state.currentRunId) return
         state.currentRunRecords.status = ADS.Error
         state.currentRunRecords.error = action.error.message || "Failed to get run records"
+      })
+
+    // getComparisonRecords — responses for run ids other than the current
+    // comparison are stale (the user already navigated on) and are discarded.
+    builder
+      .addCase(evaluationExtractionRunsThunks.getComparisonRecords.pending, (state, action) => {
+        if (!isCurrentComparison(state.comparisonRunIds, action.meta.arg)) return
+        if (!ADS.isFulfilled(state.comparisonRecords)) {
+          state.comparisonRecords.status = ADS.Loading
+        }
+        state.comparisonRecords.error = null
+      })
+      .addCase(evaluationExtractionRunsThunks.getComparisonRecords.fulfilled, (state, action) => {
+        if (!isCurrentComparison(state.comparisonRunIds, action.meta.arg)) return
+        state.comparisonRecords = { status: ADS.Fulfilled, error: null, value: action.payload }
+      })
+      .addCase(evaluationExtractionRunsThunks.getComparisonRecords.rejected, (state, action) => {
+        if (!isCurrentComparison(state.comparisonRunIds, action.meta.arg)) return
+        state.comparisonRecords.status = ADS.Error
+        state.comparisonRecords.error = action.error.message || "Failed to load runs to compare"
       })
 
     // createAndExecute

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.spi.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.spi.ts
@@ -13,6 +13,8 @@ export interface IEvaluationExtractionRunsSpi {
       payload: {
         evaluationExtractionDatasetId: string
         agentId: string
+        // Agent-settings revision to pin on the run; null pins the latest published revision.
+        agentSettingsRevision: number | null
         keyMapping: EvaluationExtractionRunKeyMappingEntryDto[]
       }
     },

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.thunks.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.thunks.ts
@@ -4,6 +4,7 @@ import { getCurrentId } from "@/common/features/helpers"
 import type { ThunkConfig } from "@/common/store/types"
 import type {
   EvaluationExtractionRun,
+  EvaluationExtractionRunRecord,
   PaginatedEvaluationExtractionRunRecords,
 } from "./evaluation-extraction-runs.models"
 import { evaluationExtractionRunsActions } from "./evaluation-extraction-runs.slice"
@@ -69,6 +70,37 @@ const getRecords = createAsyncThunk<
       sortBy,
       sortOrder,
     })
+  },
+)
+
+// Loads every record for each selected run so the compare page can align statuses
+// per dataset record. Runs of the same dataset share small record counts, so a
+// single high-limit page per run is enough.
+const COMPARISON_RECORD_LIMIT = 1000
+
+const getComparisonRecords = createAsyncThunk<
+  Record<string, EvaluationExtractionRunRecord[]>,
+  { evaluationExtractionRunIds: string[] },
+  ThunkConfig
+>(
+  "evaluationExtractionRuns/getComparisonRecords",
+  async ({ evaluationExtractionRunIds }, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const entries = await Promise.all(
+      evaluationExtractionRunIds.map(async (evaluationExtractionRunId) => {
+        const page = await services.evaluationExtractionRuns.getRecords({
+          organizationId,
+          projectId,
+          evaluationExtractionRunId,
+          page: 0,
+          limit: COMPARISON_RECORD_LIMIT,
+        })
+        return [evaluationExtractionRunId, page.records] as const
+      }),
+    )
+    return Object.fromEntries(entries)
   },
 )
 
@@ -192,6 +224,7 @@ export const evaluationExtractionRunsThunks = {
   deleteOne,
   retryOne,
   getAll,
+  getComparisonRecords,
   getOne,
   getRecords,
   streamRunStatus,

--- a/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.thunks.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.thunks.ts
@@ -77,6 +77,8 @@ const createAndExecute = createAsyncThunk<
   {
     evaluationExtractionDatasetId: string
     agentId: string
+    // Agent-settings revision to pin on the run; null pins the latest published revision.
+    agentSettingsRevision: number | null
     keyMapping: EvaluationExtractionRunKeyMappingEntryDto[]
     recordLimit: number | null
   },
@@ -94,6 +96,7 @@ const createAndExecute = createAsyncThunk<
       payload: {
         evaluationExtractionDatasetId: payload.evaluationExtractionDatasetId,
         agentId: payload.agentId,
+        agentSettingsRevision: payload.agentSettingsRevision,
         keyMapping: payload.keyMapping,
       },
     })

--- a/apps/web/src/eval/features/evaluation-extraction-runs/external/evaluation-extraction-runs.api.ts
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/external/evaluation-extraction-runs.api.ts
@@ -105,6 +105,8 @@ function toEvaluationExtractionRun(dto: EvaluationExtractionRunDto): EvaluationE
     id: dto.id,
     evaluationExtractionDatasetId: dto.evaluationExtractionDatasetId,
     agentId: dto.agentId,
+    agentSettingsId: dto.agentSettingsId,
+    agentRevision: dto.agentRevision,
     keyMapping: dto.keyMapping,
     status: dto.status,
     summary: dto.summary,

--- a/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.en.json
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.en.json
@@ -8,6 +8,14 @@
     "agent": "Agent",
     "agentPlaceholder": "Select an agent",
     "agentSettingsUnavailable": "This agent's configuration could not be loaded.",
+    "version": {
+      "label": "Version",
+      "placeholder": "Select a version",
+      "loading": "Loading versions...",
+      "item": "v{{revision}} — {{detail}}",
+      "current": "Current ({{date}})",
+      "revision": "v{{revision}}"
+    },
     "scope": {
       "title": "Records to run",
       "all": "Run entire dataset ({{count}} records)",
@@ -23,6 +31,7 @@
       "scored": "Scored",
       "fyi": "FYI",
       "columnPlaceholder": "Select column",
+      "incomplete": "Map every scored key to a dataset column.",
       "noOutputSchema": "This agent has no output schema defined."
     },
     "results": {

--- a/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.en.json
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.en.json
@@ -74,6 +74,17 @@
       "description": "{{count}} runs",
       "matchRate": "{{matchRate}}% match",
       "recordCount": "{{count}} records",
+      "columns": {
+        "id": "ID",
+        "status": "Status",
+        "date": "Date",
+        "agent": "Agent",
+        "version": "Version",
+        "matchRate": "Match rate",
+        "records": "Records"
+      },
+      "compare": "Compare runs",
+      "compareSelected": "Compare {{count}} runs",
       "delete": {
         "button": "Delete run",
         "confirm": {
@@ -81,6 +92,27 @@
           "description": "This action cannot be undone. All run records will be permanently deleted.",
           "submit": "Delete"
         }
+      }
+    },
+    "comparison": {
+      "title": "Compare Runs",
+      "description": "Comparing {{count}} runs",
+      "summary": "Summary",
+      "records": "Per-record results",
+      "recordsDescription": "{{count}} records",
+      "metric": "Metric",
+      "record": "Record",
+      "matchedFields": "{{matched}}/{{scored}} fields",
+      "notFound": "No runs selected to compare.",
+      "metrics": {
+        "status": "Status",
+        "agent": "Agent",
+        "version": "Version",
+        "matchRate": "Match rate",
+        "perfectMatches": "Perfect matches",
+        "mismatches": "Mismatches",
+        "errors": "Errors",
+        "total": "Total records"
       }
     },
     "agentMetadata": {

--- a/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.fr.json
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.fr.json
@@ -74,6 +74,17 @@
       "description": "{{count}} exécutions",
       "matchRate": "{{matchRate}}% de correspondance",
       "recordCount": "{{count}} enregistrements",
+      "columns": {
+        "id": "ID",
+        "status": "Statut",
+        "date": "Date",
+        "agent": "Agent",
+        "version": "Version",
+        "matchRate": "Taux de correspondance",
+        "records": "Enregistrements"
+      },
+      "compare": "Comparer les exécutions",
+      "compareSelected": "Comparer {{count}} exécutions",
       "delete": {
         "button": "Supprimer l'exécution",
         "confirm": {
@@ -81,6 +92,27 @@
           "description": "Cette action est irréversible. Tous les enregistrements de l'exécution seront définitivement supprimés.",
           "submit": "Supprimer"
         }
+      }
+    },
+    "comparison": {
+      "title": "Comparer les exécutions",
+      "description": "Comparaison de {{count}} exécutions",
+      "summary": "Résumé",
+      "records": "Résultats par enregistrement",
+      "recordsDescription": "{{count}} enregistrements",
+      "metric": "Métrique",
+      "record": "Enregistrement",
+      "matchedFields": "{{matched}}/{{scored}} champs",
+      "notFound": "Aucune exécution sélectionnée à comparer.",
+      "metrics": {
+        "status": "Statut",
+        "agent": "Agent",
+        "version": "Version",
+        "matchRate": "Taux de correspondance",
+        "perfectMatches": "Correspondances parfaites",
+        "mismatches": "Non-correspondances",
+        "errors": "Erreurs",
+        "total": "Total des enregistrements"
       }
     },
     "agentMetadata": {

--- a/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.fr.json
+++ b/apps/web/src/eval/features/evaluation-extraction-runs/locales/evaluation-extraction-run.fr.json
@@ -8,6 +8,14 @@
     "agent": "Agent",
     "agentPlaceholder": "Sélectionner un agent",
     "agentSettingsUnavailable": "La configuration de cet agent n'a pas pu être chargée.",
+    "version": {
+      "label": "Version",
+      "placeholder": "Sélectionner une version",
+      "loading": "Chargement des versions...",
+      "item": "v{{revision}} — {{detail}}",
+      "current": "Actuelle ({{date}})",
+      "revision": "v{{revision}}"
+    },
     "scope": {
       "title": "Enregistrements à exécuter",
       "all": "Exécuter le dataset entier ({{count}} enregistrements)",
@@ -23,6 +31,7 @@
       "scored": "Évalué",
       "fyi": "Info",
       "columnPlaceholder": "Sélectionner une colonne",
+      "incomplete": "Associez chaque clé évaluée à une colonne du dataset.",
       "noOutputSchema": "Cet agent n'a pas de schéma de sortie défini."
     },
     "results": {

--- a/apps/web/src/eval/hooks/use-evaluation-extraction-run-path.ts
+++ b/apps/web/src/eval/hooks/use-evaluation-extraction-run-path.ts
@@ -12,5 +12,16 @@ export function useEvaluationExtractionRunPath() {
   const buildRunPath = ({ runId }: { runId: string }): string => {
     return EvalRoutes.evaluationRun.build({ organizationId, projectId, datasetId, runId })
   }
-  return { buildRunPath }
+
+  const buildComparePath = ({ runIds }: { runIds: string[] }): string => {
+    const path = EvalRoutes.extractionDatasetCompare.build({
+      organizationId,
+      projectId,
+      datasetId,
+    })
+    const search = new URLSearchParams({ runs: runIds.join(",") }).toString()
+    return `${path}?${search}`
+  }
+
+  return { buildRunPath, buildComparePath }
 }

--- a/apps/web/src/eval/routes/EvalRoutes.tsx
+++ b/apps/web/src/eval/routes/EvalRoutes.tsx
@@ -11,6 +11,7 @@ import { EvaluationConversationRunsCompareRoute } from "./EvaluationConversation
 import { EvaluationExtractionDatasetRoute } from "./EvaluationExtractionDatasetRoute"
 import { EvaluationExtractionDatasetsRoute } from "./EvaluationExtractionDatasetsRoute"
 import { EvaluationExtractionRunRoute } from "./EvaluationExtractionRunRoute"
+import { EvaluationExtractionRunsCompareRoute } from "./EvaluationExtractionRunsCompareRoute"
 import { EvalRoutes } from "./helpers"
 
 export const evalRoutes = {
@@ -39,6 +40,10 @@ export const evalRoutes = {
               path: EvalRoutes.extractionDataset.path,
               element: <EvaluationExtractionDatasetRoute />,
               children: [
+                {
+                  path: EvalRoutes.extractionDatasetCompare.path,
+                  element: <EvaluationExtractionRunsCompareRoute />,
+                },
                 {
                   path: EvalRoutes.evaluationRun.path,
                   element: <EvaluationExtractionRunRoute />,

--- a/apps/web/src/eval/routes/EvaluationExtractionRunRoute.tsx
+++ b/apps/web/src/eval/routes/EvaluationExtractionRunRoute.tsx
@@ -81,6 +81,9 @@ function WithData() {
 
             <div className="flex gap-2">
               <RunStatusBadge status={run.status} />
+              <Badge variant="secondary">
+                {t("evaluationExtractionRun:version.revision", { revision: run.agentRevision })}
+              </Badge>
               {isFinished && (
                 <Badge variant="secondary">
                   {t("evaluationExtractionRun:results.duration", {
@@ -116,6 +119,7 @@ function WithData() {
             <AgentMetadataDialog
               buttonProps={{ variant: "outline", size: "sm" }}
               agentId={run.agentId}
+              revision={run.agentRevision}
             />
             <DeleteEvaluationExtractionRunButton
               buttonProps={{ variant: "secondary", size: "icon" }}

--- a/apps/web/src/eval/routes/EvaluationExtractionRunsCompareRoute.tsx
+++ b/apps/web/src/eval/routes/EvaluationExtractionRunsCompareRoute.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom"
+import { GridHeader } from "@/common/components/grid/Grid"
+import { selectCurrentOrganizationId } from "@/common/features/organizations/organizations.selectors"
+import { selectCurrentProjectId } from "@/common/features/projects/projects.selectors"
+import { useMount } from "@/common/hooks/use-mount"
+import { useCurrentId, useValue } from "@/common/hooks/use-value"
+import { AsyncRoute } from "@/common/routes/AsyncRoute"
+import { LoadingRoute } from "@/common/routes/LoadingRoute"
+import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import {
+  selectCurrentDatasetData,
+  selectCurrentDatasetId,
+} from "../features/evaluation-extraction-datasets/evaluation-extraction-datasets.selectors"
+import { EvaluationExtractionRunsComparison } from "../features/evaluation-extraction-runs/components/EvaluationExtractionRunsComparison"
+import {
+  selectEvaluationExtractionRunsData,
+  selectExtractionRunsComparison,
+} from "../features/evaluation-extraction-runs/evaluation-extraction-runs.selectors"
+import { evaluationExtractionRunsActions } from "../features/evaluation-extraction-runs/evaluation-extraction-runs.slice"
+import { EvalRoutes } from "./helpers"
+
+function useCompareRunIds(): string[] {
+  const [searchParams] = useSearchParams()
+  const runsParam = searchParams.get("runs") ?? ""
+  return useMemo(() => runsParam.split(",").filter(Boolean), [runsParam])
+}
+
+export function EvaluationExtractionRunsCompareRoute() {
+  const datasetId = useCurrentId(selectCurrentDatasetId)
+  const dataset = useAppSelector(selectCurrentDatasetData)
+  const runs = useAppSelector(selectEvaluationExtractionRunsData)
+  const comparison = useAppSelector(selectExtractionRunsComparison)
+  const dispatch = useAppDispatch()
+  const runIds = useCompareRunIds()
+  const organizationId = useCurrentId(selectCurrentOrganizationId)
+  const projectId = useCurrentId(selectCurrentProjectId)
+  const runIdsKey = runIds.join(",")
+
+  // URL-driven id setting (same role as useSetCurrentIds, ADR 0009); declared
+  // before useMount so the ids are in the store when compareMount fires.
+  useEffect(() => {
+    dispatch(evaluationExtractionRunsActions.setComparisonRunIds(runIds))
+  }, [dispatch, runIds])
+
+  useMount({
+    actions: {
+      mount: evaluationExtractionRunsActions.compareMount,
+      unmount: evaluationExtractionRunsActions.compareUnmount,
+    },
+    condition: runIds.length > 0,
+    refreshOn: [runIdsKey],
+  })
+
+  const parentPath = EvalRoutes.extractionDataset.build({
+    organizationId,
+    projectId,
+    datasetId,
+  })
+
+  if (!datasetId) return <LoadingRoute />
+  if (runIds.length === 0) return <Navigate to={parentPath} replace />
+  return (
+    <AsyncRoute data={[dataset, runs, comparison]}>
+      <WithData runIds={runIds} />
+    </AsyncRoute>
+  )
+}
+
+function WithData({ runIds }: { runIds: string[] }) {
+  const { t } = useTranslation()
+  const organizationId = useCurrentId(selectCurrentOrganizationId)
+  const projectId = useCurrentId(selectCurrentProjectId)
+  const dataset = useValue(selectCurrentDatasetData)
+  const allRuns = useValue(selectEvaluationExtractionRunsData)
+  const recordsByRunId = useValue(selectExtractionRunsComparison)
+  const navigate = useNavigate()
+
+  // Preserve the order the user selected the runs in.
+  const runs = useMemo(
+    () =>
+      runIds
+        .map((runId) => allRuns.find((run) => run.id === runId))
+        .filter((run) => run !== undefined),
+    [runIds, allRuns],
+  )
+
+  const handleBack = () =>
+    navigate(
+      EvalRoutes.extractionDataset.build({ organizationId, projectId, datasetId: dataset.id }),
+    )
+
+  return (
+    <div>
+      <GridHeader
+        title={t("evaluationExtractionRun:comparison.title")}
+        description={t("evaluationExtractionRun:comparison.description", { count: runs.length })}
+        onBack={handleBack}
+      />
+      <div className="p-6">
+        {runs.length === 0 ? (
+          <p className="text-muted-foreground">
+            {t("evaluationExtractionRun:comparison.notFound")}
+          </p>
+        ) : (
+          <EvaluationExtractionRunsComparison runs={runs} recordsByRunId={recordsByRunId} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/eval/routes/helpers.ts
+++ b/apps/web/src/eval/routes/helpers.ts
@@ -11,6 +11,8 @@ const conversation = project.extend("/conversation")
 // EXTRACTION-LEVEL
 const extractionDataset = extraction.extend("/:datasetId")
 const evaluationRun = extractionDataset.extend("/runs/:runId")
+// Selected run ids are carried in the `?runs=id1,id2` query string.
+const extractionDatasetCompare = extractionDataset.extend("/compare")
 
 // CONVERSATION-LEVEL
 const conversationDataset = conversation.extend("/:datasetId")
@@ -26,6 +28,7 @@ export const EvalRoutes = {
   evaluationRun,
   extraction,
   extractionDataset,
+  extractionDatasetCompare,
   home,
   organization,
   project,

--- a/apps/web/src/stories/routes/eval/EvaluationExtractionRunsCompareRoute.stories.tsx
+++ b/apps/web/src/stories/routes/eval/EvaluationExtractionRunsCompareRoute.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { DEFAULT_PAGE_SIZE } from "@/common/components/shared/RecordTableParts"
+import { agentFactory } from "@/common/features/agents/agent.factory"
+import { evaluationExtractionDatasetFactory } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.factory"
+import {
+  evaluationExtractionRunFactory,
+  evaluationExtractionRunRecordFactory,
+} from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.factory"
+import type {
+  EvaluationExtractionRunRecord,
+  EvaluationExtractionRunRecordStatus,
+} from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.models"
+import { evalRoutes } from "@/eval/routes/EvalRoutes"
+import { EvalRoutes } from "@/eval/routes/helpers"
+import { buildDecorator, render } from "@/stories/decorators"
+import {
+  buildStudioData,
+  type StudioStoryArgs,
+  studioStoryArgs,
+  studioStoryArgTypes,
+} from "@/stories/routes/studio/helpers"
+import { mergeSeeds, seed } from "@/stories/seed"
+import {
+  buildMockAgentsService,
+  buildMockExtractionDatasetsService,
+  buildMockExtractionRunsService,
+} from "./helpers"
+
+type StoryArgs = StudioStoryArgs
+
+const RUN_IDS = ["run-a", "run-b", "run-c"] as const
+
+// Shared source records: every run extracts the same dataset records (same ids), so the
+// compare page aligns results row by row.
+const RECORD_SPECS = [
+  { datasetRecordId: "rec-1", title: "Standard subscription", summary: "Monthly plan" },
+  { datasetRecordId: "rec-2", title: "Premium subscription", summary: "Yearly plan" },
+  { datasetRecordId: "rec-3", title: "Support request", summary: "Refund question" },
+]
+
+const STATUSES_BY_RUN: Record<string, EvaluationExtractionRunRecordStatus[]> = {
+  "run-a": ["match", "mismatch", "mismatch"],
+  "run-b": ["match", "match", "mismatch"],
+  "run-c": ["match", "match", "match"],
+}
+
+const RUN_CONFIG = {
+  "run-a": { revision: 3, perfectMatches: 1 },
+  "run-b": { revision: 4, perfectMatches: 2 },
+  "run-c": { revision: 5, perfectMatches: 3 },
+}
+
+const decorator = buildDecorator<StoryArgs>((args) => {
+  const { baseSeeds, project, agents } = buildStudioData({ ...args, withAgents: true })
+  const dataset = evaluationExtractionDatasetFactory
+    .transient({ project })
+    .build({ recordCount: RECORD_SPECS.length })
+  const agent = agents[0] ?? agentFactory.transient({ project }).build()
+
+  const runs = RUN_IDS.map((runId) => {
+    const config = RUN_CONFIG[runId]
+    return evaluationExtractionRunFactory.transient({ dataset, agent }).build({
+      id: runId,
+      agentRevision: config.revision,
+      status: "completed",
+      summary: {
+        total: RECORD_SPECS.length,
+        perfectMatches: config.perfectMatches,
+        mismatches: RECORD_SPECS.length - config.perfectMatches,
+        errors: 0,
+        running: 0,
+      },
+    })
+  })
+
+  const recordsByRunId: Record<string, EvaluationExtractionRunRecord[]> = Object.fromEntries(
+    runs.map((run) => [
+      run.id,
+      RECORD_SPECS.map((spec, index) =>
+        evaluationExtractionRunRecordFactory.transient({ run }).build({
+          evaluationExtractionDatasetRecordId: spec.datasetRecordId,
+          status: STATUSES_BY_RUN[run.id]?.[index] ?? "match",
+          datasetRecordData: { title: spec.title, summary: spec.summary },
+        }),
+      ),
+    ]),
+  )
+
+  const paginatedByRunId = Object.fromEntries(
+    Object.entries(recordsByRunId).map(([runId, records]) => [
+      runId,
+      { records, total: records.length, page: 0, limit: DEFAULT_PAGE_SIZE },
+    ]),
+  )
+
+  return {
+    state: mergeSeeds(
+      baseSeeds,
+      seed.eval.extractionDatasets([dataset], { currentId: dataset.id }),
+      seed.eval.extractionRuns(runs),
+      seed.eval.extractionRunsComparison(recordsByRunId),
+    ),
+    services: {
+      agents: buildMockAgentsService({ agents }),
+      evaluationExtractionDatasets: buildMockExtractionDatasetsService({
+        datasets: [dataset],
+      }),
+      evaluationExtractionRuns: buildMockExtractionRunsService({
+        runs,
+        recordsByRunId: paginatedByRunId,
+      }),
+    },
+  }
+})
+
+const meta = {
+  title: "routes/eval/extraction/compare",
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    ...studioStoryArgTypes,
+  },
+  args: {
+    ...studioStoryArgs,
+    featureFlags: [...studioStoryArgs.featureFlags, "evaluation"],
+    withAgents: true,
+  },
+  render: render({
+    routes: evalRoutes,
+    path: `${EvalRoutes.extractionDatasetCompare.path}?runs=${RUN_IDS.join(",")}`,
+  }),
+} satisfies Meta<StoryArgs>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const CompareRuns: Story = {
+  decorators: [decorator],
+}

--- a/apps/web/src/stories/routes/eval/helpers.ts
+++ b/apps/web/src/stories/routes/eval/helpers.ts
@@ -11,6 +11,16 @@ import type {
   PaginatedEvaluationConversationRunRecords,
 } from "@/eval/features/evaluation-conversation-runs/evaluation-conversation-runs.models"
 import type { IEvaluationConversationRunsSpi } from "@/eval/features/evaluation-conversation-runs/evaluation-conversation-runs.spi"
+import type {
+  EvaluationExtractionDataset,
+  PaginatedEvaluationExtractionDatasetRecords,
+} from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.models"
+import type { IEvaluationExtractionDatasetsSpi } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.spi"
+import type {
+  EvaluationExtractionRun,
+  PaginatedEvaluationExtractionRunRecords,
+} from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.models"
+import type { IEvaluationExtractionRunsSpi } from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.spi"
 
 export function buildEmptyRecordsPage<TRecord>(): {
   records: TRecord[]
@@ -123,6 +133,87 @@ export function buildMockConversationRunsService(
     },
     async getRecords({ evaluationConversationRunId }) {
       return recordsByRunId[evaluationConversationRunId] ?? records
+    },
+    async streamRunStatus() {},
+    async deleteOne() {},
+  }
+}
+
+export function buildMockExtractionDatasetsService(
+  overrides: {
+    datasets?: EvaluationExtractionDataset[]
+    records?: PaginatedEvaluationExtractionDatasetRecords
+  } = {},
+): IEvaluationExtractionDatasetsSpi {
+  const datasets = overrides.datasets ?? []
+  const records = overrides.records ?? buildEmptyRecordsPage()
+  return {
+    async getAllFiles() {
+      return []
+    },
+    async getAll() {
+      return datasets
+    },
+    async getRecords() {
+      return records
+    },
+    async createOne() {
+      return { success: true }
+    },
+    async renameOne() {
+      return { success: true }
+    },
+    async updateOne() {
+      return { success: true }
+    },
+    async getFileColumns() {
+      return []
+    },
+    async deleteOne() {},
+  }
+}
+
+export function buildMockExtractionRunsService(
+  overrides: {
+    runs?: EvaluationExtractionRun[]
+    records?: PaginatedEvaluationExtractionRunRecords
+    // Per-run records, keyed by run id, so the compare page can show differing results.
+    recordsByRunId?: Record<string, PaginatedEvaluationExtractionRunRecords>
+  } = {},
+): IEvaluationExtractionRunsSpi {
+  const runs = overrides.runs ?? []
+  const records = overrides.records ?? buildEmptyRecordsPage()
+  const recordsByRunId = overrides.recordsByRunId ?? {}
+
+  const findRun = (evaluationExtractionRunId: string): EvaluationExtractionRun => {
+    const run = runs.find((candidate) => candidate.id === evaluationExtractionRunId)
+    if (!run) throw new Error(`No seeded run with id ${evaluationExtractionRunId}`)
+    return run
+  }
+
+  return {
+    async createOne() {
+      const [firstRun] = runs
+      if (!firstRun) throw new Error("No run seeded for createOne")
+      return firstRun
+    },
+    async executeOne({ evaluationExtractionRunId }) {
+      return findRun(evaluationExtractionRunId)
+    },
+    async retryOne({ evaluationExtractionRunId }) {
+      return findRun(evaluationExtractionRunId)
+    },
+    async cancelOne({ evaluationExtractionRunId }) {
+      return { ...findRun(evaluationExtractionRunId), status: "cancelled" }
+    },
+    async getOne({ evaluationExtractionRunId }) {
+      return findRun(evaluationExtractionRunId)
+    },
+    async getAll() {
+      return runs
+    },
+    async getRecords({ evaluationExtractionRunId }) {
+      return recordsByRunId[evaluationExtractionRunId] ?? records
     },
     async streamRunStatus() {},
     async deleteOne() {},

--- a/apps/web/src/stories/seed.ts
+++ b/apps/web/src/stories/seed.ts
@@ -27,6 +27,11 @@ import type {
   EvaluationConversationRunRecord,
   PaginatedEvaluationConversationRunRecords,
 } from "@/eval/features/evaluation-conversation-runs/evaluation-conversation-runs.models"
+import type { EvaluationExtractionDataset } from "@/eval/features/evaluation-extraction-datasets/evaluation-extraction-datasets.models"
+import type {
+  EvaluationExtractionRun,
+  EvaluationExtractionRunRecord,
+} from "@/eval/features/evaluation-extraction-runs/evaluation-extraction-runs.models"
 import type { AgentMembership } from "@/studio/features/agent-memberships/agent-memberships.models"
 import type { AgentMessageFeedback } from "@/studio/features/agent-message-feedback/agent-message-feedback.models"
 import type { AgentSubAgent } from "@/studio/features/agent-sub-agents/agent-sub-agents.models"
@@ -459,6 +464,43 @@ export const seed = {
     ): StoryPreloadedState {
       return {
         conversationRuns: {
+          // Seed the run ids too so the route's setComparisonRunIds sees the
+          // same comparison and does not reset the seeded records on mount.
+          comparisonRunIds: Object.keys(recordsByRunId),
+          comparisonRecords: ads.fulfilled(recordsByRunId),
+        },
+      }
+    },
+
+    extractionDatasets(
+      datasets: EvaluationExtractionDataset[],
+      options: { currentId?: string | null } = {},
+    ): StoryPreloadedState {
+      const currentId = options.currentId ?? null
+      return mergeSeeds(
+        { extractionDatasets: { data: ads.fulfilled(datasets) } },
+        { currentIds: { datasetId: currentId } },
+      )
+    },
+
+    extractionRuns(
+      runs: EvaluationExtractionRun[],
+      options: { currentId?: string | null } = {},
+    ): StoryPreloadedState {
+      const currentId = options.currentId ?? null
+      const currentRun = runs.find((run) => run.id === currentId)
+      return mergeSeeds(
+        { extractionRuns: { data: ads.fulfilled(runs), currentRunId: currentId } },
+        currentRun ? { extractionRuns: { currentRun: ads.fulfilled(currentRun) } } : {},
+        { currentIds: { runId: currentId } },
+      )
+    },
+
+    extractionRunsComparison(
+      recordsByRunId: Record<string, EvaluationExtractionRunRecord[]>,
+    ): StoryPreloadedState {
+      return {
+        extractionRuns: {
           // Seed the run ids too so the route's setComparisonRunIds sees the
           // same comparison and does not reset the seeded records on mount.
           comparisonRunIds: Object.keys(recordsByRunId),

--- a/packages/api-contracts/src/evaluations/evaluation-extraction-runs.dto.ts
+++ b/packages/api-contracts/src/evaluations/evaluation-extraction-runs.dto.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import type { TimeType } from "../generic"
 
 export const EVALUATION_EXTRACTION_RUN_STATUS_CHANGED_CHANNEL_DTO =
@@ -43,6 +44,9 @@ export type EvaluationExtractionRunDto = {
   id: string
   evaluationExtractionDatasetId: string
   agentId: string
+  agentSettingsId: string
+  // Revision of the settings version the run is pinned to.
+  agentRevision: number
   keyMapping: EvaluationExtractionRunKeyMappingEntryDto[]
   status: EvaluationExtractionRunStatusDto
   summary: EvaluationExtractionRunSummaryDto | null
@@ -67,11 +71,23 @@ export type EvaluationExtractionRunRecordDto = {
 }
 
 // Request DTOs
-export type CreateEvaluationExtractionRunRequestDto = {
-  evaluationExtractionDatasetId: string
-  agentId: string
-  keyMapping: EvaluationExtractionRunKeyMappingEntryDto[]
-}
+export const createEvaluationExtractionRunSchema = z.object({
+  evaluationExtractionDatasetId: z.string(),
+  agentId: z.string(),
+  // Agent-settings revision to pin on the run; null pins the latest published revision.
+  agentSettingsRevision: z.number().int().nullable(),
+  keyMapping: z.array(
+    z.object({
+      agentOutputKey: z.string(),
+      datasetColumnId: z.string(),
+      mode: z.enum(["scored", "fyi"]),
+    }),
+  ),
+})
+
+export type CreateEvaluationExtractionRunRequestDto = z.infer<
+  typeof createEvaluationExtractionRunSchema
+>
 
 export type ExecuteEvaluationExtractionRunRequestDto = {
   recordLimit: number | null


### PR DESCRIPTION
## Summary

Closes #633.

- **Choose which agent settings version an evaluation runs**: the extraction evaluation run dialog gets a version picker (latest published by default). The chosen revision is pinned through the create payload and shown on the run history, the run page, and the agent metadata dialog. The dialog moves to react-hook-form with the contract zod schema (ADR 0012).
- **Run history table and side-by-side run comparison**: mirrors the evaluation conversation runs UX — the run history becomes a selectable table, and a new compare page shows summary metrics and per-record results across the selected runs.
- Adds the missing factories, seed helpers, and route story for the extraction eval features (ADR 0010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)