### PR TITLE
fix(llm): strip and recover the brace-terminated <function:> leaked tool-call variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Agent replies no longer show a leaked internal tool-call tag (a new `<function:...` variant); the platform hides it and still runs the tool.
 
 ### Security
 

--- a/apps/api/src/external/llm/leaked-tool-call-recovery.spec.ts
+++ b/apps/api/src/external/llm/leaked-tool-call-recovery.spec.ts
@@ -93,6 +93,33 @@ describe("leaked tool call recovery", () => {
     })
   })
 
+  it("recovers the brace-terminated <function:> variant that has no closing angle bracket", async () => {
+    const execute = jest.fn().mockResolvedValue({ ok: true })
+    provider.addTextTurn(
+      "agent-1",
+      "Voici votre réponse, votre demande est bien prise en compte.\n\n" +
+        "<function:default_api:notify_operator{severity:high," +
+        "summary:Escalation requested by the user.,reference:ABC-123}",
+    )
+    provider.addObjectTurn("agent-1", {
+      severity: "high",
+      summary: "Escalation requested by the user.",
+      reference: "ABC-123",
+    })
+
+    const text = await streamAll(buildConfig({ execute }))
+
+    expect(text).not.toContain("default_api")
+    expect(text).not.toContain("<function")
+    expect(text).toContain("bien prise en compte")
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(execute).toHaveBeenCalledWith({
+      severity: "high",
+      summary: "Escalation requested by the user.",
+      reference: "ABC-123",
+    })
+  })
+
   it("does not run recovery when no call leaked", async () => {
     const execute = jest.fn()
     provider.addTextTurn("agent-1", "Voici votre réponse, sans balise.")

--- a/apps/api/src/external/llm/thought-tokens-helper.spec.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.spec.ts
@@ -6,6 +6,11 @@ import { findLeakedToolCallNames, ThoughtTokensHelper } from "./thought-tokens-h
 const LEAKED_PSEUDO_CALL =
   '<call:default_api:mandatory_tool xmlns:default_api="default_api" categoryNames:[greetings,QA],suggestedTitle:Règles de Warmachine et pays de pays/>'
 
+// A newer leak variant captured in production: opens with `<function:` and
+// terminates at the closing brace of its arguments — there is no `>` at all.
+const LEAKED_FUNCTION_CALL =
+  "<function:default_api:mandatory_tool{categoryNames:[test],suggestedTitle:null}"
+
 describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
   it("removes a pseudo-call tag from a complete text", () => {
     const text = `C'est noté, tu habites en France !\n\n${LEAKED_PSEUDO_CALL}`
@@ -21,6 +26,27 @@ describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
       'a <default_api:mandatory_tool args="x"/> b </default_api:call> c',
     )
     expect(cleaned).toBe("a  b  c")
+  })
+
+  it("removes the brace-terminated <function:> variant that has no closing angle bracket", () => {
+    const text = `Je vous invite à contacter votre conseiller.\n\n${LEAKED_FUNCTION_CALL}`
+    const cleaned = ThoughtTokensHelper.removeThoughtTokens(text)
+
+    expect(cleaned).not.toContain("default_api")
+    expect(cleaned).not.toContain("<function")
+    expect(cleaned).toContain("Je vous invite à contacter votre conseiller.")
+  })
+
+  it("removes the brace-terminated variant for the whole opener family", () => {
+    const cleaned = ThoughtTokensHelper.removeThoughtTokens(
+      "a <call:default_api:notify_operator{severity:high} b <default_api:mandatory_tool{x:1} c",
+    )
+    expect(cleaned).toBe("a  b  c")
+  })
+
+  it("keeps legitimate text mentioning the function keyword", () => {
+    const text = "En JS, une fonction s'écrit function foo() {} et on vérifie que 2 < 3."
+    expect(ThoughtTokensHelper.removeThoughtTokens(text)).toBe(text)
   })
 
   it("keeps legitimate text with angle brackets and comparisons", () => {
@@ -40,6 +66,20 @@ describe("ThoughtTokensHelper - hallucinated tool-call XML", () => {
 
     expect(out).not.toContain("default_api")
     expect(out).not.toContain("<call:")
+    expect(out).toContain("Voici ma réponse complète")
+  })
+
+  it("strips the brace-terminated <function:> variant even when split across stream deltas", () => {
+    const stripper = ThoughtTokensHelper.createStripper()
+    const full = `Voici ma réponse complète pour toi, avec assez de texte pour dépasser la retenue du stripper.\n\n${LEAKED_FUNCTION_CALL}`
+    let out = ""
+    for (let i = 0; i < full.length; i += 7) {
+      out += stripper.feed(full.slice(i, i + 7))
+    }
+    out += stripper.flush()
+
+    expect(out).not.toContain("default_api")
+    expect(out).not.toContain("<function")
     expect(out).toContain("Voici ma réponse complète")
   })
 
@@ -70,6 +110,11 @@ describe("findLeakedToolCallNames", () => {
 
   it("extracts the tool name from the attribute-style variant", () => {
     expect(findLeakedToolCallNames(LEAKED_PSEUDO_CALL)).toEqual(["mandatory_tool"])
+  })
+
+  it("extracts the tool name from the <function:> brace variant with no closing angle bracket", () => {
+    const text = `Je vous invite à contacter votre conseiller.\n\n${LEAKED_FUNCTION_CALL}`
+    expect(findLeakedToolCallNames(text)).toEqual(["mandatory_tool"])
   })
 
   it("returns nothing for legitimate text, including angle brackets and markup", () => {

--- a/apps/api/src/external/llm/thought-tokens-helper.ts
+++ b/apps/api/src/external/llm/thought-tokens-helper.ts
@@ -6,12 +6,16 @@ const CHANNEL_KEYWORDS = "thought|analysis|reasoning|finalize|commentary|final"
 
 // Hallucinated tool-call syntax that Gemini models (lite especially) leak
 // into the TEXT stream instead of emitting a real functionCall, e.g.
-// `<call:default_api:some_tool xmlns:default_api=... />`. `default_api` is an
-// internal Gemini tool namespace; none of these tags can ever be legitimate
-// user-facing content.
-const PSEUDO_TOOL_CALL_RE = /<\/?(?:call|default_api)[:\s][^>]*\/?>/gi
+// `<call:default_api:some_tool xmlns:default_api=... />` or
+// `<function:default_api:some_tool{args}` (brace-terminated, no `>` at all).
+// `default_api` is an internal Gemini tool namespace; none of these tags can
+// ever be legitimate user-facing content. A tag is complete either at its
+// closing `>` or, for the brace variant, at the `}` that closes its (flat)
+// argument object — with an optional `/>` glued right after.
+const PSEUDO_TOOL_CALL_RE =
+  /<\/?(?:call|function|default_api)[:\s](?:[^>{]*\{[^{}]*\}\/?>?|[^>]*\/?>)/gi
 // An opener of that family that has no closing `>` yet (still streaming).
-const PSEUDO_TOOL_CALL_OPEN_RE = /<\/?(?:call|default_api)[:\s][^>]*$/i
+const PSEUDO_TOOL_CALL_OPEN_RE = /<\/?(?:call|function|default_api)[:\s][^>]*$/i
 // Give up holding the stream back after this many buffered characters: a
 // legitimate `<call:`-looking text (vanishingly unlikely) must not stall the
 // stream forever.
@@ -64,7 +68,7 @@ export function findLeakedToolCalls(text: string): LeakedToolCall[] {
   // (`{...}`, ` attr=...`, or the closing `>`).
   for (const match of text.matchAll(PSEUDO_TOOL_CALL_RE)) {
     const raw = match[0]
-    const opener = /<\/?(?:call|default_api)[:\s]([^>{(\s]+)/i.exec(raw)
+    const opener = /<\/?(?:call|function|default_api)[:\s]([^>{(\s]+)/i.exec(raw)
     const segments = (opener?.[1] ?? "").split(":").filter(Boolean)
     const name = segments.at(-1)
     if (name && name !== "default_api" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {


### PR DESCRIPTION
## Problem

A production chat showed the model's internal tool call rendered verbatim in the assistant bubble:

```
<function:default_api:mandatory_tool{categoryNames:[test],suggestedTitle:null}
```

This is the known Gemini failure family (tool call verbalized into the text channel), but in a **new spelling**: it opens with `<function:` and terminates at the closing brace of its arguments — there is no `>` at all. The existing `PSEUDO_TOOL_CALL_RE` only recognized `<call:` / `<default_api` openers terminated by `>`, so this variant failed **both** defense layers:

- the sanitizer did not strip it → the user saw the raw tag;
- `findLeakedToolCalls` did not match it → no recovery, no `LeakedToolCall` error log, and the mandatory report (categories / title) was silently lost.

## Fix

Extend the pseudo tool-call pattern family in `thought-tokens-helper.ts`:

- add `function` to the opener alternation (strip, streaming hold-back, and name extraction);
- accept a brace-terminated tag (`...{flat args}` with an optional `/>` glued after) as a complete match, alongside the existing `>`-terminated form. The brace alternative is tried first so a stray later `>` in legitimate text can never extend the match.

Everything downstream (streaming stripper, leak logging, structured-output recovery) keys off these regexes, so the one-file change restores both protections: the tag is hidden from the user **and** the leaked call is recovered and executed.

## Tests

- unit: strip the new variant from complete text and across stream deltas; whole opener family in brace form; tool-name extraction; legitimate text with `function` keyword / angle brackets untouched (red → green verified)
- e2e (`leaked-tool-call-recovery.spec.ts`): the `<function:` variant is hidden from the streamed text and the tool still executes with the recovered arguments (verified red against the old regex)

## Gates

- `npm run biome:check` ✅ (no fixes)
- `npm run typecheck` ✅
- `npm run test:parallel` ✅ (2165 passed, 12 skipped)
- `npm run check:boundaries` ✅ (exit 0; 1 pre-existing warning also present on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)