### PR TITLE
fix(agent-sessions): surface chat SSE error frames that carry no data line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Chat: a server error carrying no message now ends the reply with an error instead of being dropped.
 
 ### Security
 

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming-events.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming-events.spec.ts
@@ -41,6 +41,18 @@ describe("parseSSEEvent", () => {
     })
   })
 
+  it("turns an error frame with no data line into an error event with the fallback message", () => {
+    // Nest omits the `data:` line entirely when the thrown error's message is falsy:
+    // `data += message.data ? toDataString(message.data) : ''` in its sse-stream.
+    const event = parseSSEEvent("\nevent: error\nid: 1", buildContext())
+
+    expect(event).toEqual({
+      type: "error",
+      messageId: "optimistic-1",
+      error: "The agent stopped responding",
+    })
+  })
+
   it("reads a JSON payload frame", () => {
     const event = parseSSEEvent('data: {"type":"chunk","content":"Hi","messageId":"m1"}', {
       messageId: "optimistic-1",

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming-events.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming-events.ts
@@ -42,16 +42,18 @@ export function parseSSEEvent(
   context: StreamContext,
 ): StreamEventPayload | null {
   const dataLines = readField(eventText, "data")
-  if (dataLines.length === 0) return null
   const data = dataLines.join("\n")
 
   // Nest turns anything the SSE handler throws into `event: error` with the raw message as data —
   // a bare string, never JSON. The events the app emits itself carry no `event:` line at all, so
   // the line is what identifies the frame. Parsing it would throw, drop the frame, and leave the
-  // caller waiting for a terminal event that never comes.
+  // caller waiting for a terminal event that never comes. Checked before the no-data early return:
+  // Nest omits the `data:` line entirely when the thrown error's message is falsy.
   if (readField(eventText, "event")[0] === "error") {
     return { type: "error", messageId: context.messageId, error: data || unknownStreamError }
   }
+
+  if (dataLines.length === 0) return null
 
   try {
     return JSON.parse(data) as StreamEventPayload

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming.spec.ts
@@ -57,6 +57,22 @@ describe("streamChatResponse", () => {
     })
   })
 
+  it("reports an error frame carrying no data line through onError", async () => {
+    // What the API answers when the SSE handler throws an error whose message is falsy: Nest
+    // omits the `data:` line entirely. The frame must still terminate the stream as an error,
+    // with the fallback message standing in for the missing one.
+    respondWith("\nevent: error\nid: 1\n\n")
+    const handlers = buildHandlers()
+
+    await streamChatResponse({ ...params, handlers })
+
+    expect(handlers.onError).toHaveBeenCalledWith({
+      type: "error",
+      messageId: "optimistic-1",
+      error: "The agent stopped responding",
+    })
+  })
+
   it("reads a full answer from the event stream", async () => {
     respondWith(
       [


### PR DESCRIPTION
Fixes #639. Follow-up from #635.

## Problem

`parseSSEEvent` bailed out on any frame without a `data:` line **before** checking whether the frame is an `event: error` frame. Nest omits the `data:` line entirely when the thrown error's message is falsy (`data += message.data ? toDataString(message.data) : ''` in its sse-stream), so a frame like `event: error\nid: 1\n\n` was silently dropped. The stream then ended with no terminal event and the #635 safety net reported the generic "The response ended unexpectedly" instead of the error branch. It also left `unknownStreamError` ("The agent stopped responding") unreachable.

## Fix

Move the `event: error` check above the empty-`data` early return. The error branch already handles an empty message via `data || unknownStreamError`, so an error frame now terminates the stream as an error whichever way the message is empty.

## Tests (written first, watched fail)

- `parseSSEEvent` unit test: an `event: error` frame with no `data:` line yields an error event with the fallback message.
- `streamChatResponse` test driving the literal response bytes `"\nevent: error\nid: 1\n\n"`, as suggested in the issue.

`npm run biome:check`, `npm run typecheck`, and the web test suite (106 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)