### PR TITLE
fix(llm): surface stream errors to the chat instead of an empty reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Chat shows an error message instead of an empty reply when the model fails.
 
 ### Security
 

--- a/apps/api/src/common/interfaces/llm-provider.interface.ts
+++ b/apps/api/src/common/interfaces/llm-provider.interface.ts
@@ -13,6 +13,8 @@ export type MockValue =
   // A production-shaped generation: text answer followed by a tool call in
   // the SAME generation (what Gemma emits for fire-and-forget tools).
   | { type: "textWithToolCall"; text: string; toolName: string; input: unknown }
+  // A generation that fails at the provider (e.g. a 400 APICallError).
+  | { type: "error"; error: Error }
 
 export type LLMConfig =
   | {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.spec.ts
@@ -151,6 +151,36 @@ describe("StreamingService", () => {
     expect(events.length).toBeGreaterThan(0)
     expect(fulltextStream).toBe(`Hello, I'm the stream default mock value!`)
   })
+  it("streamAgentResponse - emits an error event when the provider stream fails", async () => {
+    const { connectScope, agent, agentSettings, session } = await createContextWithSession()
+    const notifyClient = jest.fn()
+
+    mockProvider.addErrorTurn(agent.id, new Error("Unsupported chat content part type: 'file'"))
+
+    const stream = service.streamAgentResponse({
+      agentSessionScope: { connectScope, session, agent, agentSettings },
+      userContent: "Bonjour",
+      notifyClient,
+    })
+
+    const events: StreamEventPayload[] = []
+    await expect(
+      (async () => {
+        for await (const event of stream) {
+          events.push(JSON.parse(event.data) as StreamEventPayload)
+        }
+      })(),
+    ).rejects.toThrow("Unsupported chat content part type: 'file'")
+
+    const errorEvent = events.find((event) => event.type === "error")
+    expect(errorEvent).toMatchObject({ error: "Unsupported chat content part type: 'file'" })
+    expect(events.find((event) => event.type === "end")).toBeUndefined()
+
+    const assistantMessage = await repositories.agentMessageRepository.findOne({
+      where: { sessionId: session.id, role: "assistant" },
+    })
+    expect(assistantMessage?.status).toBe("error")
+  })
   it("streamAgentResponse - with document - pdf", async () => {
     const { connectScope, agent, agentSettings, session } = await createContextWithSession()
     const notifyClient = jest.fn()

--- a/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
+++ b/apps/api/src/external/llm/ai-sdk-llm-provider-base.ts
@@ -347,8 +347,13 @@ export abstract class AISDKLLMProviderBase implements LLMProvider {
     const fullMessages = [...systemMessagePart, ...aiSDKMessages]
     const streamResult = await agent.stream({ messages: fullMessages })
 
-    for await (const chunk of streamResult.textStream) {
-      yield chunk
+    // The AI SDK never throws stream failures at the consumer: they surface
+    // as `error` parts on fullStream, which textStream filters out — the
+    // stream just ends, indistinguishable from an empty answer. Consume
+    // fullStream so a failed generation rejects and callers can report it.
+    for await (const part of streamResult.fullStream) {
+      if (part.type === "text-delta") yield part.text
+      else if (part.type === "error") throw part.error
     }
 
     await this.runEndOfTurnTools({

--- a/apps/api/src/external/llm/providers/ai-sdk-mock.provider.spec.ts
+++ b/apps/api/src/external/llm/providers/ai-sdk-mock.provider.spec.ts
@@ -142,6 +142,14 @@ describe("AISDKMockProvider", () => {
     expect(results.join("")).toBe("Hello!")
   })
 
+  it("streamChatResponse - rethrows a provider error instead of ending silently", async () => {
+    provider.addErrorTurn(metadata.agentId, new Error("Unsupported chat content part type: 'file'"))
+
+    await expect(
+      streamToStringArray(provider.streamChatResponse({ messages, config, metadata })),
+    ).rejects.toThrow("Unsupported chat content part type: 'file'")
+  })
+
   it("addObjectTurn - should works", async () => {
     const schema = z.object({ content: z.string(), source: z.string() })
     provider.addObjectTurn(metadata.agentId, { content: "hello", source: "queued" })

--- a/apps/api/src/external/llm/providers/ai-sdk-mock.provider.ts
+++ b/apps/api/src/external/llm/providers/ai-sdk-mock.provider.ts
@@ -21,6 +21,7 @@ type ResolvedMock =
   | { type: "text"; chunks: string[] }
   | { type: "toolCall"; toolName: string; params: unknown }
   | { type: "textWithToolCall"; text: string; toolName: string; params: unknown }
+  | { type: "error"; error: Error }
 
 @Injectable()
 export class AISDKMockProvider extends AISDKLLMProviderBase {
@@ -58,6 +59,10 @@ export class AISDKMockProvider extends AISDKLLMProviderBase {
   ): void {
     this.enqueue(agentId, [{ type: "textWithToolCall", text, toolName, input }])
   }
+  /** The next generation fails at the provider, the way a real 400 does. */
+  addErrorTurn(agentId: string, error: Error): void {
+    this.enqueue(agentId, [{ type: "error", error }])
+  }
   private enqueue(agentId: string, values: MockValue[]): void {
     const queue = this.queuesByAgentId.get(agentId) ?? []
     queue.push(...values)
@@ -86,6 +91,7 @@ export class AISDKMockProvider extends AISDKLLMProviderBase {
     return new MockLanguageModelV3({
       doGenerate: async (options) => {
         const resolved = this.resolve({ mode: "generate", callOrigin, options })
+        if (resolved.type === "error") throw resolved.error
         if (resolved.type === "toolCall") {
           return {
             content: [
@@ -115,6 +121,7 @@ export class AISDKMockProvider extends AISDKLLMProviderBase {
       },
       doStream: async (options) => {
         const resolved = this.resolve({ mode: "stream", callOrigin, options })
+        if (resolved.type === "error") throw resolved.error
         return {
           stream:
             resolved.type === "toolCall"
@@ -167,6 +174,8 @@ export class AISDKMockProvider extends AISDKLLMProviderBase {
             toolName: next.toolName,
             params: next.input,
           }
+        case "error":
+          return { type: "error", error: next.error }
       }
     }
 


### PR DESCRIPTION
## Summary

When a provider stream failed (e.g. the Gemma vLLM endpoint rejecting a PDF attachment's `file` content part with a 400), the chat showed nothing: the AI SDK swallows stream failures into `error` parts on `fullStream`, which `textStream` filters out. The stream ended silently, the assistant message was marked `completed` with empty content, and the client received a normal `end` frame — no error anywhere in the UI.

`streamChatResponse` now consumes `fullStream` and rethrows `error` parts. `StreamingService`'s existing catch then marks the message as errored and emits the `error` SSE frame the frontend already renders. This surfaces every provider stream failure, not just the Gemma file-part case.

Side effects, both strictly more informative than the previous silent-empty behavior:
- sub-agent delegation failures now surface as tool errors to the parent model,
- evaluation runs (`runSingleTurn`) fail loudly instead of recording an empty output.

Out of scope: rejecting/handling PDF attachments on models without `file`-part support (the underlying 400 in this scenario — its raw message is now at least shown), and #639 (frontend parsing of data-less `event: error` frames), which stays open as its own fix.

## Test plan

- New provider-level test: `streamChatResponse` rejects with the provider error instead of resolving to an empty stream (`ai-sdk-mock.provider.spec.ts`), backed by a new `addErrorTurn` on the mock provider.
- New service-level test: `streamAgentResponse` emits the `error` SSE frame, no `end` frame, and persists the assistant message with `status: "error"` (`streaming.service.spec.ts`).
- Both tests were verified to fail against the pre-fix code.
- Full API suite (`test:parallel`): 285 suites / 2161 tests green. `typecheck` and `biome:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)