### PR TITLE
fix(agent-sessions): remove padding and border around the session chat

### DIFF
--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessages.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessages.tsx
@@ -76,8 +76,8 @@ export function AgentSessionMessages({
   const desktopHeightClasses = "md:h-[calc(100dvh-17rem)]"
   return (
     <div className={cn("flex flex-1 flex-col min-h-0", desktopHeightClasses)}>
-      <div className="flex flex-1 p-2 sm:p-4 min-h-0 md:min-h-full">
-        <Chat className="border shadow-none">
+      <div className="flex flex-1 min-h-0 md:min-h-full">
+        <Chat className="shadow-none">
           <MessageScrollerProvider scrollPreviousItemPeek={168} defaultScrollPosition="end">
             <FormSubSessionsProvider value={formSubSessions}>
               <FormResultProvider value={formResult}>


### PR DESCRIPTION
## Summary
The agent-session chat was wrapped in a padded container (`p-2 sm:p-4`) and rendered with a border, leaving a framed inset look. This removes the wrapper padding and the `border` class so the chat fills its container edge to edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)